### PR TITLE
bugfix - sets the default entry point if not provided

### DIFF
--- a/bin/convert-argv.js
+++ b/bin/convert-argv.js
@@ -207,6 +207,10 @@ module.exports = function(...args) {
 			options.context = process.cwd();
 		}
 
+		if (!options.entry) {
+			options.entry = ["./src"];
+		}
+
 		if (argv.watch) {
 			options.watch = true;
 		}

--- a/bin/convert-argv.js
+++ b/bin/convert-argv.js
@@ -208,7 +208,7 @@ module.exports = function(...args) {
 		}
 
 		if (!options.entry) {
-			options.entry = ["./src"];
+			options.entry = "./src";
 		}
 
 		if (argv.watch) {


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Sets the default entry point to `./src` if it isn't provided in the webpack config (or if no config is provided at all).

**Did you add tests for your changes?**
No, there's no test coverage of `convert-argv.js`

**If relevant, did you update the documentation?**
No, as this is covered by the normal webpack documentation.

**Summary**
When trying to run `webpack-dev-server` with no config file or no entry set, it did not default to `./src` like the webpack compiler does.

It solves this issue - https://github.com/webpack/webpack-dev-server/issues/1308

**Does this PR introduce a breaking change?**
No
