### PR TITLE
feat(0CJS): add remaining compat for new defaults to output path

### DIFF
--- a/bin/config-yargs.js
+++ b/bin/config-yargs.js
@@ -131,6 +131,7 @@ module.exports = function(yargs) {
 				requiresArg: true
 			},
 			"output-filename": {
+				alias: "o",
 				type: "string",
 				describe: "The output filename of the bundle",
 				group: OUTPUT_GROUP,

--- a/bin/convert-argv.js
+++ b/bin/convert-argv.js
@@ -7,11 +7,10 @@ module.exports = function(yargs, argv, convertOptions) {
 	var options = [];
 	// Shortcuts
 	if (argv.o) {
-		var pathMeta = argv.o.split(path.sep);
+		argv["output-filename"] = path.basename(argv.o);
 
-		argv["output-filename"] = pathMeta.pop();
-		if (pathMeta[0] === ".") {
-			argv["output-path"] = path.resolve(process.cwd(), pathMeta.join(path.sep));
+		if (!path.isAbsolute(argv.o)) {
+			argv["output-path"] = path.resolve(process.cwd(), path.dirname(argv.o));
 		}
 	}
 
@@ -357,8 +356,8 @@ module.exports = function(yargs, argv, convertOptions) {
 					var rule = {
 						test: new RegExp(
 							"\\." +
-								name.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&") +
-								"$"
+							name.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&") +
+							"$"
 						), // eslint-disable-line no-useless-escape
 						loader: binding
 					};

--- a/bin/convert-argv.js
+++ b/bin/convert-argv.js
@@ -6,6 +6,15 @@ var prepareOptions = require("./prepareOptions");
 module.exports = function(yargs, argv, convertOptions) {
 	var options = [];
 	// Shortcuts
+	if (argv.o) {
+		var pathMeta = argv.o.split(path.sep);
+
+		argv["output-filename"] = pathMeta.pop();
+		if (pathMeta[0] === ".") {
+			argv["output-path"] = path.resolve(process.cwd(), pathMeta.join(path.sep));
+		}
+	}
+
 	if (argv.d) {
 		argv.debug = true;
 		argv["output-pathinfo"] = true;
@@ -210,8 +219,6 @@ module.exports = function(yargs, argv, convertOptions) {
 	}
 
 	function processOptions(options) {
-		// eslint-disable-next-line no-unused-vars
-		var noOutputFilenameDefined = !options.output || !options.output.filename;
 
 		function ifArg(name, fn, init, finalize) {
 			if (Array.isArray(argv[name])) {
@@ -398,8 +405,8 @@ module.exports = function(yargs, argv, convertOptions) {
 
 		ifArg("output-filename", function(value) {
 			ensureObject(options, "output");
+
 			options.output.filename = value;
-			noOutputFilenameDefined = false;
 		});
 
 		ifArg("output-chunk-filename", function(value) {

--- a/bin/webpack.js
+++ b/bin/webpack.js
@@ -9,7 +9,6 @@ var resolveCwd = require("resolve-cwd");
 // Local version replace global one
 var localCLI = resolveCwd.silent("webpack-cli/bin/webpack");
 var ErrorHelpers = require("webpack/lib/ErrorHelpers");
-
 const NON_COMPILATION_ARGS = [
 	"init",
 	"migrate",
@@ -51,7 +50,7 @@ var yargs = require("yargs").usage(
 		require("../package.json").version +
 		"\n" +
 		"Usage: https://webpack.js.org/api/cli/\n" +
-		"Usage without config file: webpack <entry> [<entry>] <output>\n" +
+		"Usage without config file: webpack <entry> [<entry>] --output [-o] <output>\n" +
 		"Usage with config file: webpack"
 );
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
N/A (?)

**If relevant, did you update the documentation?**
Will create issue and add to backlog from webpack/webpack

**Summary**
This disables `webpack in out` for entry and output properties now that `webpack` alone will generate the defaults. 

* Instead if you would like to pass an array of entries, and output, you must specify `-o`: `webpack entry1.js entry2.js -o "[name].js"`

* If a relpath is specified, the defaulted output.path property will be overridden with the specified relpath, and filename will be name of the file from relpath. If no `./` infront of value, then output.path will yield to webpack's default to `path.join(process.cwd(), "dist")` .

* mode will also be defaulted so mode checks are not needed either. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
**Yes**, this change forces you to have to change cli procedure for users who use `webpack in out`, as this will now (with output defaulted), convert to `entry: [arg1, arg2, etc.]`.
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
