### PR TITLE
migrate documentation

### DIFF
--- a/MIGRATE.md
+++ b/MIGRATE.md
@@ -4,71 +4,72 @@ The `migrate` feature eases the transition from [version 1](http://webpack.githu
 also allows users to switch to the new version of webpack without having to extensively [refactor](https://webpack.js.org/guides/migrating/).
 
 ### Usage
-To use migrate, run the following command, with the path being an existing webpack configuration file
+To use `migrate`, run the following command, with the value of `<config` being a path to an existing webpack configuration file
 
 ```bash
-  webpack-cli migrate <config>
+webpack-cli migrate <config>
 ```
 
 Given a basic configuration file like so:
 
 ```javascript
-	const ExtractTextPlugin = require('extract-text-webpack-plugin');
-	const HtmlWebpackPlugin = require('html-webpack-plugin');
-	const path = require('path');
-	const UglifyJSPlugin = require('uglifyjs-webpack-plugin');
-	const webpack = require('webpack');
-	
-	module.exports = {
-	
-	  entry: {
-		index: './src/index.js',
-		vendor: './src/vendor.js'
+const ExtractTextPlugin = require('extract-text-webpack-plugin');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+const path = require('path');
+const UglifyJSPlugin = require('uglifyjs-webpack-plugin');
+const webpack = require('webpack');
+
+module.exports = {
+
+  entry: {
+	index: './src/index.js',
+	vendor: './src/vendor.js'
+  },
+
+  output: {
+	filename: '[name].[chunkhash].js',
+	chunkFilename: '[name].[chunkhash].js',
+	path: path.resolve(__dirname, 'dist')
+  },
+
+  module: {
+	loaders: [
+	  {
+		test: /\.js$/,
+		exclude: /node_modules/,
+		loader: 'babel',
+		query: {
+		  presets: ['es2015']
+		}
 	  },
-	
-	  output: {
-		filename: '[name].[chunkhash].js',
-		chunkFilename: '[name].[chunkhash].js',
-		path: path.resolve(__dirname, 'dist')
-	  },
-	
-	  module: {
-		loaders: [
-		  {
-			test: /\.js$/,
-			exclude: /node_modules/,
-			loader: 'babel',
-			query: {
-			  presets: ['es2015']
-			}
-		  },
-		  {
-			test: /\.(scss|css)$/,
-			loader: ExtractTextPlugin.extract('style', 'css!sass')
-		  }
-		]
-	  },
-	
-	  plugins: [
-		new UglifyJSPlugin(),
-	
-		new ExtractTextPlugin('styles-[contentHash].css'),
-	
-		new webpack.optimize.CommonsChunkPlugin({
-		  name: 'common',
-		  filename: 'common-[hash].min.js'
-		}),
-	
-		new HtmlWebpackPlugin()
-	  ]
-	
-	};
+	  {
+		test: /\.(scss|css)$/,
+		loader: ExtractTextPlugin.extract('style', 'css!sass')
+	  }
+	]
+  },
+
+  plugins: [
+	new UglifyJSPlugin(),
+
+	new ExtractTextPlugin('styles-[contentHash].css'),
+
+	new webpack.optimize.CommonsChunkPlugin({
+	  name: 'common',
+	  filename: 'common-[hash].min.js'
+	}),
+
+	new HtmlWebpackPlugin()
+  ]
+
+};
 ```
 
 The `migrate` command, when run, will show the proposed changes to the config file in the terminal, prompting the user to
 accept the changes or not:
 
 ```bash
+$ webpack-cli migrate ./webpack.config.js
  ✔ Reading webpack config
  ✔ Migrating config from v1 to v2
 -     loaders: [
@@ -93,62 +94,62 @@ accept the changes or not:
 After it has run, we have our new webpack config file!
 
 ```javascript
-	const ExtractTextPlugin = require('extract-text-webpack-plugin');
-	const HtmlWebpackPlugin = require('html-webpack-plugin');
-	const path = require('path');
-	const UglifyJSPlugin = require('uglifyjs-webpack-plugin');
-	const webpack = require('webpack');
-	
-	module.exports = {
-	
-	  entry: {
-		index: './src/index.js',
-		vendor: './src/vendor.js'
+const ExtractTextPlugin = require('extract-text-webpack-plugin');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+const path = require('path');
+const UglifyJSPlugin = require('uglifyjs-webpack-plugin');
+const webpack = require('webpack');
+
+module.exports = {
+
+  entry: {
+	index: './src/index.js',
+	vendor: './src/vendor.js'
+  },
+
+  output: {
+	filename: '[name].[chunkhash].js',
+	chunkFilename: '[name].[chunkhash].js',
+	path: path.resolve(__dirname, 'dist')
+  },
+
+  module: {
+	rules: [
+	  {
+		test: /\.js$/,
+		exclude: /node_modules/,
+		use: [{
+		  loader: 'babel-loader'
+		}],
+		options: {
+		  presets: ['es2015']
+		}
 	  },
-	
-	  output: {
-		filename: '[name].[chunkhash].js',
-		chunkFilename: '[name].[chunkhash].js',
-		path: path.resolve(__dirname, 'dist')
-	  },
-	
-	  module: {
-		rules: [
-		  {
-			test: /\.js$/,
-			exclude: /node_modules/,
-			use: [{
-			  loader: 'babel-loader'
-			}],
-			options: {
-			  presets: ['es2015']
-			}
-		  },
-		  {
-			test: /\.(scss|css)$/,
-			use: ExtractTextPlugin.extract({
-			  fallback: 'style',
-			  use: 'css!sass'
-			})
-		  }
-		]
-	  },
-	
-	  plugins: [
-		new UglifyJSPlugin(),
-	
-		new ExtractTextPlugin('styles-[contentHash].css'),
-	
-		new webpack.optimize.CommonsChunkPlugin({
-		  name: 'common',
-		  filename: 'common-[hash].min.js'
-		}),
-	
-		new HtmlWebpackPlugin()
-	  ]
-	
-	};
+	  {
+		test: /\.(scss|css)$/,
+		use: ExtractTextPlugin.extract({
+		  fallback: 'style',
+		  use: 'css!sass'
+		})
+	  }
+	]
+  },
+
+  plugins: [
+	new UglifyJSPlugin(),
+
+	new ExtractTextPlugin('styles-[contentHash].css'),
+
+	new webpack.optimize.CommonsChunkPlugin({
+	  name: 'common',
+	  filename: 'common-[hash].min.js'
+	}),
+
+	new HtmlWebpackPlugin()
+  ]
+
+};
 ```
 
 **Note: This command does NOT handle updating dependencies in _package.json_, it is only a migration tool for the config
-file itself.  The user is expected to manage dependencies themself.**
+file itself.  The user is expected to manage dependencies themselves.**

--- a/MIGRATE.md
+++ b/MIGRATE.md
@@ -1,1 +1,154 @@
+## webpack-migrate
 
+The `migrate` feature eases the transition from [version 1](http://webpack.github.io/docs/) to [version 2](https://gist.github.com/sokra/27b24881210b56bbaff7). `migrate` 
+also allows users to switch to the new version of webpack without having to extensively [refactor](https://webpack.js.org/guides/migrating/).
+
+### Usage
+To use migrate, run the following command, with the path being an existing webpack configuration file
+
+```bash
+  webpack-cli migrate <config>
+```
+
+Given a basic configuration file like so:
+
+```javascript
+	const ExtractTextPlugin = require('extract-text-webpack-plugin');
+	const HtmlWebpackPlugin = require('html-webpack-plugin');
+	const path = require('path');
+	const UglifyJSPlugin = require('uglifyjs-webpack-plugin');
+	const webpack = require('webpack');
+	
+	module.exports = {
+	
+	  entry: {
+		index: './src/index.js',
+		vendor: './src/vendor.js'
+	  },
+	
+	  output: {
+		filename: '[name].[chunkhash].js',
+		chunkFilename: '[name].[chunkhash].js',
+		path: path.resolve(__dirname, 'dist')
+	  },
+	
+	  module: {
+		loaders: [
+		  {
+			test: /\.js$/,
+			exclude: /node_modules/,
+			loader: 'babel',
+			query: {
+			  presets: ['es2015']
+			}
+		  },
+		  {
+			test: /\.(scss|css)$/,
+			loader: ExtractTextPlugin.extract('style', 'css!sass')
+		  }
+		]
+	  },
+	
+	  plugins: [
+		new UglifyJSPlugin(),
+	
+		new ExtractTextPlugin('styles-[contentHash].css'),
+	
+		new webpack.optimize.CommonsChunkPlugin({
+		  name: 'common',
+		  filename: 'common-[hash].min.js'
+		}),
+	
+		new HtmlWebpackPlugin()
+	  ]
+	
+	};
+```
+
+The `migrate` command, when run, will show the proposed changes to the config file in the terminal, prompting the user to
+accept the changes or not:
+
+```bash
+ ✔ Reading webpack config
+ ✔ Migrating config from v1 to v2
+-     loaders: [
++     rules: [
+-         loader: 'babel',
+        query: {
++         use: [{
+          loader: 'babel-loader'
+        }],
+        options: {
+-         loader: ExtractTextPlugin.extract('style', 'css!sass')
++         use: ExtractTextPlugin.extract({
+          fallback: 'style',
+          use: 'css!sass'
+        })
+? Are you sure these changes are fine? Yes
+
+ ✔︎ New webpack v2 config file is at /Users/obuckley/Workspace/github/repos/webpack-migrate-sandbox/webpack.config.js
+```
+
+
+After it has run, we have our new webpack config file!
+
+```javascript
+	const ExtractTextPlugin = require('extract-text-webpack-plugin');
+	const HtmlWebpackPlugin = require('html-webpack-plugin');
+	const path = require('path');
+	const UglifyJSPlugin = require('uglifyjs-webpack-plugin');
+	const webpack = require('webpack');
+	
+	module.exports = {
+	
+	  entry: {
+		index: './src/index.js',
+		vendor: './src/vendor.js'
+	  },
+	
+	  output: {
+		filename: '[name].[chunkhash].js',
+		chunkFilename: '[name].[chunkhash].js',
+		path: path.resolve(__dirname, 'dist')
+	  },
+	
+	  module: {
+		rules: [
+		  {
+			test: /\.js$/,
+			exclude: /node_modules/,
+			use: [{
+			  loader: 'babel-loader'
+			}],
+			options: {
+			  presets: ['es2015']
+			}
+		  },
+		  {
+			test: /\.(scss|css)$/,
+			use: ExtractTextPlugin.extract({
+			  fallback: 'style',
+			  use: 'css!sass'
+			})
+		  }
+		]
+	  },
+	
+	  plugins: [
+		new UglifyJSPlugin(),
+	
+		new ExtractTextPlugin('styles-[contentHash].css'),
+	
+		new webpack.optimize.CommonsChunkPlugin({
+		  name: 'common',
+		  filename: 'common-[hash].min.js'
+		}),
+	
+		new HtmlWebpackPlugin()
+	  ]
+	
+	};
+```
+
+**Note: This command does NOT handle updating dependencies in _package.json_, it is only a migration tool for the config
+file itself.  The user is expected to manage dependencies themself.**

--- a/MIGRATE.md
+++ b/MIGRATE.md
@@ -151,5 +151,11 @@ module.exports = {
 };
 ```
 
+In summary, we can see the follow changes were made
+1.  The webpack schema for using loaders has changed
+    - `loaders` is now `module.rules` 
+    -  `query` is now `options`
+1.  All loaders now have to have the *loader* suffix, e.g. `babel` -> `babel-loader`
+
 **Note: This command does NOT handle updating dependencies in _package.json_, it is only a migration tool for the config
 file itself.  The user is expected to manage dependencies themselves.**

--- a/MIGRATE.md
+++ b/MIGRATE.md
@@ -158,4 +158,4 @@ In summary, we can see the follow changes were made
 1.  All loaders now have to have the *loader* suffix, e.g. `babel` -> `babel-loader`
 
 **Note: This command does NOT handle updating dependencies in _package.json_, it is only a migration tool for the config
-file itself.  The user is expected to manage dependencies themselves.**
+file itself.  Users are expected to manage dependencies themselves.**

--- a/MIGRATE.md
+++ b/MIGRATE.md
@@ -4,7 +4,7 @@ The `migrate` feature eases the transition from [version 1](http://webpack.githu
 also allows users to switch to the new version of webpack without having to extensively [refactor](https://webpack.js.org/guides/migrating/).
 
 ### Usage
-To use `migrate`, run the following command, with the value of `<config` being a path to an existing webpack configuration file
+To use `migrate`, run the following command, with the value of `<config>` being a path to an existing webpack configuration file
 
 ```bash
 webpack-cli migrate <config>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
Documentation

**Did you add tests for your changes?**
No tests needed

**If relevant, did you update the documentation?**
Yes

**Summary**
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
This resolves issue #166 by adding documentation for the `migrate` command

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No breaking changes

**Other information**
I have created a sandbox repo that documents the research / approach / testing done for this PR
https://github.com/thescientist13/webpack-migrate-sandbox

I created a PR that shows the "after" effect of running `webpack-cli migrate`
https://github.com/thescientist13/webpack-migrate-sandbox/pull/1

I also have a couple of questions / observations
1.  When running  `webpack-cli init`, the prompt for location could make it clearer that an extension isn't required, as it seemed ambiguous if it should be provided or not.  Is this something I could open an issue / PR for?
1.  Not sure if it's assumed or not from the community, but after I ran `migrate` I didn't think about dependencies.  So just confirming that `migrate` will **not** update _package.json_, right?  (see my **Note:** at the end of _MIGRATE.md_)  If so, maybe the documentation (in the README?) could be clearer about any assumptions in regards to the scope of this specific command / feature?  Maybe provide a checklist for users to make sure their entire project gets updated correctly?  For example, UglifyJS should be pulled from `webpack` itself not the standalone npm package, webpack versions in _package.json_ should be upgraded, e.g.  `npm install webpack@^2.0.0 webpack-dev-server@^2.0.0 etc`
1.  Is there a plan for managing migrations for newer versions of webpack?  As webpack is on v3 and will be releasing more often, would there need to be consideration for v1 -> v3 and / or v2 -> v3?

Thanks and let me know your thoughts on this PR and if you need anymore info from me:

cc: @okonet / @pksjce / @ev1stensberg 