### PR TITLE
fix: Remove workspaces key, as yarn workspaces is not in use

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,9 +21,6 @@
     "module",
     "bundler"
   ],
-  "workspaces": [
-    "packages/*"
-  ],
   "scripts": {
     "lint": "eslint \"./bin/*.js\" \"./test/**/*.js\" \"{packages}/**/!(node_modules)/*.js\" ",
     "format": "prettier-eslint ./bin/*.js ./test/**/*.js ./packages/**/*.js --write",


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Removes the `"workspaces"` key from the main package.json 

**Did you add tests for your changes?**
Nope, as no functionality has changed

**If relevant, did you update the documentation?**
Not relevant.

**Summary**
this monorepo uses `lerna bootstrap` with `npm` as a dependency manager, so the "workspaces" key is not used.

fixes https://github.com/webpack/webpack-cli/issues/479

**Does this PR introduce a breaking change?**
No.