### PR TITLE
cli(init): fix webpack-cli dep

### DIFF
--- a/lib/generators/init-generator.js
+++ b/lib/generators/init-generator.js
@@ -31,7 +31,11 @@ module.exports = class InitGenerator extends Generator {
 	constructor(args, opts) {
 		super(args, opts);
 		this.isProd = false;
-		this.dependencies = ["webpack", "uglifyjs-webpack-plugin"];
+		this.dependencies = [
+			"webpack",
+			"webpack-cli",
+			"uglifyjs-webpack-plugin"
+		];
 		this.configuration = {
 			config: {
 				webpackOptions: {},


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bugfix

**Summary**
Current behaviour is `init` doesn't add `webpack-cli` dependency to the generated package.json which needs to added manually later.

![image](https://user-images.githubusercontent.com/5961873/37405359-7bb7e750-27ba-11e8-8cf5-08418727c196.png)

This PR adds `webpack-cli` to the list of dependencies to be installed with `init` command.

![image](https://user-images.githubusercontent.com/5961873/37405536-ec2616b0-27ba-11e8-9c6d-67a3d2c81350.png)



**Does this PR introduce a breaking change?**
No