### PR TITLE
Add NamedModulesPlugin transformation

### DIFF
--- a/lib/migrate/index.js
+++ b/lib/migrate/index.js
@@ -9,6 +9,7 @@ const uglifyJsPluginTransform = require("./uglifyJsPlugin/uglifyJsPlugin");
 const loaderOptionsPluginTransform = require("./loaderOptionsPlugin/loaderOptionsPlugin");
 const bannerPluginTransform = require("./bannerPlugin/bannerPlugin");
 const extractTextPluginTransform = require("./extractTextPlugin/extractTextPlugin");
+const namedModulesPluginTransform = require("./namedModulesPlugin/namedModulesPlugin");
 const removeDeprecatedPluginsTransform = require("./removeDeprecatedPlugins/removeDeprecatedPlugins");
 
 const transformsObject = {
@@ -19,6 +20,7 @@ const transformsObject = {
 	loaderOptionsPluginTransform,
 	bannerPluginTransform,
 	extractTextPluginTransform,
+	namedModulesPluginTransform,
 	removeDeprecatedPluginsTransform
 };
 

--- a/lib/migrate/namedModulesPlugin/__snapshots__/namedModulesPlugin.test.js.snap
+++ b/lib/migrate/namedModulesPlugin/__snapshots__/namedModulesPlugin.test.js.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`namedModulesPlugin transforms correctly using "namedModulesPlugin-0" data 1`] = `
+"module.export = {
+    optimizations: {
+        namedModules: true
+    }
+}
+"
+`;
+
+exports[`namedModulesPlugin transforms correctly using "namedModulesPlugin-1" data 1`] = `
+"module.export = {
+	optimizations: {
+        splitChunks: false,
+        namedModules: true
+    },
+    plugins: [new Foo()]
+}
+"
+`;
+
+exports[`namedModulesPlugin transforms correctly using "namedModulesPlugin-2" data 1`] = `
+"module.export = {
+	optimizations: {
+        namedModules: true
+    },
+    plugins: [new Foo()]
+}
+"
+`;

--- a/lib/migrate/namedModulesPlugin/__testfixtures__/.editorconfig
+++ b/lib/migrate/namedModulesPlugin/__testfixtures__/.editorconfig
@@ -1,0 +1,3 @@
+[*]
+indent_style = space
+indent_size = 4

--- a/lib/migrate/namedModulesPlugin/__testfixtures__/namedModulesPlugin-0.input.js
+++ b/lib/migrate/namedModulesPlugin/__testfixtures__/namedModulesPlugin-0.input.js
@@ -1,0 +1,5 @@
+module.export = {
+    plugins: [
+        new webpack.NamedModulesPlugin()
+    ]
+}

--- a/lib/migrate/namedModulesPlugin/__testfixtures__/namedModulesPlugin-1.input.js
+++ b/lib/migrate/namedModulesPlugin/__testfixtures__/namedModulesPlugin-1.input.js
@@ -1,0 +1,9 @@
+module.export = {
+	optimizations: {
+		splitChunks: false
+	},
+    plugins: [
+        new Foo(),
+        new webpack.NamedModulesPlugin()
+    ]
+}

--- a/lib/migrate/namedModulesPlugin/__testfixtures__/namedModulesPlugin-2.input.js
+++ b/lib/migrate/namedModulesPlugin/__testfixtures__/namedModulesPlugin-2.input.js
@@ -1,0 +1,9 @@
+module.export = {
+	optimizations: {
+		namedModules: false
+	},
+    plugins: [
+        new Foo(),
+        new webpack.NamedModulesPlugin()
+    ]
+}

--- a/lib/migrate/namedModulesPlugin/namedModulesPlugin.js
+++ b/lib/migrate/namedModulesPlugin/namedModulesPlugin.js
@@ -1,0 +1,55 @@
+const {
+	findPluginsByName,
+	safeTraverse
+} = require("../../utils/ast-utils");
+
+/**
+ *
+ * Transform for NamedModulesPlugin. If found, removes the
+ * plugin and sets optimizations.namedModules to true
+ *
+ * @param {Object} j - jscodeshift top-level import
+ * @param {Node} ast - jscodeshift ast to transform
+ * @returns {Node} ast - jscodeshift ast
+ */
+module.exports = function(j, ast) {
+	let rootPath;
+
+	// Remove old plugin
+	findPluginsByName(j, ast, ["webpack.NamedModulesPlugin"])
+		.filter(path => safeTraverse(path, ["parent", "value"]))
+		.forEach(path => {
+			rootPath = safeTraverse(path, ["parent", "parent", "parent", "value"]);
+			const arrayPath = path.parent.value;
+			if (arrayPath.elements && arrayPath.elements.length === 1) {
+				j(path.parent.parent).remove();
+			} else {
+				j(path).remove();
+			}
+		});
+
+	// Set new optimizations option
+	if (rootPath) {
+		const optimizationsExist = ast.find(j.Property).filter(path => path.node.key.name === "optimizations").size() > 0;
+
+		if (optimizationsExist) {
+			rootPath.properties.filter(path => path.key.name === "optimizations")
+				.forEach(path => {
+					const newProperties = path.value.properties.filter(path => path.key.name !== "namedModules");
+					newProperties.push(j.objectProperty(j.identifier("namedModules"), j.booleanLiteral(true)));
+					path.value.properties = newProperties;
+				});
+		} else {
+			rootPath.properties.push(
+				j.objectProperty(
+					j.identifier("optimizations"),
+					j.objectExpression([
+						j.objectProperty(j.identifier("namedModules"), j.booleanLiteral(true))
+					])
+				)
+			);
+		}
+	}
+
+	return ast;
+};

--- a/lib/migrate/namedModulesPlugin/namedModulesPlugin.test.js
+++ b/lib/migrate/namedModulesPlugin/namedModulesPlugin.test.js
@@ -1,0 +1,7 @@
+"use strict";
+
+const defineTest = require("../../utils/defineTest");
+
+defineTest(__dirname, "namedModulesPlugin", "namedModulesPlugin-0");
+defineTest(__dirname, "namedModulesPlugin", "namedModulesPlugin-1");
+defineTest(__dirname, "namedModulesPlugin", "namedModulesPlugin-2");


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Feature

**Did you add tests for your changes?**
Yes

**If relevant, did you update the documentation?**
N/A

**Summary**
The `migrate` task didn't do anything with `webpack.NamedModulesPlugin()`. This PR adds a transformation for this plugin that removes it and safely sets `optimizations: { namedPlugins: true }`. Resolves #394.

**Does this PR introduce a breaking change?**
No
