### PR TITLE
misc(dep): add webpack 4 as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,6 +112,9 @@
     "yargs": "9.0.1",
     "yeoman-environment": "^2.0.0"
   },
+  "peerDependencies": {
+    "webpack": "^4.0.0-beta.1"
+  },
   "devDependencies": {
     "@commitlint/cli": "^6.1.0",
     "@commitlint/prompt-cli": "^6.1.0",


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Dependencies definition, Fixes #295 

**Summary**
Adds webpack 4 as a peer dependency

**Does this PR introduce a breaking change?**
No

**Other information**
Followed same versioning as [webpack-dev-server](https://github.com/webpack/webpack-dev-server/blob/master/package.json#L42)