### PR TITLE
ast(parser): fix bug with literals

### DIFF
--- a/packages/utils/__snapshots__/ast-utils.test.js.snap
+++ b/packages/utils/__snapshots__/ast-utils.test.js.snap
@@ -12,14 +12,14 @@ exports[`utils addProperty add entry property using add 1`] = `
                   }],
 
                   man: () => duper,
-                  objects: are,
+                  objects: 'are',
 
-                  super: [yeah, {
-                    loader: 'eslint-loader'
+                  super: ['yeah', {
+                    loader: ''eslint-loader''
                   }],
 
-                  nice: ':)',
-                  man: () => duper
+                  nice: '':)'',
+                  man: '() => duper'
                 }
 			}"
 `;
@@ -27,14 +27,14 @@ exports[`utils addProperty add entry property using add 1`] = `
 exports[`utils addProperty add entry property using init 1`] = `
 "module.exports = {
   entry: {
-    objects: are,
+    objects: 'are',
 
-    super: [yeah, {
-      loader: 'eslint-loader'
+    super: ['yeah', {
+      loader: ''eslint-loader''
     }],
 
-    nice: ':)',
-    man: () => duper
+    nice: '':)'',
+    man: '() => duper'
   }
 }"
 `;

--- a/packages/utils/__snapshots__/recursive-parser.test.js.snap
+++ b/packages/utils/__snapshots__/recursive-parser.test.js.snap
@@ -25,23 +25,23 @@ module.exports = {
         foo: \\"Promise.resolve()\\",
         man: \\"() => duper\\",
         mode: \\"yaaa\\",
-        objects: are not,
+        objects: 'are not',
 
-        super: [op, {
-            test: /\\\\.(wasm|c)$/,
-            loader: 'pia-loader',
-            enforce: 'pre',
-            include: [asd, 'Stringy'],
+        super: ['op', {
+            test: '/\\\\.(wasm|c)$/',
+            loader: ''pia-loader'',
+            enforce: ''pre'',
+            include: ['asd', ''Stringy''],
 
             options: {
-                formatter: 'nao'
+                formatter: ''nao''
             }
         }],
 
-        nice: '=)',
-        foo: Promise.resolve(),
-        man: () => nice!!,
-        mode: super-man
+        nice: ''=)'',
+        foo: 'Promise.resolve()',
+        man: '() => nice!!',
+        mode: 'super-man'
     }
 }
 "
@@ -50,22 +50,22 @@ module.exports = {
 exports[`init transforms correctly using "fixture-1" data 1`] = `
 "module.exports = {
   entry: {
-    objects: are,
+    objects: 'are',
 
-    super: [yeah, {
-      test: /\\\\.(js|vue)$/,
-      loader: 'eslint-loader',
-      enforce: 'pre',
-      include: [customObj, 'Stringy'],
+    super: ['yeah', {
+      test: '/\\\\.(js|vue)$/',
+      loader: ''eslint-loader'',
+      enforce: ''pre'',
+      include: ['customObj', ''Stringy''],
 
       options: {
-        formatter: 'someOption'
+        formatter: ''someOption''
       }
     }],
 
-    nice: ':)',
-    foo: Promise.resolve(),
-    man: () => duper
+    nice: '':)'',
+    foo: 'Promise.resolve()',
+    man: '() => duper'
   }
 };"
 `;

--- a/packages/utils/ast-utils.js
+++ b/packages/utils/ast-utils.js
@@ -432,6 +432,7 @@ function addProperty(j, p, key, value, action) {
 		});
 		valForNode = objectExp;
 	} else {
+		value = `'${value}'`;
 		valForNode = createIdentifierOrLiteral(j, value);
 	}
 	let pushVal;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Bugfix

**Did you add tests for your changes?**
Yes

**Summary**
In case of generation of literal nodes, the final string value inside webpack.config.js doesn't yield quotes. This fixes the bug.

Here's a small demo of adding `mode` before and after the fix:
![image](https://user-images.githubusercontent.com/5961873/41174922-0fe609b4-6b79-11e8-83a3-884e77803ddc.png)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No

**Other information**
