### PR TITLE
Update versions on message prompted to user during migration

### DIFF
--- a/lib/commands/migrate.js
+++ b/lib/commands/migrate.js
@@ -99,7 +99,7 @@ function runMigration(currentConfigPath, outputConfigPath) {
 				})
 		},
 		{
-			title: "Migrating config from v1 to v2",
+			title: "Migrating config to newest version",
 			task: ctx => {
 				const transformations = require("../migrate").transformations;
 				return new Listr(


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Feature/fix

**Did you add tests for your changes?**
Not needed.

**Summary**
As part of the update in the migrations that are happening, the message that is prompted to the user must reflect from which version to which one the migration works/happens.

**Does this PR introduce a breaking change?**
Yes.

This Pr must be merged in conjunction with the other ones, related to the update on migrations.

Related issues:
#393 #395 #396 #389 #373 
