### PR TITLE
ensure default output path is absolute

### DIFF
--- a/lib/creator/yeoman/webpack-generator.js
+++ b/lib/creator/yeoman/webpack-generator.js
@@ -43,6 +43,7 @@ module.exports = class WebpackGenerator extends Generator {
 		this.configuration.config.webpackOptions.plugins = getDefaultPlugins();
 		this.configuration.config.topScope.push(
 			'const webpack = require(\'webpack\')',
+			'const path = require(\'path\')',
 			tooltip.uglify(),
 			'const UglifyJSPlugin = require(\'uglifyjs-webpack-plugin\');',
 			'\n'
@@ -76,7 +77,7 @@ module.exports = class WebpackGenerator extends Generator {
 					if(outputTypeAnswer['outputType'].length) {
 						this.configuration.config.webpackOptions.output.path = `'${outputTypeAnswer['outputType']}'`;
 					} else {
-						this.configuration.config.webpackOptions.output.path = '\'./dist\'';
+						this.configuration.config.webpackOptions.output.path = '\path.resolve(__dirname, \'dist\')';
 					}
 				}).then( () => {
 					this.prompt([


### PR DESCRIPTION
Example of problem:

```
$ webpack-cli init

Insecure about some of the questions?

https://github.com/webpack/webpack-cli/blob/master/INIT.md

? Will you be creating multiple bundles? No
? Which module will be the first to enter the application? ./src
? Which folder will your generated bundles be in? [default: dist]:
? Are you going to use this in production? No
? Will you be using ES2015? No
? Will you use one of the below CSS solutions? No
? If you want to bundle your CSS files, what will you name the bundle? (press enter to skip)
? Name your 'webpack.[name].js?' [default: 'config']:

... (npm output) ...

Congratulations! Your new webpack configuration file has been created!

$ webpack
Invalid configuration object. Webpack has been initialised using a configuration object that does not match the API schema.
 - configuration.output.path: The provided value "./dist" is not an absolute path!

$ cat -n webpack.config.js
...
    15          output: {
    16                  filename: '[name].bundle.js',
    17                  path: './dist'   <-- RUH-ROH
    18          },
...
```

This PR converts the line above to:

``` js
path: path.resolve(__dirname, 'dist')
```