### PR TITLE
misc(yargs): add description for module-bind-* args

### DIFF
--- a/bin/config-yargs.js
+++ b/bin/config-yargs.js
@@ -114,13 +114,13 @@ module.exports = function(yargs) {
 			},
 			"module-bind-post": {
 				type: "string",
-				describe: "",
+				describe: "Bind an extension to a post loader",
 				group: MODULE_GROUP,
 				requiresArg: true
 			},
 			"module-bind-pre": {
 				type: "string",
-				describe: "",
+				describe: "Bind an extension to a pre loader",
 				group: MODULE_GROUP,
 				requiresArg: true
 			},


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Enhancement

**Summary**
Add missing description for `module-bind-post` and `module-bind-pre` arguments

Docs [link](https://webpack.js.org/api/cli/#module-options) for the same.

**Does this PR introduce a breaking change?**
No