### PR TITLE
fix(migrate): Fix migration of LoaderOptionsPlugin

### DIFF
--- a/lib/transformations/__snapshots__/index.test.js.snap
+++ b/lib/transformations/__snapshots__/index.test.js.snap
@@ -27,7 +27,7 @@ module.exports = {
 		new webpack.optimize.UglifyJsPlugin({
             sourceMap: true,
         }),
-		new webpack.optimize.LoaderOptionsPlugin({
+		new webpack.LoaderOptionsPlugin({
             debug: true,
             minimize: true,
         })
@@ -97,7 +97,7 @@ module.exports = {
 		new webpack.optimize.UglifyJsPlugin({
             sourceMap: true
         }),
-		new webpack.optimize.LoaderOptionsPlugin({
+		new webpack.LoaderOptionsPlugin({
             debug: true,
             minimize: true
         })

--- a/lib/transformations/loaderOptionsPlugin/__snapshots__/loaderOptionsPlugin.test.js.snap
+++ b/lib/transformations/loaderOptionsPlugin/__snapshots__/loaderOptionsPlugin.test.js.snap
@@ -15,7 +15,7 @@ exports[`loaderOptionsPlugin transforms correctly using "loaderOptionsPlugin-1" 
     debug: true,
     plugins: [
         new webpack.optimize.UglifyJsPlugin(),
-        new webpack.optimize.LoaderOptionsPlugin({
+        new webpack.LoaderOptionsPlugin({
             foo: 'bar',
             debug: true,
             minimize: true
@@ -30,7 +30,7 @@ exports[`loaderOptionsPlugin transforms correctly using "loaderOptionsPlugin-2" 
 module.exports = {
     plugins: [
         new SomePlugin(),
-        new webpack.optimize.LoaderOptionsPlugin({
+        new webpack.LoaderOptionsPlugin({
             foo: 'bar'
         })
     ]

--- a/lib/transformations/loaderOptionsPlugin/__testfixtures__/loaderOptionsPlugin-1.input.js
+++ b/lib/transformations/loaderOptionsPlugin/__testfixtures__/loaderOptionsPlugin-1.input.js
@@ -2,7 +2,7 @@ module.exports = {
     debug: true,
     plugins: [
         new webpack.optimize.UglifyJsPlugin(),
-        new webpack.optimize.LoaderOptionsPlugin({
+        new webpack.LoaderOptionsPlugin({
             foo: 'bar'
         })
     ]

--- a/lib/transformations/loaderOptionsPlugin/__testfixtures__/loaderOptionsPlugin-2.input.js
+++ b/lib/transformations/loaderOptionsPlugin/__testfixtures__/loaderOptionsPlugin-2.input.js
@@ -2,7 +2,7 @@
 module.exports = {
     plugins: [
         new SomePlugin(),
-        new webpack.optimize.LoaderOptionsPlugin({
+        new webpack.LoaderOptionsPlugin({
             foo: 'bar'
         })
     ]

--- a/lib/transformations/loaderOptionsPlugin/loaderOptionsPlugin.js
+++ b/lib/transformations/loaderOptionsPlugin/loaderOptionsPlugin.js
@@ -23,6 +23,6 @@ module.exports = function(j, ast) {
 		.filter(path => safeTraverse(path, ['parent', 'value', 'key', 'name']) === 'plugins')
 		.forEach(path => {
 			!isEmpty(loaderOptions) &&
-			createOrUpdatePluginByName(j, path, 'webpack.optimize.LoaderOptionsPlugin', loaderOptions);
+			createOrUpdatePluginByName(j, path, 'webpack.LoaderOptionsPlugin', loaderOptions);
 		});
 };


### PR DESCRIPTION
`webpack.optimize.LoaderOptionsPlugin` should be `webpack.LoaderOptionsPlugin`

Closes #171 

**What kind of change does this PR introduce?**
bugfix

**Did you add tests for your changes?**
yes

**If relevant, did you update the documentation?**
n/a

**Summary**

See #171 

**Does this PR introduce a breaking change?**
No

**Other information**