### PR TITLE
chore(tests): Use node env for Jest to avoid JSDOM overhead

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,5 +73,8 @@
       "git add"
     ]
   },
-  "pre-commit": "lint:staged"
+  "pre-commit": "lint:staged",
+  "jest": {
+    "testEnvironment": "node"
+  }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
build related change

**Did you add tests for your changes?**

Not relevant

**If relevant, did you update the documentation?**

Not relevant

**Summary**

Jest can be configured to run in Node env only without emulating browser with JSDOM: https://facebook.github.io/jest/docs/en/configuration.html#testenvironment-string

This improves tests running speed significantly:

### Before

```
Test Suites: 31 passed, 31 total
Tests:       1 skipped, 126 passed, 127 total
Snapshots:   110 passed, 110 total
Time:        24.577s
```

### After

```
Test Suites: 31 passed, 31 total
Tests:       1 skipped, 126 passed, 127 total
Snapshots:   110 passed, 110 total
Time:        15.168s, estimated 19s
```
