### PR TITLE
feat: add envinfo as `webpack-cli info` command

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -12,4 +12,4 @@
 
 **If this is a feature request, what is motivation or use case for changing the behavior?**
 
-**Please mention other relevant information such as the browser version, Node.js version, Operating System and programming language.**
+**Please paste the results of `webpack-cli info` here, and mention other relevant information such as programming language.**

--- a/bin/webpack.js
+++ b/bin/webpack.js
@@ -30,7 +30,8 @@
 		*/
 		"serve",
 		"generate-loader",
-		"generate-plugin"
+		"generate-plugin",
+		"info"
 	];
 
 	const NON_COMPILATION_CMD = process.argv.find(arg => {

--- a/lib/commands/info.js
+++ b/lib/commands/info.js
@@ -1,0 +1,19 @@
+"use strict";
+
+const envinfo = require("envinfo");
+
+/**
+ * Prints debugging information for webpack issue reporting
+ */
+
+module.exports = function info() {
+	console.log(
+		envinfo.run({
+			System: ["OS", "CPU"],
+			Binaries: ["Node", "Yarn", "npm"],
+			Browsers: ["Chrome", "Firefox", "Safari"],
+			npmPackages: "*webpack*",
+			npmGlobalPackages: ["webpack", "webpack-cli"],
+		})
+	);
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -53,6 +53,9 @@ module.exports = function initialize(command, args) {
 		case "generate-plugin": {
 			return require("./generate-plugin/index.js")();
 		}
+		case "info": {
+			return require("./commands/info.js")();
+		}
 		default: {
 			throw new Error(`Unknown command ${command} found`);
 		}

--- a/package-lock.json
+++ b/package-lock.json
@@ -4356,6 +4356,11 @@
         "tapable": "1.0.0"
       }
     },
+    "envinfo": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-4.4.2.tgz",
+      "integrity": "sha512-5rfRs+m+6pwoKRCFqpsA5+qsLngFms1aWPrxfKbrObCzQaPc3M3yPloZx+BL9UE3dK58cxw36XVQbFRSCCfGSQ=="
+    },
     "errno": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "cross-spawn": "^6.0.5",
     "diff": "^3.5.0",
     "enhanced-resolve": "^4.0.0",
+    "envinfo": "^4.4.2",
     "glob-all": "^3.1.0",
     "global-modules": "^1.0.0",
     "got": "^8.2.0",


### PR DESCRIPTION
**What kind of change does this PR introduce?**
This adds a new feature: a `webpack-cli info` command which outputs something like this:

```
  System:
    OS: macOS High Sierra 10.13
    CPU: x64 Intel(R) Core(TM) i7-4870HQ CPU @ 2.50GHz
  Binaries:
    Node: 8.10.0
    Yarn: 1.5.1
    npm: 5.6.0
  Browsers:
    Chrome: 65.0.3325.181
    Firefox: 58.0
    Safari: 11.0
  npmPackages:
    webpack:
      wanted: ^4.1.1
      installed: 4.1.1
    webpack-addons:
      wanted: ^1.1.5
      installed: 1.1.5
    webpack-dev-server:
      wanted: ^3.0.0
      installed: 3.1.1
  npmGlobalPackages:
    webpack: 4.2.0
    webpack-cli: 2.0.11
```

**Did you add tests for your changes?**
Not sure necessary - if any objections, I am open to looking into this. 

**If relevant, did you update the documentation?**
Updated ISSUE_TEMPLATE

**Summary**
Should help with issue reporting: see https://github.com/webpack/webpack-cli/issues/334

**Does this PR introduce a breaking change?**
Nope.

**Other information**
This same approach has been successful in Jest, styled-components, create-react-app and React Native so far, I'd like to bring it to webpack!