### PR TITLE
Fix: Only try to remove deprecated plugins from array expressions

### DIFF
--- a/lib/transformations/defineTest.js
+++ b/lib/transformations/defineTest.js
@@ -53,7 +53,7 @@ function runTest(dirName, transformName, testFilePrefix) {
 		jscodeshift = jscodeshift.withParser(module.parser);
 	}
 	const ast = jscodeshift(source);
-	const output = transform(jscodeshift, ast).toSource({ quote: 'single' });
+	const output = transform(jscodeshift, ast, source).toSource({ quote: 'single' });
 	expect(output).toMatchSnapshot();
 }
 

--- a/lib/transformations/index.js
+++ b/lib/transformations/index.js
@@ -37,7 +37,7 @@ function transform(source, transforms, options) {
 		quote: 'single'
 	}, options);
 	transforms = transforms || Object.keys(transformations).map(k => transformations[k]);
-	transforms.forEach(f => f(jscodeshift, ast));
+	transforms.forEach(f => f(jscodeshift, ast, source));
 	return ast.toSource(recastOptions);
 }
 

--- a/lib/transformations/removeDeprecatedPlugins/__snapshots__/removeDeprecatedPlugins.test.js.snap
+++ b/lib/transformations/removeDeprecatedPlugins/__snapshots__/removeDeprecatedPlugins.test.js.snap
@@ -19,3 +19,14 @@ module.exports = {
 }
 "
 `;
+
+exports[`removeDeprecatedPlugins transforms correctly using "removeDeprecatedPlugins-3" data 1`] = `
+"// This should throw
+export default (config) => {
+    config.plugins.push(new webpack.optimize.UglifyJsPlugin());
+    config.plugins.push(new webpack.optimize.DedupePlugin());
+    config.plugins.push(new webpack.optimize.OccurrenceOrderPlugin());
+    return config
+}
+"
+`;

--- a/lib/transformations/removeDeprecatedPlugins/__testfixtures__/removeDeprecatedPlugins-3.input.js
+++ b/lib/transformations/removeDeprecatedPlugins/__testfixtures__/removeDeprecatedPlugins-3.input.js
@@ -1,0 +1,7 @@
+// This should throw
+export default (config) => {
+    config.plugins.push(new webpack.optimize.UglifyJsPlugin());
+    config.plugins.push(new webpack.optimize.DedupePlugin());
+    config.plugins.push(new webpack.optimize.OccurrenceOrderPlugin());
+    return config
+}

--- a/lib/transformations/removeDeprecatedPlugins/removeDeprecatedPlugins.js
+++ b/lib/transformations/removeDeprecatedPlugins/removeDeprecatedPlugins.js
@@ -1,4 +1,4 @@
-const findPluginsByName = require('../utils').findPluginsByName;
+const utils = require('../utils');
 
 module.exports = function(j, ast) {
 	// List of deprecated plugins to remove
@@ -8,14 +8,24 @@ module.exports = function(j, ast) {
 		'webpack.optimize.DedupePlugin'
 	];
 
-	return findPluginsByName(j, ast, deprecatedPlugingsList)
+	return utils.findPluginsByName(j, ast, deprecatedPlugingsList)
 		.forEach(path => {
-			// Check how many plugins are defined and
-			// if there is only last plugin left remove `plugins: []` completely
-			if (path.parent.value.elements.length === 1) {
-				j(path.parent.parent).remove();
+			// For now we only support the case there plugins are defined in an Array
+			if (path.parent &&
+				path.parent.value &&
+				utils.isType(path.parent.value, 'ArrayExpression')
+			) {
+				// Check how many plugins are defined and
+				// if there is only last plugin left remove `plugins: []` node
+				if(path.parent.value.elements.length === 1) {
+					j(path.parent.parent).remove();
+				} else {
+					j(path).remove();
+				}
 			} else {
-				j(path).remove();
+				console.error(`For now only plugins instantiated in an array can be removed.
+Please remove deprecated plugins manually. 
+See https://webpack.js.org/guides/migrating/ for more information.`);
 			}
 		});
 };

