### PR TITLE
fix: use async / await for info command

### DIFF
--- a/packages/info/index.js
+++ b/packages/info/index.js
@@ -6,9 +6,9 @@ const envinfo = require("envinfo");
  * Prints debugging information for webpack issue reporting
  */
 
-module.exports = function info() {
+module.exports = async function info() {
 	console.log(
-		envinfo.run({
+		await envinfo.run({
 			System: ["OS", "CPU"],
 			Binaries: ["Node", "Yarn", "npm"],
 			Browsers: ["Chrome", "Firefox", "Safari"],


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
This PR fixes https://github.com/webpack/webpack-cli/issues/493

**Did you add tests for your changes?**
No

**If relevant, did you update the documentation?**


**Summary**
Currently `webpack-cli info` fails as it returns a promise which is not directly resolved.

**Does this PR introduce a breaking change?**
Probably requires a Node.js version which supports async / await.

**Other information**
