### PR TITLE
fix: output bundle file name for single entry

### DIFF
--- a/lib/generators/init-generator.js
+++ b/lib/generators/init-generator.js
@@ -102,7 +102,7 @@ module.exports = class InitGenerator extends Generator {
 					};
 				} else {
 					this.configuration.config.webpackOptions.output = {
-						filename: "'[name].bundle.js'"
+						filename: "'[name].[chunkhash].js'"
 					};
 				}
 				if (outputTypeAnswer["outputType"].length) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
bugfix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
no
**If relevant, did you update the documentation?**
no
**Summary**
According to [docs](https://webpack.js.org/configuration/output/#output-filename) for a single entry point, output bundle file should use a static name but on generating `config` file using `init` it uses a file named `[name].bundle.js` it should simply be called `bundle.js`.generated `config` [link](https://gist.github.com/anu-007/8c0384ff66f1efc2e25a99d701420e22#file-webpack-config-js-L18)
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->