### PR TITLE
build: Enable codecov integration during Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ notifications:
 before_script:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
+  - bash <(curl -s https://codecov.io/bash)
 
 script:
   - npm run lint


### PR DESCRIPTION
This PR should enable the codecov reporting on PR during the Travis build