### PR TITLE
Use path.join() when specifying output directory

### DIFF
--- a/lib/creator/yeoman/webpack-generator.js
+++ b/lib/creator/yeoman/webpack-generator.js
@@ -31,6 +31,7 @@ module.exports = class WebpackGenerator extends Generator {
 		let oneOrMoreEntries;
 		let regExpForStyles;
 		let ExtractUseProps;
+		let outputPath = 'dist';
 		process.stdout.write(
 			'\n' + chalk.bold('Insecure about some of the questions?') + '\n'
 		);
@@ -75,10 +76,9 @@ module.exports = class WebpackGenerator extends Generator {
 						};
 					}
 					if(outputTypeAnswer['outputType'].length) {
-						this.configuration.config.webpackOptions.output.path = `'${outputTypeAnswer['outputType']}'`;
-					} else {
-						this.configuration.config.webpackOptions.output.path = '\path.resolve(__dirname, \'dist\')';
+						outputPath = outputTypeAnswer['outputType'];
 					}
+					this.configuration.config.webpackOptions.output.path = `path.resolve(__dirname, '${outputPath}')`;
 				}).then( () => {
 					this.prompt([
 						Confirm('prodConfirm', 'Are you going to use this in production?')


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Always use `path.resolve()` when writing the `output.path`.

**Did you add tests for your changes?**
Nope.

**If relevant, did you update the documentation?**
Nope.

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
Previously, using the default value of "dist" would correctly use `path.resolve()` when specifying an output path, whereas specifying a custom path would use that path directly without `path.resolve()`. This PR should make it more consistent. 🤞 

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
Nope.

**Other information**

Fixes #177 