### PR TITLE
Change from git:// to https://

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "webpack-addons": "^1.1.5",
     "yargs": "^9.0.1",
     "yeoman-environment": "^2.0.0",
-    "yeoman-generator": "git://github.com/ev1stensberg/generator.git#Feature-getArgument"
+    "yeoman-generator": "https://github.com/ev1stensberg/generator.git#Feature-getArgument"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Fixes #182

**Did you add tests for your changes?**
No

**If relevant, did you update the documentation?**
No

**Summary**
This is just a quick fix where we change the protocol `git://` to `https://` to allow most of the proxies to be able to download the cli. A further fix is to ask to release a new version with our patch.

**Does this PR introduce a breaking change?**
No