--- a/lib/transformations/removeDeprecatedPlugins/removeDeprecatedPlugins.js
+++ b/lib/transformations/removeDeprecatedPlugins/removeDeprecatedPlugins.js
@@ -1,6 +1,7 @@
+const codeFrame = require('babel-code-frame');
 const utils = require('../utils');
 
-module.exports = function(j, ast) {
+module.exports = function(j, ast, source) {
 	// List of deprecated plugins to remove
 	// each item refers to webpack.optimize.[NAME] construct
 	const deprecatedPlugingsList = [
@@ -23,7 +24,9 @@ module.exports = function(j, ast) {
 					j(path).remove();
 				}
 			} else {
+				const startLoc = path.value.loc.start;
 				console.error(`For now only plugins instantiated in an array can be removed.
+${ codeFrame(source, startLoc.line, startLoc.column, { highlightCode: true }) }
 Please remove deprecated plugins manually. 
 See https://webpack.js.org/guides/migrating/ for more information.`);
 			}

--- a/lib/transformations/removeDeprecatedPlugins/removeDeprecatedPlugins.js
+++ b/lib/transformations/removeDeprecatedPlugins/removeDeprecatedPlugins.js
@@ -1,5 +1,12 @@
 const codeFrame = require('babel-code-frame');
+const chalk = require('chalk');
 const utils = require('../utils');
+
+const example = `plugins: [
+    new webpack.optimize.OccurrenceOrderPlugin(),
+    new webpack.optimize.UglifyJsPlugin(),
+    new webpack.optimize.DedupePlugin()
+]`;
 
 module.exports = function(j, ast, source) {
 	// List of deprecated plugins to remove
@@ -18,17 +25,24 @@ module.exports = function(j, ast, source) {
 			) {
 				// Check how many plugins are defined and
 				// if there is only last plugin left remove `plugins: []` node
-				if(path.parent.value.elements.length === 1) {
+				if (path.parent.value.elements.length === 1) {
 					j(path.parent.parent).remove();
 				} else {
 					j(path).remove();
 				}
 			} else {
 				const startLoc = path.value.loc.start;
-				console.error(`For now only plugins instantiated in an array can be removed.
+				console.log(`
+${ chalk.red('Only plugins instantiated in the array can be automatically removed i.e.:') }
+
+${ codeFrame(example, null, null, { highlightCode: true }) }
+				
+${ chalk.red('but you use it like this:') }
+
 ${ codeFrame(source, startLoc.line, startLoc.column, { highlightCode: true }) }
-Please remove deprecated plugins manually. 
-See https://webpack.js.org/guides/migrating/ for more information.`);
+
+${ chalk.red('Please remove deprecated plugins manually. ') }
+See ${ chalk.underline('https://webpack.js.org/guides/migrating/')} for more information.`);
 			}
 		});
 };

--- a/lib/transformations/removeDeprecatedPlugins/removeDeprecatedPlugins.test.js
+++ b/lib/transformations/removeDeprecatedPlugins/removeDeprecatedPlugins.test.js
@@ -3,3 +3,4 @@ const defineTest = require('../defineTest');
 defineTest(__dirname, 'removeDeprecatedPlugins', 'removeDeprecatedPlugins-0');
 defineTest(__dirname, 'removeDeprecatedPlugins', 'removeDeprecatedPlugins-1');
 defineTest(__dirname, 'removeDeprecatedPlugins', 'removeDeprecatedPlugins-2');
+defineTest(__dirname, 'removeDeprecatedPlugins', 'removeDeprecatedPlugins-3');

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "test": "jest --coverage"
   },
   "dependencies": {
+    "babel-code-frame": "^6.22.0",
     "babel-core": "^6.21.0",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-stage-3": "^6.17.0",


### PR DESCRIPTION
**What kind of change does this PR introduce?**
bugfix

**Did you add tests for your changes?**
Yes

**If relevant, did you update the documentation?**
N/A

**Summary**

It fixes #83 and shows a nice error message for unsupported cases:

![2017-03-20 at 09 50](https://cloud.githubusercontent.com/assets/11071/24093160/b3a24ecc-0d52-11e7-935f-6c58f9f8d1da.png)

**Does this PR introduce a breaking change?**
Nope

**Other information**
For now, only plugins instantiated in an array can be removed by deprecated plugins transform since this is safe.