### PR TITLE
Support --build-delimiter for opt-in output delimiter

### DIFF
--- a/bin/process-options.js
+++ b/bin/process-options.js
@@ -98,6 +98,10 @@ module.exports = function processOptions(yargs, argv) {
 			if (bool) outputOptions.cachedAssets = true;
 		});
 
+		ifArg("build-delimiter", function(value) {
+			outputOptions.buildDelimiter = value;
+		});
+
 		if (!outputOptions.exclude && !argv["display-modules"])
 			outputOptions.exclude = [
 				"node_modules",
@@ -175,8 +179,9 @@ module.exports = function processOptions(yargs, argv) {
 			);
 		} else if (stats.hash !== lastHash) {
 			lastHash = stats.hash;
+			const delimiter = outputOptions.buildDelimiter ? `${outputOptions.buildDelimiter}\n` : "";
 			process.stdout.write("\n" + new Date() + "\n" + "\n");
-			process.stdout.write(stats.toString(outputOptions) + "\n");
+			process.stdout.write(`${stats.toString(outputOptions)}\n${delimiter}`);
 			if (argv.s) lastHash = null;
 		}
 		if (!options.watch && stats.hasErrors()) {

--- a/bin/webpack.js
+++ b/bin/webpack.js
@@ -203,6 +203,11 @@
 			group: DISPLAY_GROUP,
 			describe:
 				"Controls the output of lifecycle messaging e.g. Started watching files..."
+		},
+		"build-delimiter": {
+			type: "string",
+			group: DISPLAY_GROUP,
+			describe: "Display custom text after build output"
 		}
 	});
 
@@ -419,6 +424,10 @@
 				outputOptions.infoVerbosity = value;
 			});
 
+			ifArg("build-delimiter", function(value) {
+				outputOptions.buildDelimiter = value;
+			});
+
 			const webpack = require("webpack");
 
 			let lastHash = null;
@@ -473,7 +482,8 @@
 				} else if (stats.hash !== lastHash) {
 					lastHash = stats.hash;
 					const statsString = stats.toString(outputOptions);
-					if (statsString) stdout.write(statsString + "\n");
+					const delimiter = outputOptions.buildDelimiter ? `${outputOptions.buildDelimiter}\n` : "";
+					if (statsString) stdout.write(`${statsString}\n${delimiter}`);
 				}
 				if (!options.watch && stats.hasErrors()) {
 					process.exitCode = 2;

--- a/test/binCases/stats/build-delimiter/index.js
+++ b/test/binCases/stats/build-delimiter/index.js
@@ -1,0 +1,1 @@
+module.exports = "foo";

--- a/test/binCases/stats/build-delimiter/stdin.js
+++ b/test/binCases/stats/build-delimiter/stdin.js
@@ -1,0 +1,9 @@
+"use strict";
+
+module.exports = function testAssertions(code, stdout, stderr) {
+	const lastLines = stdout.slice(-2);
+	expect(code).toBe(0);
+	expect(lastLines[0]).toBe("success");
+	expect(lastLines[1]).toBe("");
+	expect(stderr).toHaveLength(0);
+};

--- a/test/binCases/stats/build-delimiter/test.opts
+++ b/test/binCases/stats/build-delimiter/test.opts
@@ -1,0 +1,3 @@
+--entry ./index.js
+--display normal
+--build-delimiter success


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Feature

**Did you add tests for your changes?**
Yes

**If relevant, did you update the documentation?**
N/A

**Summary**
This PR introduces a new `--build-delimiter` CLI option to add opt-in support for custom text after  normal build output. This feature is useful for tooling that parses `stdout`, originally arose from webpack/webpack#6002, and resolves #192.

**Does this PR introduce a breaking change?**
No

**Other information**
I was unsure of the purpose of `bin/process-options.js` as it doesn't appear to be used anywhere. I noticed this file has been recently updated, so I added the CLI option to both `bin/process-options.js` and `bin/webpack.js`.