### PR TITLE
fix: Give examples that are valid (and clearer).

### DIFF
--- a/lib/creator/yeoman/utils/entry.js
+++ b/lib/creator/yeoman/utils/entry.js
@@ -8,7 +8,7 @@ module.exports = (self, answer) => {
 		result = self.prompt([
 			InputValidate(
 				'multipleEntries',
-				'Type the name you want for your modules (entry files), separated by comma [example: \'app\']',
+				'Type the names you want for your modules (entry files), separated by comma [example: \'app,vendor\']',
 				validate
 			)
 		]).then( (multipleEntriesAnswer) => {
@@ -41,7 +41,7 @@ module.exports = (self, answer) => {
 			return forEachPromise(entryIdentifiers, (entryProp) => self.prompt([
 				InputValidate(
 					`${entryProp}`,
-					`What is the location of '${entryProp}'? [example: '../dist/app.js']`,
+					`What is the location of '${entryProp}'? [example: './${entryProp}']`,
 					validate
 				)
 			])).then(propAns => {

--- a/lib/creator/yeoman/utils/entry.js
+++ b/lib/creator/yeoman/utils/entry.js
@@ -41,7 +41,7 @@ module.exports = (self, answer) => {
 			return forEachPromise(entryIdentifiers, (entryProp) => self.prompt([
 				InputValidate(
 					`${entryProp}`,
-					`What is the location of '${entryProp}'? [example: './app']`,
+					`What is the location of '${entryProp}'? [example: './src/${entryProp}']`,
 					validate
 				)
 			])).then(propAns => {
@@ -65,7 +65,7 @@ module.exports = (self, answer) => {
 		result = self.prompt([
 			InputValidate(
 				'singularEntry',
-				'Which module will be the first to enter the application? [example: \'./index\']',
+				'Which module will be the first to enter the application? [example: \'./src/index\']',
 				validate
 			)
 		]).then( (singularAnswer) => `'${singularAnswer['singularEntry']}'`);

--- a/lib/creator/yeoman/utils/entry.js
+++ b/lib/creator/yeoman/utils/entry.js
@@ -41,7 +41,7 @@ module.exports = (self, answer) => {
 			return forEachPromise(entryIdentifiers, (entryProp) => self.prompt([
 				InputValidate(
 					`${entryProp}`,
-					`What is the location of '${entryProp}'? [example: './${entryProp}']`,
+					`What is the location of '${entryProp}'? [example: './app']`,
 					validate
 				)
 			])).then(propAns => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Bugfix

**Did you add tests for your changes?**
N/A

**If relevant, did you update the documentation?**
N/A

**Summary**
When using `webpack-cli init` and answering the questions for 'multiple' entry files, the examples given are misleading.
 
The main issue is that following the format of one example will lead to a `.js.js` extension, so the resulting config will not be valid.

See [comments here](https://github.com/webpack/webpack-cli/commit/37c40f046bec586819263361e56fc90dc3309e08) for more details.

**Does this PR introduce a breaking change?**
No