### PR TITLE
cli(init): mode support to config

### DIFF
--- a/lib/generators/init-generator.js
+++ b/lib/generators/init-generator.js
@@ -115,9 +115,11 @@ module.exports = class InitGenerator extends Generator {
 					Confirm("prodConfirm", "Are you going to use this in production?")
 				]);
 			})
-			.then(
-				prodConfirmAnswer => (this.isProd = prodConfirmAnswer["prodConfirm"])
-			)
+			.then(prodConfirmAnswer => {
+				this.isProd = prodConfirmAnswer["prodConfirm"];
+				this.configuration.config.webpackOptions.mode =
+					this.isProd ? `"${"production"}"` : `"${"development"}"`;
+			})
 			.then(() => {
 				return this.prompt([
 					Confirm("babelConfirm", "Will you be using ES2015?")

--- a/lib/init/transformations/mode/__snapshots__/mode.test.js.snap
+++ b/lib/init/transformations/mode/__snapshots__/mode.test.js.snap
@@ -9,6 +9,13 @@ exports[`mode transforms correctly using "mode-1" data 1`] = `
 
 exports[`mode transforms correctly using "mode-1" data 2`] = `
 "module.exports = {
+  mode: 'development'
+};
+"
+`;
+
+exports[`mode transforms correctly using "mode-1" data 3`] = `
+"module.exports = {
   mode: modeVariable
 };
 "
@@ -24,6 +31,13 @@ exports[`mode transforms correctly using "mode-2" data 1`] = `
 exports[`mode transforms correctly using "mode-2" data 2`] = `
 "module.exports = {
 	mode: 'production'
+}
+"
+`;
+
+exports[`mode transforms correctly using "mode-2" data 3`] = `
+"module.exports = {
+	mode: 'development'
 }
 "
 `;

--- a/lib/init/transformations/mode/mode.test.js
+++ b/lib/init/transformations/mode/mode.test.js
@@ -3,7 +3,9 @@
 const defineTest = require("../../../utils/defineTest");
 
 defineTest(__dirname, "mode", "mode-1", "'production'", "init");
+defineTest(__dirname, "mode", "mode-1", "'development'", "init");
 defineTest(__dirname, "mode", "mode-1", "modeVariable", "init");
 
 defineTest(__dirname, "mode", "mode-2", "none", "add");
 defineTest(__dirname, "mode", "mode-2", "'production'", "add");
+defineTest(__dirname, "mode", "mode-2", "'development'", "add");


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bugfix

**Did you add tests for your changes?**
No

**Summary**
Currently, when using `init` command, we were not adding `mode` property to the generated config file.
This PR adds a `mode` property based on the answer to "Are you going to use this in production?".
The transformations for `mode` are already implemented and working.

**Does this PR introduce a breaking change?**
No
