### PR TITLE
fix: Use real paths from argvs instead of dummy hard-coded file

### DIFF
--- a/bin/webpack.js
+++ b/bin/webpack.js
@@ -162,9 +162,13 @@ var initInquirer = require('../lib/initialize');
 if(argv.init) {
 	initInquirer(argv._);
 } else if(argv.migrate) {
-	const dummyConfigLoc = require.resolve(path.join(process.cwd(), 'example/webpack.config.js'));
-	const outputConfigLoc = path.join(process.cwd(), 'example/neo-webpack.config.js');
-	require('../lib/migrate.js')(dummyConfigLoc, outputConfigLoc);
+	const filePaths = argv._;
+	if (!filePaths.length) {
+		throw new Error('Please specify a path to your webpack config');
+	}
+	const inputConfigPath = path.resolve(process.cwd(), filePaths[0]);
+
+	require('../lib/migrate.js')(inputConfigPath, inputConfigPath);
 } else {
 	processOptions(yargs,argv);
 }

--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -4,8 +4,8 @@ const chalk = require('chalk');
 const transform = require('./transformations').transform;
 const inquirer = require('inquirer');
 
-module.exports = (currentConfigLoc, outputConfigLoc) => {
-	let currentConfig = fs.readFileSync(currentConfigLoc, 'utf8');
+module.exports = (currentConfigPath, outputConfigPath) => {
+	let currentConfig = fs.readFileSync(currentConfigPath, 'utf8');
 	const outputConfig = transform(currentConfig);
 	const diffOutput = diff.diffLines(currentConfig, outputConfig);
 	diffOutput.map(diffLine => {
@@ -27,8 +27,8 @@ module.exports = (currentConfigLoc, outputConfigLoc) => {
 		.then(answers => {
 			if (answers['confirmMigration']) {
 				// TODO validate the config
-				fs.writeFileSync(outputConfigLoc, outputConfig, 'utf8');
-				process.stdout.write(chalk.green(`Congratulations! Your new webpack v2 config file is at ${outputConfigLoc}`));
+				fs.writeFileSync(outputConfigPath, outputConfig, 'utf8');
+				process.stdout.write(chalk.green(`Congratulations! Your new webpack v2 config file is at ${outputConfigPath}`));
 			} else {
 				process.stdout.write(chalk.yellow('Migration aborted'));
 			}


### PR DESCRIPTION
This PR is an ongoing work on #6 which enables to pass the path to webpack config as argument. It will overwrite it if confirmed by the user.