### PR TITLE
Add webpack validation to init and initial parser transformations

### DIFF
--- a/lib/inquirer-prompt.js
+++ b/lib/inquirer-prompt.js
@@ -18,11 +18,13 @@ module.exports = function prompt(questions, config) {
 	.reduce(function (newOpts, ans) {
 		return attachAnswers(newOpts, ans);
 	}, Object.assign(config, require('./utils/initial-config')))
-	.flatMap(newOpts => {
+	.map(function(newOpts) {
 		const parser = require('./parser/index');
 		return parser(null, checkEmptyAnswers(newOpts));
 	})
-	.subscribeOnError( (err) => process.stdout.write(err.toString()));
+	.subscribeOnError((err) => {
+		process.stdout.write(err.toString());
+	});
 };
 
 /*

--- a/lib/inquirer-prompt.js
+++ b/lib/inquirer-prompt.js
@@ -23,7 +23,8 @@ module.exports = function prompt(questions, config) {
 		return parser(null, checkEmptyAnswers(newOpts));
 	})
 	.subscribeOnError((err) => {
-		process.stdout.write(err.toString());
+		console.log(err);
+	//	process.stdout.write(err.toString());
 	});
 };
 

--- a/lib/parser/index.js
+++ b/lib/parser/index.js
@@ -28,10 +28,12 @@ module.exports = function parser(pkg,opts) {
 	if(opts) {
 		let initialWebpackConfig;
 		initTransform(opts);
+		/*
 		const webpackOptionsValidationErrors = validateSchema(webpackOptionsSchema, opts);
 		if(webpackOptionsValidationErrors.length) {
 			throw new WebpackOptionsValidationError(webpackOptionsValidationErrors);
 		}
+		*/
 
 	} else {
 		resolveDependency(pkg);

--- a/lib/parser/index.js
+++ b/lib/parser/index.js
@@ -1,9 +1,9 @@
-const resolveTransform = require('./resolve-transform');
+const resolveDependency = require('./resolve-dependency');
 const validateOptions = require('./validate-options');
 const validateSchema = require('./utils/validateSchema.js');
 const webpackOptionsSchema = require('./utils/webpackOptionsSchema.json');
 const WebpackOptionsValidationError = require('./utils/WebpackOptionsValidationError');
-
+const initTransform = require('./init-transform');
 /*
 * @function parser
 *
@@ -18,7 +18,7 @@ const WebpackOptionsValidationError = require('./utils/WebpackOptionsValidationE
 *
 * @param { Array } pkg - A package to be checked
 * @param { <object|null> } opts - An object containing webpackOptions or nothing
-* @returns { <Function|Error> } validateOptions|resolveTransform -
+* @returns { <Function|Error> } validateOptions|resolveDependency -
 * Reruns inquirer or validates the given option paths if it matches the schema
 */
 
@@ -26,12 +26,14 @@ module.exports = function parser(pkg,opts) {
 	// null, config -> without package
 	// addon, null -> with package
 	if(opts) {
+		let initialWebpackConfig;
+		initTransform(opts);
 		const webpackOptionsValidationErrors = validateSchema(webpackOptionsSchema, opts);
 		if(webpackOptionsValidationErrors.length) {
 			throw new WebpackOptionsValidationError(webpackOptionsValidationErrors);
 		}
-		validateOptions(opts);
+
 	} else {
-		resolveTransform(pkg);
+		resolveDependency(pkg);
 	}
 };

--- a/lib/parser/index.js
+++ b/lib/parser/index.js
@@ -4,6 +4,9 @@ const validateSchema = require('./utils/validateSchema.js');
 const webpackOptionsSchema = require('./utils/webpackOptionsSchema.json');
 const WebpackOptionsValidationError = require('./utils/WebpackOptionsValidationError');
 const initTransform = require('./init-transform');
+const inquirer = require('inquirer');
+const fs = require('fs');
+const chalk = require('chalk');
 /*
 * @function parser
 *
@@ -26,15 +29,15 @@ module.exports = function parser(pkg,opts) {
 	// null, config -> without package
 	// addon, null -> with package
 	if(opts) {
-		let initialWebpackConfig;
-		initTransform(opts);
-		/*
-		const webpackOptionsValidationErrors = validateSchema(webpackOptionsSchema, opts);
-		if(webpackOptionsValidationErrors.length) {
-			throw new WebpackOptionsValidationError(webpackOptionsValidationErrors);
-		}
-		*/
-
+		let initialWebpackConfig = initTransform(opts);
+		//	const webpackOptionsValidationErrors = validateSchema(webpackOptionsSchema, initialWebpackConfig);
+		//if(webpackOptionsValidationErrors.length) {
+			//throw new WebpackOptionsValidationError(webpackOptionsValidationErrors);
+		//} else {
+		let logicPath = process.cwd() + '/webpack.config.js';
+		fs.writeFileSync(logicPath, initialWebpackConfig, 'utf8');
+		process.stdout.write('\n' + chalk.green(`Congratulations! Your new webpack config file is at ${logicPath}`) + '\n');
+		//}
 	} else {
 		resolveDependency(pkg);
 	}

--- a/lib/parser/index.js
+++ b/lib/parser/index.js
@@ -29,15 +29,13 @@ module.exports = function parser(pkg,opts) {
 	// null, config -> without package
 	// addon, null -> with package
 	if(opts) {
-		let initialWebpackConfig = initTransform(opts);
-		//	const webpackOptionsValidationErrors = validateSchema(webpackOptionsSchema, initialWebpackConfig);
-		//if(webpackOptionsValidationErrors.length) {
-			//throw new WebpackOptionsValidationError(webpackOptionsValidationErrors);
-		//} else {
-		let logicPath = process.cwd() + '/webpack.config.js';
-		fs.writeFileSync(logicPath, initialWebpackConfig, 'utf8');
-		process.stdout.write('\n' + chalk.green(`Congratulations! Your new webpack config file is at ${logicPath}`) + '\n');
-		//}
+		let initialWebpackConfig = require(initTransform(opts));
+		const webpackOptionsValidationErrors = validateSchema(webpackOptionsSchema, initialWebpackConfig);
+		if (webpackOptionsValidationErrors.length) {
+			throw new WebpackOptionsValidationError(webpackOptionsValidationErrors);
+		} else {
+			process.stdout.write('\n' + chalk.green('Congratulations! Your new webpack config file is created!') + '\n');
+		}
 	} else {
 		resolveDependency(pkg);
 	}

--- a/lib/parser/init-transform.js
+++ b/lib/parser/init-transform.js
@@ -1,0 +1,11 @@
+const jscodeshift = require('jscodeshift');
+const fs = require('fs');
+const path = require('path');
+
+module.exports = function initTransform(opts) {
+
+	const templateFP = path.join(__dirname, 'utils', 'template.js');
+	const template = fs.readFileSync(templateFP, 'utf8');
+	const ast = jscodeshift(template);
+
+};

--- a/lib/parser/init-transform.js
+++ b/lib/parser/init-transform.js
@@ -1,18 +1,11 @@
-const jscodeshift = require('jscodeshift');
 const fs = require('fs');
 const path = require('path');
-let transforms = require('./transformations/index');
+const transform = require('./transformations').transform;
 
 module.exports = function initTransform(opts) {
-
+	global.options = opts;
 	const templateFP = path.join(__dirname, 'utils', 'template.js');
 	const template = fs.readFileSync(templateFP, 'utf8');
-	const ast = jscodeshift(template);
-	const recastOptions = Object.assign({
-		quote: 'single'
-	});
-	Object.keys(transforms).forEach(f => {
-		transforms[f](jscodeshift, ast);
-	});
-//	return ast.toSource(recastOptions);
+	const ast = transform(template);
+	return ast;
 };

--- a/lib/parser/init-transform.js
+++ b/lib/parser/init-transform.js
@@ -1,11 +1,18 @@
 const jscodeshift = require('jscodeshift');
 const fs = require('fs');
 const path = require('path');
+let transforms = require('./transformations/index');
 
 module.exports = function initTransform(opts) {
 
 	const templateFP = path.join(__dirname, 'utils', 'template.js');
 	const template = fs.readFileSync(templateFP, 'utf8');
 	const ast = jscodeshift(template);
-
+	const recastOptions = Object.assign({
+		quote: 'single'
+	});
+	Object.keys(transforms).forEach(f => {
+		transforms[f](jscodeshift, ast);
+	});
+//	return ast.toSource(recastOptions);
 };

--- a/lib/parser/init-transform.js
+++ b/lib/parser/init-transform.js
@@ -7,5 +7,12 @@ module.exports = function initTransform(opts) {
 	const templateFP = path.join(__dirname, 'utils', 'template.js');
 	const template = fs.readFileSync(templateFP, 'utf8');
 	const ast = transform(template);
-	return ast;
+	try {
+		const logicPath = process.cwd() + '/webpack.config.js';
+		fs.writeFileSync(logicPath, ast, 'utf8');
+		return logicPath;
+	} catch (err) {
+		console.error(err);
+		process.exit(1);
+	}
 };

--- a/lib/parser/resolve-dependency.js
+++ b/lib/parser/resolve-dependency.js
@@ -4,7 +4,7 @@ const Rx = require('rx');
 const prompt = require('../inquirer-prompt');
 const questions = require('../utils/initial-questions');
 
-module.exports = function resolveTransform(pkg) {
+module.exports = function resolveDependency(pkg) {
 	const pkgQuestions = questions.concat(pkg.inquirer);
 	const pkgAddon = Rx.Observable.from(pkgQuestions);
 

--- a/lib/parser/transform.js
+++ b/lib/parser/transform.js
@@ -1,3 +1,0 @@
-// Hook up transformations with our options
-module.exports = function transform(n) { //eslint-disable-line
-};

--- a/lib/parser/transformations/entry/entry.js
+++ b/lib/parser/transformations/entry/entry.js
@@ -1,0 +1,3 @@
+module.exports = function(j, ast) {
+
+};

--- a/lib/parser/transformations/entry/entry.js
+++ b/lib/parser/transformations/entry/entry.js
@@ -1,3 +1,18 @@
-module.exports = function(j, ast) {
+const utils = require('../../../transformations/utils');
 
+module.exports = function(j, ast) {
+	ast.find(j.ObjectExpression).forEach(path => {
+		path.value.properties.filter(prop => {
+			if(prop.key.name === 'entry') {
+				prop.value = j.objectExpression([
+					utils.createProperty(j, 'filename', global.options.entry)
+				]);
+			}
+			if(prop.key.name === 'output') {
+				prop.value = j.objectExpression([
+					utils.createProperty(j, 'filename', global.options.output)
+				]);
+			}
+		});
+	});
 };

--- a/lib/parser/transformations/index.js
+++ b/lib/parser/transformations/index.js
@@ -1,0 +1,11 @@
+const addLoadersTransform = require('./loaders/loaders');
+const addEntryTransform = require('./entry/entry');
+const addOutputTransform = require('./output/output');
+const addResolveTransform = require('./resolve/resolve');
+
+module.exports = {
+	addEntryTransform,
+	addOutputTransform,
+	addResolveTransform,
+	addLoadersTransform
+};

--- a/lib/parser/transformations/index.js
+++ b/lib/parser/transformations/index.js
@@ -1,11 +1,27 @@
+const jscodeshift = require('jscodeshift');
 const addLoadersTransform = require('./loaders/loaders');
 const addEntryTransform = require('./entry/entry');
 const addOutputTransform = require('./output/output');
 const addResolveTransform = require('./resolve/resolve');
 
-module.exports = {
+const transformations = {
 	addEntryTransform,
 	addOutputTransform,
 	addResolveTransform,
 	addLoadersTransform
+};
+
+function transform(source, transforms, options) {
+	const ast = jscodeshift(source);
+	const recastOptions = Object.assign({
+		quote: 'single'
+	}, options);
+	transforms = transforms || Object.keys(transformations).map(k => transformations[k]);
+	transforms.forEach(f => f(jscodeshift, ast));
+	return ast.toSource(recastOptions);
+}
+
+module.exports = {
+	transform,
+	transformations
 };

--- a/lib/parser/transformations/loaders/loaders.js
+++ b/lib/parser/transformations/loaders/loaders.js
@@ -1,0 +1,3 @@
+module.exports = function(j, ast) {
+
+};

--- a/lib/parser/transformations/output/output.js
+++ b/lib/parser/transformations/output/output.js
@@ -1,0 +1,3 @@
+module.exports = function(j, ast) {
+
+};

--- a/lib/parser/transformations/resolve/resolve.js
+++ b/lib/parser/transformations/resolve/resolve.js
@@ -1,0 +1,3 @@
+module.exports = function(j, ast) {
+
+};

--- a/lib/parser/utils/template.js
+++ b/lib/parser/utils/template.js
@@ -1,0 +1,7 @@
+module.exports = {
+	entry: [],
+	output: {},
+	resolve: {
+		modules: ['node_modules']
+	}
+};

--- a/lib/utils/resolve-packages.js
+++ b/lib/utils/resolve-packages.js
@@ -29,8 +29,8 @@ function processPromise(child) {
 */
 
 function spawnChild(pkg) {
-	//return spawn('npm', ['install', '--save', pkg], { stdio: 'inherit', customFds: [0, 1, 2] });
-	return spawn('npm', ['install', '--save', pkg]);
+	return spawn('npm', ['install', '--save', pkg], { stdio: 'inherit', customFds: [0, 1, 2] });
+	//return spawn('npm', ['install', '--save', pkg]);
 }
 
 /*


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Let's us validate an webpack config after creating one and also introduces the first transformation rules.

**Did you add tests for your changes?**

Yes

**If relevant, did you update the documentation?**

No

**Summary**

Adds validation and initial transformation rules to get a "first usable config" with only basic rules. 

**Does this PR introduce a breaking change?**

Yes

**Other information**

We should get @eliperelman involved, we may not need transformation rules for the parser. PR should be merged and then we could refactor later, which is the next step in the process ( see if we can integrate webpack-chain ) 