### PR TITLE
fix: removes debug in migrate

### DIFF
--- a/lib/migrate/__snapshots__/index.test.js.snap
+++ b/lib/migrate/__snapshots__/index.test.js.snap
@@ -61,27 +61,32 @@ module.exports = {
 exports[`transform should respect recast options 1`] = `
 "
 module.exports = {
-	devtool: 'eval',
-	entry: [
+    devtool: 'eval',
+
+    entry: [
 		'./src/index'
 	],
-	output: {
+
+    output: {
 		path: path.join(__dirname, 'dist'),
 		filename: 'index.js'
 	},
-	module: {
+
+    module: {
 		rules: [{
-			test: /.js$/,
+			test: /\.js$/,
 			use: [{
                 loader: \\"babel-loader\\",
             }],
 			include: path.join(__dirname, 'src')
 		}]
 	},
-	resolve: {
+
+    resolve: {
         modules: ['node_modules', path.resolve('/src')],
     },
-	plugins: [
+
+    plugins: [
 		new webpack.optimize.UglifyJsPlugin({
             sourceMap: true,
         }),
@@ -90,7 +95,6 @@ module.exports = {
             minimize: true,
         })
 	],
-	debug: true
 };
 "
 `;
@@ -131,27 +135,32 @@ module.exports = {
 exports[`transform should transform using all transformations 1`] = `
 "
 module.exports = {
-	devtool: 'eval',
-	entry: [
+    devtool: 'eval',
+
+    entry: [
 		'./src/index'
 	],
-	output: {
+
+    output: {
 		path: path.join(__dirname, 'dist'),
 		filename: 'index.js'
 	},
-	module: {
+
+    module: {
 		rules: [{
-			test: /.js$/,
+			test: /\.js$/,
 			use: [{
                 loader: 'babel-loader'
             }],
 			include: path.join(__dirname, 'src')
 		}]
 	},
-	resolve: {
+
+    resolve: {
         modules: ['node_modules', path.resolve('/src')]
     },
-	plugins: [
+
+    plugins: [
 		new webpack.optimize.UglifyJsPlugin({
             sourceMap: true
         }),
@@ -159,8 +168,7 @@ module.exports = {
             debug: true,
             minimize: true
         })
-	],
-	debug: true
+	]
 };
 "
 `;

--- a/lib/migrate/loaderOptionsPlugin/__snapshots__/loaderOptionsPlugin.test.js.snap
+++ b/lib/migrate/loaderOptionsPlugin/__snapshots__/loaderOptionsPlugin.test.js.snap
@@ -12,7 +12,6 @@ module.exports = {
 
 exports[`loaderOptionsPlugin transforms correctly using "loaderOptionsPlugin-1" data 1`] = `
 "module.exports = {
-    debug: true,
     plugins: [
         new webpack.optimize.UglifyJsPlugin(),
         new webpack.LoaderOptionsPlugin({

--- a/lib/migrate/loaderOptionsPlugin/loaderOptionsPlugin.js
+++ b/lib/migrate/loaderOptionsPlugin/loaderOptionsPlugin.js
@@ -18,10 +18,13 @@ module.exports = function(j, ast) {
 	const loaderOptions = {};
 
 	// If there is debug: true, set debug: true in the plugin
-	// TODO: remove global debug setting
-	// TODO: I can't figure out how to find the topmost `debug: true`. help!
 	if (ast.find(j.Identifier, { name: "debug" }).size()) {
 		loaderOptions.debug = true;
+		ast
+			.find(j.Identifier, { name: "debug" })
+			.forEach(p => {
+				p.parent.prune();
+			});
 	}
 
 	// If there is UglifyJsPlugin, set minimize: true


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
bugfix - removes `debug` in `migrate`.
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
**Did you add tests for your changes?**
No
**If relevant, did you update the documentation?**
n/a
**Summary**
Fixes [120](https://github.com/webpack/webpack-cli/issues/120) : removes `debug` after running `migrate` on a config that has debug
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No
**Other information**
n/a