### PR TITLE
fix: Deps 'webpack' and 'uglifyjs-webpack-plugin' not installed when ...

### DIFF
--- a/lib/creator/yeoman/webpack-generator.js
+++ b/lib/creator/yeoman/webpack-generator.js
@@ -93,7 +93,7 @@ module.exports = class WebpackGenerator extends Generator {
 						]).then( (ans) => {
 							if(ans['babelConfirm'] === true) {
 								this.configuration.config.webpackOptions.module.rules.push(getBabelPlugin());
-								this.npmInstalls = ['babel-loader', 'babel-core', 'babel-preset-env'];
+								this.npmInstalls.push('babel-loader', 'babel-core', 'babel-preset-env');
 							}
 						}).then( () => {
 							this.prompt([


### PR DESCRIPTION
... user answers yes to 'using ES2015?' (#135).

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Bugfix

**Did you add tests for your changes?**
No (none in repo)

**If relevant, did you update the documentation?**
N/A

**Summary**
Fixes essential deps not being installed, when using `webpack-cli init` and answering 'yes' to 'Will you be using ES2015?'

**Does this PR introduce a breaking change?**
No