### PR TITLE
fix: Install correct (`es2015`) babel preset to match generated config

### DIFF
--- a/lib/creator/yeoman/webpack-generator.js
+++ b/lib/creator/yeoman/webpack-generator.js
@@ -94,7 +94,7 @@ module.exports = class WebpackGenerator extends Generator {
 						]).then( (ans) => {
 							if(ans['babelConfirm'] === true) {
 								this.configuration.config.webpackOptions.module.rules.push(getBabelPlugin());
-								this.npmInstalls.push('babel-loader', 'babel-core', 'babel-preset-env');
+								this.npmInstalls.push('babel-loader', 'babel-core', 'babel-preset-es2015');
 							}
 						}).then( () => {
 							this.prompt([


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bugfix

**Did you add tests for your changes?**
No (none in repo)

**If relevant, did you update the documentation?**
N/A

**Summary**
Raised in #135, but I didn't address this outstanding problem in the previous PR.

The config generated uses `presets: ['es2015']`, see: https://github.com/webpack/webpack-cli/blob/master/lib/creator/yeoman/utils/module.js#L8

... but are previously installing `babel-preset-env` instead, which results in: `Error: Couldn't find preset "es2015"` when user answers `'y'` to 'Will you be using ES2015?', then runs `webpack`.

**Does this PR introduce a breaking change?**
No
