### PR TITLE
misc(refactor): reduce code duplication use process.exitCode instead of process.exit

### DIFF
--- a/bin/convert-argv.js
+++ b/bin/convert-argv.js
@@ -237,7 +237,7 @@ module.exports = function(...args) {
 		function ifArg(name, fn, init, finalize) {
 			const isArray = Array.isArray(argv[name]);
 			const isSet = typeof argv[name] !== "undefined" && argv[name] !== null;
-			if (!isArray || !isSet) return;
+			if (!isArray && !isSet) return;
 
 			init && init();
 			if (isArray) argv[name].forEach(fn);

--- a/bin/convert-argv.js
+++ b/bin/convert-argv.js
@@ -235,23 +235,14 @@ module.exports = function(...args) {
 
 	function processOptions(options) {
 		function ifArg(name, fn, init, finalize) {
-			if (Array.isArray(argv[name])) {
-				if (init) {
-					init();
-				}
-				argv[name].forEach(fn);
-				if (finalize) {
-					finalize();
-				}
-			} else if (typeof argv[name] !== "undefined" && argv[name] !== null) {
-				if (init) {
-					init();
-				}
-				fn(argv[name], -1);
-				if (finalize) {
-					finalize();
-				}
-			}
+			const isArray = Array.isArray(argv[name]);
+			const isSet = typeof argv[name] !== "undefined" && argv[name] !== null;
+			if (!isArray || !isSet) return;
+
+			init && init();
+			if (isArray) argv[name].forEach(fn);
+			else if (isSet) fn(argv[name], -1);
+			finalize && finalize();
 		}
 
 		function ifArgPair(name, fn, init, finalize) {

--- a/bin/prepareOptions.js
+++ b/bin/prepareOptions.js
@@ -2,15 +2,11 @@
 
 module.exports = function prepareOptions(options, argv) {
 	argv = argv || {};
-
 	options = handleExport(options);
 
-	if (Array.isArray(options)) {
-		options = options.map(_options => handleFunction(_options, argv));
-	} else {
-		options = handleFunction(options, argv);
-	}
-	return options;
+	return Array.isArray(options) ?
+		options.map(_options => handleFunction(_options, argv)) :
+		handleFunction(options, argv);
 };
 
 function handleExport(options) {
@@ -18,8 +14,8 @@ function handleExport(options) {
 		typeof options === "object" &&
 		options !== null &&
 		typeof options.default !== "undefined";
-	options = isES6DefaultExported ? options.default : options;
-	return options;
+
+	return isES6DefaultExported ? options.default : options;
 }
 
 function handleFunction(options, argv) {

--- a/bin/process-options.js
+++ b/bin/process-options.js
@@ -14,7 +14,7 @@ module.exports = function processOptions(yargs, argv) {
 	if (typeof options.then === "function") {
 		options.then(processOptions).catch(function(err) {
 			console.error(err.stack || err);
-			process.exit();
+			process.exitCode = 1;
 		});
 		return;
 	}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
* small code duplication reduce
* use `process.exitCode = 1` vs `process.exit(1)` 

https://nodejs.org/dist/latest-v9.x/docs/api/process.html#process_process_exit_code

>Rather than calling process.exit() directly, the code should set the process.exitCode and allow the process to exit naturally by avoiding scheduling any additional work for the event loop:

**Did you add tests for your changes?**
no

**If relevant, did you update the documentation?**
not relevant

**Summary**
Progressing in the `bin` directory
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
none