### PR TITLE
Show help on no command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # IDE folders
 .idea
+.vscode
 
 # Mac OS X Finder
 .DS_Store

--- a/bin/webpack.js
+++ b/bin/webpack.js
@@ -192,7 +192,8 @@
 			type: "string",
 			default: "info",
 			group: DISPLAY_GROUP,
-			describe: "Controls the output of lifecycle messaging e.g. Started watching files... (verbose, info, none)"
+			describe:
+				"Controls the output of lifecycle messaging e.g. Started watching files... (verbose, info, none)"
 		}
 	});
 
@@ -412,7 +413,9 @@
 
 			ifArg("info-verbosity", function(value) {
 				if (!["none", "info", "verbose"].includes(value))
-					throw new Error("Invalid configuration object. \n configuration['info-verbosity'] should be one of these:\n \"none\" | \"info\" | \"verbose\"");
+					throw new Error(
+						"Invalid configuration object. \n configuration['info-verbosity'] should be one of these:\n \"none\" | \"info\" | \"verbose\""
+					);
 				outputOptions.infoVerbosity = value;
 			});
 
@@ -446,10 +449,10 @@
 			}
 
 			if (outputOptions.infoVerbosity === "verbose") {
-				compiler.hooks.beforeCompile.tap("WebpackInfo", (compilation) => {
+				compiler.hooks.beforeCompile.tap("WebpackInfo", compilation => {
 					console.log("\nCompilation starting…\n");
 				});
-				compiler.hooks.afterCompile.tap("WebpackInfo", (compilation) => {
+				compiler.hooks.afterCompile.tap("WebpackInfo", compilation => {
 					console.log("\nCompilation finished\n");
 				});
 			}

--- a/bin/webpack.js
+++ b/bin/webpack.js
@@ -196,12 +196,6 @@
 				"Controls the output of lifecycle messaging e.g. Started watching files... (verbose, info, none)"
 		}
 	});
-
-	if (yargs.argv._.length === 0) {
-		yargs.showHelp();
-		return;
-	}
-
 	// yargs will terminate the process early when the user uses help or version.
 	// This causes large help outputs to be cut short (https://github.com/nodejs/node/wiki/API-changes-between-v0.10-and-v4#process).
 	// To prevent this we use the yargs.parse API and exit the process normally
@@ -465,9 +459,12 @@
 				if (err) {
 					lastHash = null;
 					console.error(err.stack || err);
-					if (err.details) console.error(err.details);
-					process.exit(1); // eslint-disable-line
+					if (err.details) {
+						console.error(err.details);
+					}
+					process.exit(1);
 				}
+
 				if (outputOptions.json) {
 					stdout.write(
 						JSON.stringify(stats.toJson(outputOptions), null, 2) + "\n"
@@ -477,10 +474,20 @@
 					var statsString = stats.toString(outputOptions);
 					if (statsString) stdout.write(statsString + "\n");
 				}
+
 				if (!options.watch && stats.hasErrors()) {
 					process.exitCode = 2;
+
+					const fs = require("fs");
+					const context = stats.compilation.compiler.context;
+					const configPath = context + "/webpack.config.js";
+					const configMissing = !fs.existsSync(configPath);
+					if (yargs.argv._.length === 0 && configMissing) {
+						yargs.showHelp("log");
+					}
 				}
 			}
+
 			if (firstOptions.watch || options.watch) {
 				var watchOptions =
 					firstOptions.watchOptions ||
@@ -496,7 +503,9 @@
 				compiler.watch(watchOptions, compilerCallback);
 				if (outputOptions.infoVerbosity !== "none")
 					console.log("\nWebpack is watching the files…\n");
-			} else compiler.run(compilerCallback);
+			} else {
+				compiler.run(compilerCallback);
+			}
 		}
 
 		processOptions(options);

--- a/bin/webpack.js
+++ b/bin/webpack.js
@@ -196,6 +196,11 @@
 		}
 	});
 
+	if (yargs.argv._.length === 0) {
+		yargs.showHelp();
+		return;
+	}
+
 	// yargs will terminate the process early when the user uses help or version.
 	// This causes large help outputs to be cut short (https://github.com/nodejs/node/wiki/API-changes-between-v0.10-and-v4#process).
 	// To prevent this we use the yargs.parse API and exit the process normally

--- a/test/binCases/help/help-output-no-command/stdin.js
+++ b/test/binCases/help/help-output-no-command/stdin.js
@@ -1,0 +1,16 @@
+"use strict";
+
+module.exports = function testAssertions(code, stdout, stderr) {
+	expect(code).toBe(2);
+	expect(stdout).toEqual(expect.anything());
+	expect(stdout).toContain("Config options:");
+	expect(stdout).toContain("Basic options:");
+	expect(stdout).toContain("Module options:");
+	expect(stdout).toContain("Output options:");
+	expect(stdout).toContain("Advanced options:");
+	expect(stdout).toContain("Resolving options:");
+	expect(stdout).toContain("Optimizing options:");
+	expect(stdout).toContain("Stats options:");
+	expect(stdout).toContain("Options:");
+	expect(stderr).toHaveLength(0);
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Shows the full help content when no arguments are given to the CLI, and when the webpack build fails. 

**Did you add tests for your changes?**
Yes.

**Summary**
See https://github.com/webpack/webpack-cli/issues/124

Before, when running the webpack build without a config, the CLI runs webpack with the default config, and fails with an unhelpful, possibly confusing error message. The original issue suggests to show help to solve this issue.

The reasons behind these specific conditions is to allow the default configuration to run as-is without arguments.

**Does this PR introduce a breaking change?**
No