### PR TITLE
fix(init): support non-string options for single entry

### DIFF
--- a/lib/generators/utils/entry.js
+++ b/lib/generators/utils/entry.js
@@ -3,6 +3,20 @@
 const InputValidate = require("webpack-addons").InputValidate;
 const validate = require("./validate");
 
+function normalizeEntryPoint(entryPoint) {
+	if (
+		entryPoint.charAt(0) !== "(" &&
+		entryPoint.charAt(0) !== "[" &&
+		!entryPoint.includes("function") &&
+		!entryPoint.includes("path") &&
+		!entryPoint.includes("process")
+	) {
+		return `\'${entryPoint.replace(/"|'/g,"").concat(".js")}\'`;
+	}
+
+	return entryPoint;
+}
+
 /**
  *
  * Prompts for entry points, either if it has multiple or one entry
@@ -33,16 +47,7 @@ module.exports = (self, answer) => {
 						return promise.then(n => {
 							if (n) {
 								Object.keys(n).forEach(val => {
-									if (
-										n[val].charAt(0) !== "(" &&
-										n[val].charAt(0) !== "[" &&
-										!n[val].includes("function") &&
-										!n[val].includes("path") &&
-										!n[val].includes("process")
-									) {
-										n[val] = `\'${n[val].replace(/"|'/g,"").concat(".js")}\'`;
-									}
-									webpackEntryPoint[val] = n[val];
+									webpackEntryPoint[val] = normalizeEntryPoint(n[val]);
 								});
 							} else {
 								n = {};
@@ -61,16 +66,7 @@ module.exports = (self, answer) => {
 					])
 				).then(entryPropAnswer => {
 					Object.keys(entryPropAnswer).forEach(val => {
-						if (
-							entryPropAnswer[val].charAt(0) !== "(" &&
-							entryPropAnswer[val].charAt(0) !== "[" &&
-							!entryPropAnswer[val].includes("function") &&
-							!entryPropAnswer[val].includes("path") &&
-							!entryPropAnswer[val].includes("process")
-						) {
-							entryPropAnswer[val] = `\'${entryPropAnswer[val].replace(/"|'/g,"").concat(".js")}\'`;
-						}
-						webpackEntryPoint[val] = entryPropAnswer[val];
+						webpackEntryPoint[val] = normalizeEntryPoint(entryPropAnswer[val]);
 					});
 					return webpackEntryPoint;
 				});
@@ -84,9 +80,9 @@ module.exports = (self, answer) => {
 				)
 			])
 			.then(singularEntryAnswer => {
-				let { singularEntry } = singularEntryAnswer;
-				if (singularEntry.indexOf("\"") >= 0) singularEntry = singularEntry.replace(/"/g, "'");
-				return singularEntry;
+				const { singularEntry } = singularEntryAnswer;
+
+				return normalizeEntryPoint(singularEntry);
 			});
 	}
 	return result;


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix.

**Did you add tests for your changes?**

No, there wasn't an existing test suite for `lib/generators/utils/entry.js`.

**If relevant, did you update the documentation?**

No.

**Summary**

Fixes #397. Add same input processing code to single entry choice. There were three same code blocks, so I refactored it to a separate function. I'm not sure about adding a utility function to the top of `lib/genereators/utils/entry.js`. If it's better to move the function somewhere, please let me know!

**Does this PR introduce a breaking change?**
No.

**Other information**
