### PR TITLE
fix: remove reference to specific version during migration

### DIFF
--- a/lib/commands/migrate.js
+++ b/lib/commands/migrate.js
@@ -178,9 +178,15 @@ function runMigration(currentConfigPath, outputConfigPath) {
 							);
 						}
 					}
+					console.log(chalk.green(`\n✔︎ New webpack config file is at ${outputConfigPath}.`));
 					console.log(
 						chalk.green(
-							`\n ✔︎ New webpack config file is at ${outputConfigPath}`
+							"✔︎ Heads up! Updating to the latest version could contain breaking changes."
+						)
+					);
+					console.log(
+						chalk.green(
+							"✔︎ Plugin and loader dependencies may need to be updated."
 						)
 					);
 				});

--- a/lib/commands/migrate.js
+++ b/lib/commands/migrate.js
@@ -180,7 +180,7 @@ function runMigration(currentConfigPath, outputConfigPath) {
 					}
 					console.log(
 						chalk.green(
-							`\n ✔︎ New webpack v2 config file is at ${outputConfigPath}`
+							`\n ✔︎ New webpack config file is at ${outputConfigPath}`
 						)
 					);
 				});


### PR DESCRIPTION
**What kind of change does this PR introduce?**
bugfix

**Did you add tests for your changes?**
Not needed

**Summary**
Migration feedback was referencing a specific version of webpack. I kept that generic.

**Does this PR introduce a breaking change?**
No