### PR TITLE
Feature: adds a stats option

### DIFF
--- a/bin/process-options.js
+++ b/bin/process-options.js
@@ -21,6 +21,10 @@ module.exports = function processOptions(yargs, argv) {
 
 	var firstOptions = Array.isArray(options) ? (options[0] || {}) : options;
 
+	ifArg('stats', function (value) {
+		options.stats = value;
+	});
+
 	if(typeof options.stats === 'boolean' || typeof options.stats === 'string') {
 		var statsPresetToOptions = require('webpack/lib/Stats.js').presetToOptions;
 		options.stats = statsPresetToOptions(options.stats);
@@ -50,9 +54,11 @@ module.exports = function processOptions(yargs, argv) {
 		outputOptions.assetsSort = value;
 	});
 
-	ifArg('display-exclude', function(value) {
-		outputOptions.exclude = value;
-	});
+	if (!argv.stats) {
+		ifArg('display-exclude', function(value) {
+			outputOptions.exclude = value;
+		});
+	}
 
 	if(!outputOptions.json) {
 		if(typeof outputOptions.cached === 'undefined')
@@ -60,44 +66,48 @@ module.exports = function processOptions(yargs, argv) {
 		if(typeof outputOptions.cachedAssets === 'undefined')
 			outputOptions.cachedAssets = false;
 
-		ifArg('display-chunks', function(bool) {
-			outputOptions.modules = !bool;
-			outputOptions.chunks = bool;
-		});
+		if (!argv.stats) {
+			ifArg('display-chunks', function(bool) {
+				outputOptions.modules = !bool;
+				outputOptions.chunks = bool;
+			});
 
-		ifArg('display-entrypoints', function(bool) {
-			outputOptions.entrypoints = bool;
-		});
+			ifArg('display-entrypoints', function(bool) {
+				outputOptions.entrypoints = bool;
+			});
 
-		ifArg('display-reasons', function(bool) {
-			outputOptions.reasons = bool;
-		});
+			ifArg('display-reasons', function(bool) {
+				outputOptions.reasons = bool;
+			});
 
-		ifArg('display-used-exports', function(bool) {
-			outputOptions.usedExports = bool;
-		});
+			ifArg('display-used-exports', function(bool) {
+				outputOptions.usedExports = bool;
+			});
 
-		ifArg('display-provided-exports', function(bool) {
-			outputOptions.providedExports = bool;
-		});
+			ifArg('display-provided-exports', function(bool) {
+				outputOptions.providedExports = bool;
+			});
 
-		ifArg('display-error-details', function(bool) {
-			outputOptions.errorDetails = bool;
-		});
+			ifArg('display-error-details', function(bool) {
+				outputOptions.errorDetails = bool;
+			});
 
-		ifArg('display-origins', function(bool) {
-			outputOptions.chunkOrigins = bool;
-		});
+			ifArg('display-origins', function(bool) {
+				outputOptions.chunkOrigins = bool;
+			});
 
-		ifArg('display-cached', function(bool) {
-			if(bool)
-				outputOptions.cached = true;
-		});
+			ifArg('display-cached', function(bool) {
+				if(bool)
+					outputOptions.cached = true;
+			});
 
-		ifArg('display-cached-assets', function(bool) {
-			if(bool)
-				outputOptions.cachedAssets = true;
-		});
+			ifArg('display-cached-assets', function(bool) {
+				if(bool)
+					outputOptions.cachedAssets = true;
+			});
+		} else {
+			outputOptions.modules = true;
+		}
 
 		if(!outputOptions.exclude && !argv['display-modules'])
 			outputOptions.exclude = ['node_modules', 'bower_components', 'jam', 'components'];
@@ -118,12 +128,14 @@ module.exports = function processOptions(yargs, argv) {
 			outputOptions.cachedAssets = true;
 	}
 
-	ifArg('hide-modules', function(bool) {
-		if(bool) {
-			outputOptions.modules = false;
-			outputOptions.chunkModules = false;
-		}
-	});
+	if (!argv.stats) {
+		ifArg('hide-modules', function(bool) {
+			if(bool) {
+				outputOptions.modules = false;
+				outputOptions.chunkModules = false;
+			}
+		});
+	}
 
 	var webpack = require('webpack/lib/webpack.js');
 

--- a/bin/webpack.js
+++ b/bin/webpack.js
@@ -37,7 +37,6 @@ var yargs = require('yargs')
 
 require('./config-yargs')(yargs);
 
-
 var DISPLAY_GROUP = 'Stats options:';
 var BASIC_GROUP = 'Basic options:';
 
@@ -140,12 +139,30 @@ yargs.options({
 		type: 'boolean',
 		group: DISPLAY_GROUP,
 		describe: 'Show more details'
+	},
+	'stats': {
+		type: 'string',
+		describe: 'Display information using a preset(Accepted presets: none, errors-only, minimal, normal, verbose)',
+		group: DISPLAY_GROUP
 	}
 });
 
 var argv = yargs.argv;
 
-if(argv.verbose) {
+if (argv.stats) {
+	for (let key in argv) {
+		const value = argv[key];
+
+		if ((key.indexOf('display-') == 0 ||
+         key.match(/hide-modules/)    ||
+         key.match(/verbose/)
+        ) && value ) {
+			throw new Error(`Please omit ${ key } if you are using stats`);
+		}
+	}
+}
+
+if(argv.verbose && !argv.stats) {
 	argv['display-reasons'] = true;
 	argv['display-entrypoints'] = true;
 	argv['display-used-exports'] = true;

--- a/bin/webpack.js
+++ b/bin/webpack.js
@@ -142,8 +142,9 @@ yargs.options({
 	},
 	'stats': {
 		type: 'string',
-		describe: 'Display information using a preset(Accepted presets: none, errors-only, minimal, normal, verbose)',
-		group: DISPLAY_GROUP
+		group: DISPLAY_GROUP,
+		describe: 'Display with a preset (Accepted presets: ' + '\n' +
+		'none, errors-only, minimal, normal, verbose)'
 	}
 });
 


### PR DESCRIPTION
display information using presets as shortcuts

Feature: adds a stats option

display information using presets as shortcuts

**What kind of change does this PR introduce?**
*feature*

**Did you add tests for your changes?**
Actually Not!

**Summary**
One cool feature in webpack config files is that you can display stats information about your bundling process using presets as shortcuts. I would love this feature to be avaliable on the CLI as well. #84 