### PR TITLE
fix: plugin, loader generators path bug

### DIFF
--- a/lib/generators/loader-generator.js
+++ b/lib/generators/loader-generator.js
@@ -36,7 +36,7 @@ const LoaderGenerator = webpackGenerator(
 			validate: str => str.length > 0
 		}
 	],
-	path.join(__dirname, "templates"),
+	path.join(__dirname, "../generate-loader/templates"),
 	[
 		"src/cjs.js.tpl",
 		"test/test-utils.js.tpl",
@@ -48,7 +48,9 @@ const LoaderGenerator = webpackGenerator(
 		"examples/simple/src/lazy-module.js.tpl",
 		"examples/simple/src/static-esm-module.js.tpl"
 	],
-	["src/_index.js.tpl"],
+	[
+		"src/_index.js.tpl"
+	],
 	gen => ({ name: gen.props.name })
 );
 

--- a/lib/generators/plugin-generator.js
+++ b/lib/generators/plugin-generator.js
@@ -21,7 +21,7 @@ const PluginGenerator = webpackGenerator(
 			validate: str => str.length > 0
 		}
 	],
-	path.join(__dirname, "templates"),
+	path.join(__dirname, "../generate-plugin/templates"),
 	[
 		"src/cjs.js.tpl",
 		"test/test-utils.js.tpl",
@@ -30,7 +30,10 @@ const PluginGenerator = webpackGenerator(
 		"examples/simple/src/lazy-module.js.tpl",
 		"examples/simple/src/static-esm-module.js.tpl"
 	],
-	["src/_index.js.tpl", "examples/simple/_webpack.config.js.tpl"],
+	[
+		"src/_index.js.tpl",
+		"examples/simple/_webpack.config.js.tpl"
+	],
 	gen => ({ name: _.upperFirst(_.camelCase(gen.props.name)) })
 );
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bugfix

**Did you add tests for your changes?**
No

**Summary**
Currently, `webpack-cli generate-plugin` and `webpack-cli generate-loader` are broken because of wrong path passed to generators.

![image](https://user-images.githubusercontent.com/5961873/37875114-87f41718-3058-11e8-999f-87076bb76e96.png)

---

This PR fixes the path to generate the plugin/loader boilerplate as intended.

![image](https://user-images.githubusercontent.com/5961873/37875156-eba36b2e-3058-11e8-856a-fe4e69b8df51.png)

**Does this PR introduce a breaking change?**
No