### PR TITLE
chore(badge): Add badge to display install size

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 [![Code Climate](https://codeclimate.com/github/webpack/webpack-cli/badges/gpa.svg)](https://codeclimate.com/github/webpack/webpack-cli)
 [![chat on gitter](https://badges.gitter.im/webpack/webpack.svg)](https://gitter.im/webpack/webpack)
 [![Greenkeeper badge](https://badges.greenkeeper.io/webpack/webpack-cli.svg)](https://greenkeeper.io/)
+[![Install Size](https://packagephobia.now.sh/badge?p=webpack-cli)](https://packagephobia.now.sh/result?p=webpack-cli)
 
 # Webpack CLI
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Add badge to `README.md` to display install size

**Did you add tests for your changes?**
No

**If relevant, did you update the documentation?**
No

**Summary**

See [this tweet](https://twitter.com/styfle/status/1006605750981021697)

**Does this PR introduce a breaking change?**
No

**Other information**
This badge is already available on [webpack-command](https://github.com/webpack-contrib/webpack-command/blob/master/README.md) and [webpack](https://github.com/webpack/webpack/blob/master/README.md) readmes