### PR TITLE
fix(generators) Use webpack 4 version of extract-text-webpack-plugin

### DIFF
--- a/lib/generators/init-generator.js
+++ b/lib/generators/init-generator.js
@@ -340,7 +340,7 @@ module.exports = class InitGenerator extends Generator {
 				if (regExpForStyles) {
 					if (this.isProd) {
 						this.configuration.config.topScope.push(tooltip.cssPlugin());
-						this.dependencies.push("extract-text-webpack-plugin");
+						this.dependencies.push("extract-text-webpack-plugin@next");
 
 						if (cssBundleName.length !== 0) {
 							this.configuration.config.webpackOptions.plugins.push(


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bugfix, fixes #320 

**Did you add tests for your changes?**
No, but tests pass locally

**Summary**
Updated `extract-text-webpack-plugin` to use latest version under `next` dist-tag which is compatible with webpack 4, once it is stable we should remove this change and use `latest` dist-tag.
