### PR TITLE
[feature] strict Promise configuration validation

### DIFF
--- a/schemas/webpackConfigurationSchema.json
+++ b/schemas/webpackConfigurationSchema.json
@@ -1,5 +1,5 @@
 {
-  "oneOf": [
+  "anyOf": [
     {
       "type": "object",
       "description": "A webpack configuration object."
@@ -13,7 +13,7 @@
       }
     },
     {
-      "instanceof": "Function",
+      "instanceof": "Promise",
       "description": "A promise that resolves with a configuration object, or an array of configuration objects."
     }
   ]


### PR DESCRIPTION
- updates configuration schema to use `"instanceof": "Promise"` (webpack/webpack-cli#258)

**What kind of change does this PR introduce?**
feature/refactoring

**Did you add tests for your changes?**
Covered by existing tests.

**If relevant, did you update the documentation?**
n/a

**Summary**
Previously, validation for `Promise` configurations passed via `"instanceof": "Function"`, with `webpack@4+` (`ajv-keywords@3+`), we can do strict validation on `"instanceof": "Promise"`.

To accommodate this change we have to change the check to `anyOf` due to `Promise` passing `"type": "object"`.

```js
> const Ajv = require('ajv');
undefined
> const ajv = new Ajv;
undefined
> ajv.validate({type:'object'}, new Promise(res => res));
true
```
