### PR TITLE
Swap chalk for turbocolor.

### DIFF
--- a/docs/generators_init-generator.js.html
+++ b/docs/generators_init-generator.js.html
@@ -1,35 +1,36 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="utf-8">
-    <title>JSDoc: Source: generators/init-generator.js</title>
 
-    <script src="scripts/prettify/prettify.js"> </script>
-    <script src="scripts/prettify/lang-css.js"> </script>
-    <!--[if lt IE 9]>
+<head>
+	<meta charset="utf-8">
+	<title>JSDoc: Source: generators/init-generator.js</title>
+
+	<script src="scripts/prettify/prettify.js"> </script>
+	<script src="scripts/prettify/lang-css.js"> </script>
+	<!--[if lt IE 9]>
       <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
-    <link type="text/css" rel="stylesheet" href="styles/prettify-tomorrow.css">
-    <link type="text/css" rel="stylesheet" href="styles/jsdoc-default.css">
+	<link type="text/css" rel="stylesheet" href="styles/prettify-tomorrow.css">
+	<link type="text/css" rel="stylesheet" href="styles/jsdoc-default.css">
 </head>
 
 <body>
 
-<div id="main">
+	<div id="main">
 
-    <h1 class="page-title">Source: generators/init-generator.js</h1>
-
-    
+		<h1 class="page-title">Source: generators/init-generator.js</h1>
 
 
 
-    
-    <section>
-        <article>
-            <pre class="prettyprint source linenums"><code>"use strict";
+
+
+
+		<section>
+			<article>
+				<pre class="prettyprint source linenums"><code>"use strict";
 
 const Generator = require("yeoman-generator");
-const chalk = require("chalk");
+const color = require("turbocolor");
 const logSymbols = require("log-symbols");
 
 const Input = require("@webpack-cli/webpack-scaffold").Input;
@@ -81,16 +82,16 @@ module.exports = class InitGenerator extends Generator {
 		process.stdout.write(
 			"\n" +
 				logSymbols.info +
-				chalk.blue(" INFO ") +
+				color.blue(" INFO ") +
 				"For more information and a detailed description of each question, have a look at " +
-				chalk.bold.green(
+				color.bold.green(
 					"https://github.com/webpack/webpack-cli/blob/master/INIT.md"
 				) +
 				"\n"
 		);
 		process.stdout.write(
 			logSymbols.info +
-				chalk.blue(" INFO ") +
+				color.blue(" INFO ") +
 				"Alternatively, run `webpack(-cli) --help` for usage info." +
 				"\n\n"
 		);
@@ -447,25 +448,173 @@ module.exports = class InitGenerator extends Generator {
 	}
 };
 </code></pre>
-        </article>
-    </section>
+			</article>
+		</section>
 
 
 
 
-</div>
+	</div>
 
-<nav>
-    <h2><a href="index.html">Home</a></h2><h3>Classes</h3><ul><li><a href="AddGenerator.html">AddGenerator</a></li><li><a href="InitGenerator.html">InitGenerator</a></li><li><a href="LoaderGenerator.html">LoaderGenerator</a></li><li><a href="PluginGenerator.html">PluginGenerator</a></li></ul><h3>Global</h3><ul><li><a href="global.html#addonGenerator">addonGenerator</a></li><li><a href="global.html#addOrUpdateConfigObject">addOrUpdateConfigObject</a></li><li><a href="global.html#addProperty">addProperty</a></li><li><a href="global.html#createIdentifierOrLiteral">createIdentifierOrLiteral</a></li><li><a href="global.html#createLiteral">createLiteral</a></li><li><a href="global.html#createOrUpdatePluginByName">createOrUpdatePluginByName</a></li><li><a href="global.html#createProperty">createProperty</a></li><li><a href="global.html#defineTest">defineTest</a></li><li><a href="global.html#findAndRemovePluginByName">findAndRemovePluginByName</a></li><li><a href="global.html#findInvocation">findInvocation</a></li><li><a href="global.html#findPluginsArrayAndRemoveIfEmpty">findPluginsArrayAndRemoveIfEmpty</a></li><li><a href="global.html#findPluginsByName">findPluginsByName</a></li><li><a href="global.html#findRootNodesByName">findRootNodesByName</a></li><li><a href="global.html#findVariableToPlugin">findVariableToPlugin</a></li><li><a href="global.html#generatorCopy">generatorCopy</a></li><li><a href="global.html#generatorCopyTpl">generatorCopyTpl</a></li><li><a href="global.html#getPackageManager">getPackageManager</a></li><li><a href="global.html#getPathToGlobalPackages">getPathToGlobalPackages</a></li><li><a href="global.html#getRequire">getRequire</a></li><li><a href="global.html#getRootPathModule">getRootPathModule</a></li><li><a href="global.html#isType">isType</a></li><li><a href="global.html#loaderCreator">loaderCreator</a></li><li><a href="global.html#makeLoaderName">makeLoaderName</a></li><li><a href="global.html#mapOptionsToTransform">mapOptionsToTransform</a></li><li><a href="global.html#parseMerge">parseMerge</a></li><li><a href="global.html#parseTopScope">parseTopScope</a></li><li><a href="global.html#pluginCreator">pluginCreator</a></li><li><a href="global.html#processPromise">processPromise</a></li><li><a href="global.html#replaceAt">replaceAt</a></li><li><a href="global.html#resolvePackages">resolvePackages</a></li><li><a href="global.html#runMigration">runMigration</a></li><li><a href="global.html#runSingleTransform">runSingleTransform</a></li><li><a href="global.html#safeTraverse">safeTraverse</a></li><li><a href="global.html#safeTraverseAndGetType">safeTraverseAndGetType</a></li><li><a href="global.html#serve">serve</a></li><li><a href="global.html#spawnChild">spawnChild</a></li><li><a href="global.html#spawnNPM">spawnNPM</a></li><li><a href="global.html#spawnNPMWithArg">spawnNPMWithArg</a></li><li><a href="global.html#spawnYarn">spawnYarn</a></li><li><a href="global.html#spawnYarnWithArg">spawnYarnWithArg</a></li><li><a href="global.html#transform">transform</a></li><li><a href="global.html#traverseAndGetProperties">traverseAndGetProperties</a></li></ul>
-</nav>
+	<nav>
+		<h2>
+			<a href="index.html">Home</a>
+		</h2>
+		<h3>Classes</h3>
+		<ul>
+			<li>
+				<a href="AddGenerator.html">AddGenerator</a>
+			</li>
+			<li>
+				<a href="InitGenerator.html">InitGenerator</a>
+			</li>
+			<li>
+				<a href="LoaderGenerator.html">LoaderGenerator</a>
+			</li>
+			<li>
+				<a href="PluginGenerator.html">PluginGenerator</a>
+			</li>
+		</ul>
+		<h3>Global</h3>
+		<ul>
+			<li>
+				<a href="global.html#addonGenerator">addonGenerator</a>
+			</li>
+			<li>
+				<a href="global.html#addOrUpdateConfigObject">addOrUpdateConfigObject</a>
+			</li>
+			<li>
+				<a href="global.html#addProperty">addProperty</a>
+			</li>
+			<li>
+				<a href="global.html#createIdentifierOrLiteral">createIdentifierOrLiteral</a>
+			</li>
+			<li>
+				<a href="global.html#createLiteral">createLiteral</a>
+			</li>
+			<li>
+				<a href="global.html#createOrUpdatePluginByName">createOrUpdatePluginByName</a>
+			</li>
+			<li>
+				<a href="global.html#createProperty">createProperty</a>
+			</li>
+			<li>
+				<a href="global.html#defineTest">defineTest</a>
+			</li>
+			<li>
+				<a href="global.html#findAndRemovePluginByName">findAndRemovePluginByName</a>
+			</li>
+			<li>
+				<a href="global.html#findInvocation">findInvocation</a>
+			</li>
+			<li>
+				<a href="global.html#findPluginsArrayAndRemoveIfEmpty">findPluginsArrayAndRemoveIfEmpty</a>
+			</li>
+			<li>
+				<a href="global.html#findPluginsByName">findPluginsByName</a>
+			</li>
+			<li>
+				<a href="global.html#findRootNodesByName">findRootNodesByName</a>
+			</li>
+			<li>
+				<a href="global.html#findVariableToPlugin">findVariableToPlugin</a>
+			</li>
+			<li>
+				<a href="global.html#generatorCopy">generatorCopy</a>
+			</li>
+			<li>
+				<a href="global.html#generatorCopyTpl">generatorCopyTpl</a>
+			</li>
+			<li>
+				<a href="global.html#getPackageManager">getPackageManager</a>
+			</li>
+			<li>
+				<a href="global.html#getPathToGlobalPackages">getPathToGlobalPackages</a>
+			</li>
+			<li>
+				<a href="global.html#getRequire">getRequire</a>
+			</li>
+			<li>
+				<a href="global.html#getRootPathModule">getRootPathModule</a>
+			</li>
+			<li>
+				<a href="global.html#isType">isType</a>
+			</li>
+			<li>
+				<a href="global.html#loaderCreator">loaderCreator</a>
+			</li>
+			<li>
+				<a href="global.html#makeLoaderName">makeLoaderName</a>
+			</li>
+			<li>
+				<a href="global.html#mapOptionsToTransform">mapOptionsToTransform</a>
+			</li>
+			<li>
+				<a href="global.html#parseMerge">parseMerge</a>
+			</li>
+			<li>
+				<a href="global.html#parseTopScope">parseTopScope</a>
+			</li>
+			<li>
+				<a href="global.html#pluginCreator">pluginCreator</a>
+			</li>
+			<li>
+				<a href="global.html#processPromise">processPromise</a>
+			</li>
+			<li>
+				<a href="global.html#replaceAt">replaceAt</a>
+			</li>
+			<li>
+				<a href="global.html#resolvePackages">resolvePackages</a>
+			</li>
+			<li>
+				<a href="global.html#runMigration">runMigration</a>
+			</li>
+			<li>
+				<a href="global.html#runSingleTransform">runSingleTransform</a>
+			</li>
+			<li>
+				<a href="global.html#safeTraverse">safeTraverse</a>
+			</li>
+			<li>
+				<a href="global.html#safeTraverseAndGetType">safeTraverseAndGetType</a>
+			</li>
+			<li>
+				<a href="global.html#serve">serve</a>
+			</li>
+			<li>
+				<a href="global.html#spawnChild">spawnChild</a>
+			</li>
+			<li>
+				<a href="global.html#spawnNPM">spawnNPM</a>
+			</li>
+			<li>
+				<a href="global.html#spawnNPMWithArg">spawnNPMWithArg</a>
+			</li>
+			<li>
+				<a href="global.html#spawnYarn">spawnYarn</a>
+			</li>
+			<li>
+				<a href="global.html#spawnYarnWithArg">spawnYarnWithArg</a>
+			</li>
+			<li>
+				<a href="global.html#transform">transform</a>
+			</li>
+			<li>
+				<a href="global.html#traverseAndGetProperties">traverseAndGetProperties</a>
+			</li>
+		</ul>
+	</nav>
 
-<br class="clear">
+	<br class="clear">
 
-<footer>
-    Documentation generated by <a href="https://github.com/jsdoc3/jsdoc">JSDoc 3.5.5</a> on Sat Jun 02 2018 17:44:07 GMT+0200 (CEST)
-</footer>
+	<footer>
+		Documentation generated by
+		<a href="https://github.com/jsdoc3/jsdoc">JSDoc 3.5.5</a> on Sat Jun 02 2018 17:44:07 GMT+0200 (CEST)
+	</footer>
 
-<script> prettyPrint(); </script>
-<script src="scripts/linenumber.js"> </script>
+	<script> prettyPrint(); </script>
+	<script src="scripts/linenumber.js"> </script>
 </body>
+
 </html>

--- a/docs/init_init.js.html
+++ b/docs/init_init.js.html
@@ -1,36 +1,37 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="utf-8">
-    <title>JSDoc: Source: init/init.js</title>
 
-    <script src="scripts/prettify/prettify.js"> </script>
-    <script src="scripts/prettify/lang-css.js"> </script>
-    <!--[if lt IE 9]>
+<head>
+	<meta charset="utf-8">
+	<title>JSDoc: Source: init/init.js</title>
+
+	<script src="scripts/prettify/prettify.js"> </script>
+	<script src="scripts/prettify/lang-css.js"> </script>
+	<!--[if lt IE 9]>
       <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
-    <link type="text/css" rel="stylesheet" href="styles/prettify-tomorrow.css">
-    <link type="text/css" rel="stylesheet" href="styles/jsdoc-default.css">
+	<link type="text/css" rel="stylesheet" href="styles/prettify-tomorrow.css">
+	<link type="text/css" rel="stylesheet" href="styles/jsdoc-default.css">
 </head>
 
 <body>
 
-<div id="main">
+	<div id="main">
 
-    <h1 class="page-title">Source: init/init.js</h1>
-
-    
+		<h1 class="page-title">Source: init/init.js</h1>
 
 
 
-    
-    <section>
-        <article>
-            <pre class="prettyprint source linenums"><code>"use strict";
+
+
+
+		<section>
+			<article>
+				<pre class="prettyprint source linenums"><code>"use strict";
 
 const path = require("path");
 const j = require("jscodeshift");
-const chalk = require("chalk");
+const color = require("turbocolor");
 const pEachSeries = require("p-each-series");
 
 const runPrettier = require("@webpack-cli/utils/run-prettier");
@@ -105,7 +106,7 @@ module.exports = function runTransform(webpackProperties, action) {
 	if (initActionNotDefined &amp;&amp; webpackProperties.config.item) {
 		process.stdout.write(
 			"\n" +
-				chalk.green(
+				color.green(
 					`Congratulations! ${
 						webpackProperties.config.item
 					} has been ${action}ed!\n`
@@ -114,32 +115,180 @@ module.exports = function runTransform(webpackProperties, action) {
 	} else {
 		process.stdout.write(
 			"\n" +
-				chalk.green(
+				color.green(
 					"Congratulations! Your new webpack configuration file has been created!\n"
 				)
 		);
 	}
 };
 </code></pre>
-        </article>
-    </section>
+			</article>
+		</section>
 
 
 
 
-</div>
+	</div>
 
-<nav>
-    <h2><a href="index.html">Home</a></h2><h3>Classes</h3><ul><li><a href="AddGenerator.html">AddGenerator</a></li><li><a href="InitGenerator.html">InitGenerator</a></li><li><a href="LoaderGenerator.html">LoaderGenerator</a></li><li><a href="PluginGenerator.html">PluginGenerator</a></li></ul><h3>Global</h3><ul><li><a href="global.html#addonGenerator">addonGenerator</a></li><li><a href="global.html#addOrUpdateConfigObject">addOrUpdateConfigObject</a></li><li><a href="global.html#addProperty">addProperty</a></li><li><a href="global.html#createIdentifierOrLiteral">createIdentifierOrLiteral</a></li><li><a href="global.html#createLiteral">createLiteral</a></li><li><a href="global.html#createOrUpdatePluginByName">createOrUpdatePluginByName</a></li><li><a href="global.html#createProperty">createProperty</a></li><li><a href="global.html#defineTest">defineTest</a></li><li><a href="global.html#findAndRemovePluginByName">findAndRemovePluginByName</a></li><li><a href="global.html#findInvocation">findInvocation</a></li><li><a href="global.html#findPluginsArrayAndRemoveIfEmpty">findPluginsArrayAndRemoveIfEmpty</a></li><li><a href="global.html#findPluginsByName">findPluginsByName</a></li><li><a href="global.html#findRootNodesByName">findRootNodesByName</a></li><li><a href="global.html#findVariableToPlugin">findVariableToPlugin</a></li><li><a href="global.html#generatorCopy">generatorCopy</a></li><li><a href="global.html#generatorCopyTpl">generatorCopyTpl</a></li><li><a href="global.html#getPackageManager">getPackageManager</a></li><li><a href="global.html#getPathToGlobalPackages">getPathToGlobalPackages</a></li><li><a href="global.html#getRequire">getRequire</a></li><li><a href="global.html#getRootPathModule">getRootPathModule</a></li><li><a href="global.html#isType">isType</a></li><li><a href="global.html#loaderCreator">loaderCreator</a></li><li><a href="global.html#makeLoaderName">makeLoaderName</a></li><li><a href="global.html#mapOptionsToTransform">mapOptionsToTransform</a></li><li><a href="global.html#parseMerge">parseMerge</a></li><li><a href="global.html#parseTopScope">parseTopScope</a></li><li><a href="global.html#pluginCreator">pluginCreator</a></li><li><a href="global.html#processPromise">processPromise</a></li><li><a href="global.html#replaceAt">replaceAt</a></li><li><a href="global.html#resolvePackages">resolvePackages</a></li><li><a href="global.html#runMigration">runMigration</a></li><li><a href="global.html#runSingleTransform">runSingleTransform</a></li><li><a href="global.html#safeTraverse">safeTraverse</a></li><li><a href="global.html#safeTraverseAndGetType">safeTraverseAndGetType</a></li><li><a href="global.html#serve">serve</a></li><li><a href="global.html#spawnChild">spawnChild</a></li><li><a href="global.html#spawnNPM">spawnNPM</a></li><li><a href="global.html#spawnNPMWithArg">spawnNPMWithArg</a></li><li><a href="global.html#spawnYarn">spawnYarn</a></li><li><a href="global.html#spawnYarnWithArg">spawnYarnWithArg</a></li><li><a href="global.html#transform">transform</a></li><li><a href="global.html#traverseAndGetProperties">traverseAndGetProperties</a></li></ul>
-</nav>
+	<nav>
+		<h2>
+			<a href="index.html">Home</a>
+		</h2>
+		<h3>Classes</h3>
+		<ul>
+			<li>
+				<a href="AddGenerator.html">AddGenerator</a>
+			</li>
+			<li>
+				<a href="InitGenerator.html">InitGenerator</a>
+			</li>
+			<li>
+				<a href="LoaderGenerator.html">LoaderGenerator</a>
+			</li>
+			<li>
+				<a href="PluginGenerator.html">PluginGenerator</a>
+			</li>
+		</ul>
+		<h3>Global</h3>
+		<ul>
+			<li>
+				<a href="global.html#addonGenerator">addonGenerator</a>
+			</li>
+			<li>
+				<a href="global.html#addOrUpdateConfigObject">addOrUpdateConfigObject</a>
+			</li>
+			<li>
+				<a href="global.html#addProperty">addProperty</a>
+			</li>
+			<li>
+				<a href="global.html#createIdentifierOrLiteral">createIdentifierOrLiteral</a>
+			</li>
+			<li>
+				<a href="global.html#createLiteral">createLiteral</a>
+			</li>
+			<li>
+				<a href="global.html#createOrUpdatePluginByName">createOrUpdatePluginByName</a>
+			</li>
+			<li>
+				<a href="global.html#createProperty">createProperty</a>
+			</li>
+			<li>
+				<a href="global.html#defineTest">defineTest</a>
+			</li>
+			<li>
+				<a href="global.html#findAndRemovePluginByName">findAndRemovePluginByName</a>
+			</li>
+			<li>
+				<a href="global.html#findInvocation">findInvocation</a>
+			</li>
+			<li>
+				<a href="global.html#findPluginsArrayAndRemoveIfEmpty">findPluginsArrayAndRemoveIfEmpty</a>
+			</li>
+			<li>
+				<a href="global.html#findPluginsByName">findPluginsByName</a>
+			</li>
+			<li>
+				<a href="global.html#findRootNodesByName">findRootNodesByName</a>
+			</li>
+			<li>
+				<a href="global.html#findVariableToPlugin">findVariableToPlugin</a>
+			</li>
+			<li>
+				<a href="global.html#generatorCopy">generatorCopy</a>
+			</li>
+			<li>
+				<a href="global.html#generatorCopyTpl">generatorCopyTpl</a>
+			</li>
+			<li>
+				<a href="global.html#getPackageManager">getPackageManager</a>
+			</li>
+			<li>
+				<a href="global.html#getPathToGlobalPackages">getPathToGlobalPackages</a>
+			</li>
+			<li>
+				<a href="global.html#getRequire">getRequire</a>
+			</li>
+			<li>
+				<a href="global.html#getRootPathModule">getRootPathModule</a>
+			</li>
+			<li>
+				<a href="global.html#isType">isType</a>
+			</li>
+			<li>
+				<a href="global.html#loaderCreator">loaderCreator</a>
+			</li>
+			<li>
+				<a href="global.html#makeLoaderName">makeLoaderName</a>
+			</li>
+			<li>
+				<a href="global.html#mapOptionsToTransform">mapOptionsToTransform</a>
+			</li>
+			<li>
+				<a href="global.html#parseMerge">parseMerge</a>
+			</li>
+			<li>
+				<a href="global.html#parseTopScope">parseTopScope</a>
+			</li>
+			<li>
+				<a href="global.html#pluginCreator">pluginCreator</a>
+			</li>
+			<li>
+				<a href="global.html#processPromise">processPromise</a>
+			</li>
+			<li>
+				<a href="global.html#replaceAt">replaceAt</a>
+			</li>
+			<li>
+				<a href="global.html#resolvePackages">resolvePackages</a>
+			</li>
+			<li>
+				<a href="global.html#runMigration">runMigration</a>
+			</li>
+			<li>
+				<a href="global.html#runSingleTransform">runSingleTransform</a>
+			</li>
+			<li>
+				<a href="global.html#safeTraverse">safeTraverse</a>
+			</li>
+			<li>
+				<a href="global.html#safeTraverseAndGetType">safeTraverseAndGetType</a>
+			</li>
+			<li>
+				<a href="global.html#serve">serve</a>
+			</li>
+			<li>
+				<a href="global.html#spawnChild">spawnChild</a>
+			</li>
+			<li>
+				<a href="global.html#spawnNPM">spawnNPM</a>
+			</li>
+			<li>
+				<a href="global.html#spawnNPMWithArg">spawnNPMWithArg</a>
+			</li>
+			<li>
+				<a href="global.html#spawnYarn">spawnYarn</a>
+			</li>
+			<li>
+				<a href="global.html#spawnYarnWithArg">spawnYarnWithArg</a>
+			</li>
+			<li>
+				<a href="global.html#transform">transform</a>
+			</li>
+			<li>
+				<a href="global.html#traverseAndGetProperties">traverseAndGetProperties</a>
+			</li>
+		</ul>
+	</nav>
 
-<br class="clear">
+	<br class="clear">
 
-<footer>
-    Documentation generated by <a href="https://github.com/jsdoc3/jsdoc">JSDoc 3.5.5</a> on Sat Jun 02 2018 17:44:07 GMT+0200 (CEST)
-</footer>
+	<footer>
+		Documentation generated by
+		<a href="https://github.com/jsdoc3/jsdoc">JSDoc 3.5.5</a> on Sat Jun 02 2018 17:44:07 GMT+0200 (CEST)
+	</footer>
 
-<script> prettyPrint(); </script>
-<script src="scripts/linenumber.js"> </script>
+	<script> prettyPrint(); </script>
+	<script src="scripts/linenumber.js"> </script>
 </body>
+
 </html>

--- a/docs/migrate_index.js.html
+++ b/docs/migrate_index.js.html
@@ -1,36 +1,37 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="utf-8">
-    <title>JSDoc: Source: migrate/index.js</title>
 
-    <script src="scripts/prettify/prettify.js"> </script>
-    <script src="scripts/prettify/lang-css.js"> </script>
-    <!--[if lt IE 9]>
+<head>
+	<meta charset="utf-8">
+	<title>JSDoc: Source: migrate/index.js</title>
+
+	<script src="scripts/prettify/prettify.js"> </script>
+	<script src="scripts/prettify/lang-css.js"> </script>
+	<!--[if lt IE 9]>
       <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
-    <link type="text/css" rel="stylesheet" href="styles/prettify-tomorrow.css">
-    <link type="text/css" rel="stylesheet" href="styles/jsdoc-default.css">
+	<link type="text/css" rel="stylesheet" href="styles/prettify-tomorrow.css">
+	<link type="text/css" rel="stylesheet" href="styles/jsdoc-default.css">
 </head>
 
 <body>
 
-<div id="main">
+	<div id="main">
 
-    <h1 class="page-title">Source: migrate/index.js</h1>
-
-    
+		<h1 class="page-title">Source: migrate/index.js</h1>
 
 
 
-    
-    <section>
-        <article>
-            <pre class="prettyprint source linenums"><code>"use strict";
+
+
+
+		<section>
+			<article>
+				<pre class="prettyprint source linenums"><code>"use strict";
 
 const fs = require("fs");
 const path = require("path");
-const chalk = require("chalk");
+const color = require("turbocolor");
 const diff = require("diff");
 const inquirer = require("inquirer");
 const PLazy = require("p-lazy");
@@ -56,7 +57,7 @@ module.exports = function migrate(...args) {
 	const filePaths = args.slice(3);
 	if (!filePaths.length) {
 		const errMsg = "\n ✖ Please specify a path to your webpack config \n ";
-		console.error(chalk.red(errMsg));
+		console.error(color.red(errMsg));
 		return;
 	}
 	const currentConfigPath = path.resolve(process.cwd(), filePaths[0]);
@@ -76,7 +77,7 @@ module.exports = function migrate(...args) {
 			])
 			.then(ans => {
 				if (!ans["confirmPath"]) {
-					console.error(chalk.red("✖ ︎Migration aborted due no output path"));
+					console.error(color.red("✖ ︎Migration aborted due no output path"));
 					return;
 				}
 				outputConfigPath = path.resolve(process.cwd(), filePaths[0]);
@@ -150,9 +151,9 @@ function runMigration(currentConfigPath, outputConfigPath) {
 			const diffOutput = diff.diffLines(ctx.source, result);
 			diffOutput.forEach(diffLine => {
 				if (diffLine.added) {
-					process.stdout.write(chalk.green(`+ ${diffLine.value}`));
+					process.stdout.write(color.green(`+ ${diffLine.value}`));
 				} else if (diffLine.removed) {
-					process.stdout.write(chalk.red(`- ${diffLine.value}`));
+					process.stdout.write(color.red(`- ${diffLine.value}`));
 				}
 			});
 			return inquirer
@@ -177,7 +178,7 @@ function runMigration(currentConfigPath, outputConfigPath) {
 							}
 						]);
 					} else {
-						console.log(chalk.red("✖ Migration aborted"));
+						console.log(color.red("✖ Migration aborted"));
 					}
 				})
 				.then(answer => {
@@ -195,7 +196,7 @@ function runMigration(currentConfigPath, outputConfigPath) {
 						);
 						if (webpackOptionsValidationErrors.length) {
 							console.log(
-								chalk.red(
+								color.red(
 									"\n✖ Your configuration validation wasn't successful \n"
 								)
 							);
@@ -207,17 +208,17 @@ function runMigration(currentConfigPath, outputConfigPath) {
 						}
 					}
 					console.log(
-						chalk.green(
+						color.green(
 							`\n✔︎ New webpack config file is at ${outputConfigPath}.`
 						)
 					);
 					console.log(
-						chalk.green(
+						color.green(
 							"✔︎ Heads up! Updating to the latest version could contain breaking changes."
 						)
 					);
 					console.log(
-						chalk.green(
+						color.green(
 							"✔︎ Plugin and loader dependencies may need to be updated."
 						)
 					);
@@ -225,31 +226,179 @@ function runMigration(currentConfigPath, outputConfigPath) {
 		})
 		.catch(err => {
 			const errMsg = "\n ✖ ︎Migration aborted due to some errors: \n";
-			console.error(chalk.red(errMsg));
+			console.error(color.red(errMsg));
 			console.error(err);
 			process.exitCode = 1;
 		});
 }
 </code></pre>
-        </article>
-    </section>
+			</article>
+		</section>
 
 
 
 
-</div>
+	</div>
 
-<nav>
-    <h2><a href="index.html">Home</a></h2><h3>Classes</h3><ul><li><a href="AddGenerator.html">AddGenerator</a></li><li><a href="InitGenerator.html">InitGenerator</a></li><li><a href="LoaderGenerator.html">LoaderGenerator</a></li><li><a href="PluginGenerator.html">PluginGenerator</a></li></ul><h3>Global</h3><ul><li><a href="global.html#addonGenerator">addonGenerator</a></li><li><a href="global.html#addOrUpdateConfigObject">addOrUpdateConfigObject</a></li><li><a href="global.html#addProperty">addProperty</a></li><li><a href="global.html#createIdentifierOrLiteral">createIdentifierOrLiteral</a></li><li><a href="global.html#createLiteral">createLiteral</a></li><li><a href="global.html#createOrUpdatePluginByName">createOrUpdatePluginByName</a></li><li><a href="global.html#createProperty">createProperty</a></li><li><a href="global.html#defineTest">defineTest</a></li><li><a href="global.html#findAndRemovePluginByName">findAndRemovePluginByName</a></li><li><a href="global.html#findInvocation">findInvocation</a></li><li><a href="global.html#findPluginsArrayAndRemoveIfEmpty">findPluginsArrayAndRemoveIfEmpty</a></li><li><a href="global.html#findPluginsByName">findPluginsByName</a></li><li><a href="global.html#findRootNodesByName">findRootNodesByName</a></li><li><a href="global.html#findVariableToPlugin">findVariableToPlugin</a></li><li><a href="global.html#generatorCopy">generatorCopy</a></li><li><a href="global.html#generatorCopyTpl">generatorCopyTpl</a></li><li><a href="global.html#getPackageManager">getPackageManager</a></li><li><a href="global.html#getPathToGlobalPackages">getPathToGlobalPackages</a></li><li><a href="global.html#getRequire">getRequire</a></li><li><a href="global.html#getRootPathModule">getRootPathModule</a></li><li><a href="global.html#isType">isType</a></li><li><a href="global.html#loaderCreator">loaderCreator</a></li><li><a href="global.html#makeLoaderName">makeLoaderName</a></li><li><a href="global.html#mapOptionsToTransform">mapOptionsToTransform</a></li><li><a href="global.html#parseMerge">parseMerge</a></li><li><a href="global.html#parseTopScope">parseTopScope</a></li><li><a href="global.html#pluginCreator">pluginCreator</a></li><li><a href="global.html#processPromise">processPromise</a></li><li><a href="global.html#replaceAt">replaceAt</a></li><li><a href="global.html#resolvePackages">resolvePackages</a></li><li><a href="global.html#runMigration">runMigration</a></li><li><a href="global.html#runSingleTransform">runSingleTransform</a></li><li><a href="global.html#safeTraverse">safeTraverse</a></li><li><a href="global.html#safeTraverseAndGetType">safeTraverseAndGetType</a></li><li><a href="global.html#serve">serve</a></li><li><a href="global.html#spawnChild">spawnChild</a></li><li><a href="global.html#spawnNPM">spawnNPM</a></li><li><a href="global.html#spawnNPMWithArg">spawnNPMWithArg</a></li><li><a href="global.html#spawnYarn">spawnYarn</a></li><li><a href="global.html#spawnYarnWithArg">spawnYarnWithArg</a></li><li><a href="global.html#transform">transform</a></li><li><a href="global.html#traverseAndGetProperties">traverseAndGetProperties</a></li></ul>
-</nav>
+	<nav>
+		<h2>
+			<a href="index.html">Home</a>
+		</h2>
+		<h3>Classes</h3>
+		<ul>
+			<li>
+				<a href="AddGenerator.html">AddGenerator</a>
+			</li>
+			<li>
+				<a href="InitGenerator.html">InitGenerator</a>
+			</li>
+			<li>
+				<a href="LoaderGenerator.html">LoaderGenerator</a>
+			</li>
+			<li>
+				<a href="PluginGenerator.html">PluginGenerator</a>
+			</li>
+		</ul>
+		<h3>Global</h3>
+		<ul>
+			<li>
+				<a href="global.html#addonGenerator">addonGenerator</a>
+			</li>
+			<li>
+				<a href="global.html#addOrUpdateConfigObject">addOrUpdateConfigObject</a>
+			</li>
+			<li>
+				<a href="global.html#addProperty">addProperty</a>
+			</li>
+			<li>
+				<a href="global.html#createIdentifierOrLiteral">createIdentifierOrLiteral</a>
+			</li>
+			<li>
+				<a href="global.html#createLiteral">createLiteral</a>
+			</li>
+			<li>
+				<a href="global.html#createOrUpdatePluginByName">createOrUpdatePluginByName</a>
+			</li>
+			<li>
+				<a href="global.html#createProperty">createProperty</a>
+			</li>
+			<li>
+				<a href="global.html#defineTest">defineTest</a>
+			</li>
+			<li>
+				<a href="global.html#findAndRemovePluginByName">findAndRemovePluginByName</a>
+			</li>
+			<li>
+				<a href="global.html#findInvocation">findInvocation</a>
+			</li>
+			<li>
+				<a href="global.html#findPluginsArrayAndRemoveIfEmpty">findPluginsArrayAndRemoveIfEmpty</a>
+			</li>
+			<li>
+				<a href="global.html#findPluginsByName">findPluginsByName</a>
+			</li>
+			<li>
+				<a href="global.html#findRootNodesByName">findRootNodesByName</a>
+			</li>
+			<li>
+				<a href="global.html#findVariableToPlugin">findVariableToPlugin</a>
+			</li>
+			<li>
+				<a href="global.html#generatorCopy">generatorCopy</a>
+			</li>
+			<li>
+				<a href="global.html#generatorCopyTpl">generatorCopyTpl</a>
+			</li>
+			<li>
+				<a href="global.html#getPackageManager">getPackageManager</a>
+			</li>
+			<li>
+				<a href="global.html#getPathToGlobalPackages">getPathToGlobalPackages</a>
+			</li>
+			<li>
+				<a href="global.html#getRequire">getRequire</a>
+			</li>
+			<li>
+				<a href="global.html#getRootPathModule">getRootPathModule</a>
+			</li>
+			<li>
+				<a href="global.html#isType">isType</a>
+			</li>
+			<li>
+				<a href="global.html#loaderCreator">loaderCreator</a>
+			</li>
+			<li>
+				<a href="global.html#makeLoaderName">makeLoaderName</a>
+			</li>
+			<li>
+				<a href="global.html#mapOptionsToTransform">mapOptionsToTransform</a>
+			</li>
+			<li>
+				<a href="global.html#parseMerge">parseMerge</a>
+			</li>
+			<li>
+				<a href="global.html#parseTopScope">parseTopScope</a>
+			</li>
+			<li>
+				<a href="global.html#pluginCreator">pluginCreator</a>
+			</li>
+			<li>
+				<a href="global.html#processPromise">processPromise</a>
+			</li>
+			<li>
+				<a href="global.html#replaceAt">replaceAt</a>
+			</li>
+			<li>
+				<a href="global.html#resolvePackages">resolvePackages</a>
+			</li>
+			<li>
+				<a href="global.html#runMigration">runMigration</a>
+			</li>
+			<li>
+				<a href="global.html#runSingleTransform">runSingleTransform</a>
+			</li>
+			<li>
+				<a href="global.html#safeTraverse">safeTraverse</a>
+			</li>
+			<li>
+				<a href="global.html#safeTraverseAndGetType">safeTraverseAndGetType</a>
+			</li>
+			<li>
+				<a href="global.html#serve">serve</a>
+			</li>
+			<li>
+				<a href="global.html#spawnChild">spawnChild</a>
+			</li>
+			<li>
+				<a href="global.html#spawnNPM">spawnNPM</a>
+			</li>
+			<li>
+				<a href="global.html#spawnNPMWithArg">spawnNPMWithArg</a>
+			</li>
+			<li>
+				<a href="global.html#spawnYarn">spawnYarn</a>
+			</li>
+			<li>
+				<a href="global.html#spawnYarnWithArg">spawnYarnWithArg</a>
+			</li>
+			<li>
+				<a href="global.html#transform">transform</a>
+			</li>
+			<li>
+				<a href="global.html#traverseAndGetProperties">traverseAndGetProperties</a>
+			</li>
+		</ul>
+	</nav>
 
-<br class="clear">
+	<br class="clear">
 
-<footer>
-    Documentation generated by <a href="https://github.com/jsdoc3/jsdoc">JSDoc 3.5.5</a> on Sat Jun 02 2018 17:44:07 GMT+0200 (CEST)
-</footer>
+	<footer>
+		Documentation generated by
+		<a href="https://github.com/jsdoc3/jsdoc">JSDoc 3.5.5</a> on Sat Jun 02 2018 17:44:07 GMT+0200 (CEST)
+	</footer>
 
-<script> prettyPrint(); </script>
-<script src="scripts/linenumber.js"> </script>
+	<script> prettyPrint(); </script>
+	<script src="scripts/linenumber.js"> </script>
 </body>
+
 </html>

--- a/docs/migrate_removeDeprecatedPlugins_removeDeprecatedPlugins.js.html
+++ b/docs/migrate_removeDeprecatedPlugins_removeDeprecatedPlugins.js.html
@@ -1,32 +1,33 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="utf-8">
-    <title>JSDoc: Source: migrate/removeDeprecatedPlugins/removeDeprecatedPlugins.js</title>
 
-    <script src="scripts/prettify/prettify.js"> </script>
-    <script src="scripts/prettify/lang-css.js"> </script>
-    <!--[if lt IE 9]>
+<head>
+	<meta charset="utf-8">
+	<title>JSDoc: Source: migrate/removeDeprecatedPlugins/removeDeprecatedPlugins.js</title>
+
+	<script src="scripts/prettify/prettify.js"> </script>
+	<script src="scripts/prettify/lang-css.js"> </script>
+	<!--[if lt IE 9]>
       <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
-    <link type="text/css" rel="stylesheet" href="styles/prettify-tomorrow.css">
-    <link type="text/css" rel="stylesheet" href="styles/jsdoc-default.css">
+	<link type="text/css" rel="stylesheet" href="styles/prettify-tomorrow.css">
+	<link type="text/css" rel="stylesheet" href="styles/jsdoc-default.css">
 </head>
 
 <body>
 
-<div id="main">
+	<div id="main">
 
-    <h1 class="page-title">Source: migrate/removeDeprecatedPlugins/removeDeprecatedPlugins.js</h1>
-
-    
+		<h1 class="page-title">Source: migrate/removeDeprecatedPlugins/removeDeprecatedPlugins.js</h1>
 
 
 
-    
-    <section>
-        <article>
-            <pre class="prettyprint source linenums"><code>const chalk = require("chalk");
+
+
+
+		<section>
+			<article>
+				<pre class="prettyprint source linenums"><code>const color = require("turbocolor");
 const utils = require("@webpack-cli/utils/ast-utils");
 
 /**
@@ -63,33 +64,181 @@ module.exports = function(j, ast, source) {
 				}
 			} else {
 				console.log(`
-${chalk.red("Please remove deprecated plugins manually. ")}
-See ${chalk.underline(
+${color.red("Please remove deprecated plugins manually. ")}
+See ${color.underline(
 		"https://webpack.js.org/guides/migrating/"
 	)} for more information.`);
 			}
 		});
 };
 </code></pre>
-        </article>
-    </section>
+			</article>
+		</section>
 
 
 
 
-</div>
+	</div>
 
-<nav>
-    <h2><a href="index.html">Home</a></h2><h3>Classes</h3><ul><li><a href="AddGenerator.html">AddGenerator</a></li><li><a href="InitGenerator.html">InitGenerator</a></li><li><a href="LoaderGenerator.html">LoaderGenerator</a></li><li><a href="PluginGenerator.html">PluginGenerator</a></li></ul><h3>Global</h3><ul><li><a href="global.html#addonGenerator">addonGenerator</a></li><li><a href="global.html#addOrUpdateConfigObject">addOrUpdateConfigObject</a></li><li><a href="global.html#addProperty">addProperty</a></li><li><a href="global.html#createIdentifierOrLiteral">createIdentifierOrLiteral</a></li><li><a href="global.html#createLiteral">createLiteral</a></li><li><a href="global.html#createOrUpdatePluginByName">createOrUpdatePluginByName</a></li><li><a href="global.html#createProperty">createProperty</a></li><li><a href="global.html#defineTest">defineTest</a></li><li><a href="global.html#findAndRemovePluginByName">findAndRemovePluginByName</a></li><li><a href="global.html#findInvocation">findInvocation</a></li><li><a href="global.html#findPluginsArrayAndRemoveIfEmpty">findPluginsArrayAndRemoveIfEmpty</a></li><li><a href="global.html#findPluginsByName">findPluginsByName</a></li><li><a href="global.html#findRootNodesByName">findRootNodesByName</a></li><li><a href="global.html#findVariableToPlugin">findVariableToPlugin</a></li><li><a href="global.html#generatorCopy">generatorCopy</a></li><li><a href="global.html#generatorCopyTpl">generatorCopyTpl</a></li><li><a href="global.html#getPackageManager">getPackageManager</a></li><li><a href="global.html#getPathToGlobalPackages">getPathToGlobalPackages</a></li><li><a href="global.html#getRequire">getRequire</a></li><li><a href="global.html#getRootPathModule">getRootPathModule</a></li><li><a href="global.html#isType">isType</a></li><li><a href="global.html#loaderCreator">loaderCreator</a></li><li><a href="global.html#makeLoaderName">makeLoaderName</a></li><li><a href="global.html#mapOptionsToTransform">mapOptionsToTransform</a></li><li><a href="global.html#parseMerge">parseMerge</a></li><li><a href="global.html#parseTopScope">parseTopScope</a></li><li><a href="global.html#pluginCreator">pluginCreator</a></li><li><a href="global.html#processPromise">processPromise</a></li><li><a href="global.html#replaceAt">replaceAt</a></li><li><a href="global.html#resolvePackages">resolvePackages</a></li><li><a href="global.html#runMigration">runMigration</a></li><li><a href="global.html#runSingleTransform">runSingleTransform</a></li><li><a href="global.html#safeTraverse">safeTraverse</a></li><li><a href="global.html#safeTraverseAndGetType">safeTraverseAndGetType</a></li><li><a href="global.html#serve">serve</a></li><li><a href="global.html#spawnChild">spawnChild</a></li><li><a href="global.html#spawnNPM">spawnNPM</a></li><li><a href="global.html#spawnNPMWithArg">spawnNPMWithArg</a></li><li><a href="global.html#spawnYarn">spawnYarn</a></li><li><a href="global.html#spawnYarnWithArg">spawnYarnWithArg</a></li><li><a href="global.html#transform">transform</a></li><li><a href="global.html#traverseAndGetProperties">traverseAndGetProperties</a></li></ul>
-</nav>
+	<nav>
+		<h2>
+			<a href="index.html">Home</a>
+		</h2>
+		<h3>Classes</h3>
+		<ul>
+			<li>
+				<a href="AddGenerator.html">AddGenerator</a>
+			</li>
+			<li>
+				<a href="InitGenerator.html">InitGenerator</a>
+			</li>
+			<li>
+				<a href="LoaderGenerator.html">LoaderGenerator</a>
+			</li>
+			<li>
+				<a href="PluginGenerator.html">PluginGenerator</a>
+			</li>
+		</ul>
+		<h3>Global</h3>
+		<ul>
+			<li>
+				<a href="global.html#addonGenerator">addonGenerator</a>
+			</li>
+			<li>
+				<a href="global.html#addOrUpdateConfigObject">addOrUpdateConfigObject</a>
+			</li>
+			<li>
+				<a href="global.html#addProperty">addProperty</a>
+			</li>
+			<li>
+				<a href="global.html#createIdentifierOrLiteral">createIdentifierOrLiteral</a>
+			</li>
+			<li>
+				<a href="global.html#createLiteral">createLiteral</a>
+			</li>
+			<li>
+				<a href="global.html#createOrUpdatePluginByName">createOrUpdatePluginByName</a>
+			</li>
+			<li>
+				<a href="global.html#createProperty">createProperty</a>
+			</li>
+			<li>
+				<a href="global.html#defineTest">defineTest</a>
+			</li>
+			<li>
+				<a href="global.html#findAndRemovePluginByName">findAndRemovePluginByName</a>
+			</li>
+			<li>
+				<a href="global.html#findInvocation">findInvocation</a>
+			</li>
+			<li>
+				<a href="global.html#findPluginsArrayAndRemoveIfEmpty">findPluginsArrayAndRemoveIfEmpty</a>
+			</li>
+			<li>
+				<a href="global.html#findPluginsByName">findPluginsByName</a>
+			</li>
+			<li>
+				<a href="global.html#findRootNodesByName">findRootNodesByName</a>
+			</li>
+			<li>
+				<a href="global.html#findVariableToPlugin">findVariableToPlugin</a>
+			</li>
+			<li>
+				<a href="global.html#generatorCopy">generatorCopy</a>
+			</li>
+			<li>
+				<a href="global.html#generatorCopyTpl">generatorCopyTpl</a>
+			</li>
+			<li>
+				<a href="global.html#getPackageManager">getPackageManager</a>
+			</li>
+			<li>
+				<a href="global.html#getPathToGlobalPackages">getPathToGlobalPackages</a>
+			</li>
+			<li>
+				<a href="global.html#getRequire">getRequire</a>
+			</li>
+			<li>
+				<a href="global.html#getRootPathModule">getRootPathModule</a>
+			</li>
+			<li>
+				<a href="global.html#isType">isType</a>
+			</li>
+			<li>
+				<a href="global.html#loaderCreator">loaderCreator</a>
+			</li>
+			<li>
+				<a href="global.html#makeLoaderName">makeLoaderName</a>
+			</li>
+			<li>
+				<a href="global.html#mapOptionsToTransform">mapOptionsToTransform</a>
+			</li>
+			<li>
+				<a href="global.html#parseMerge">parseMerge</a>
+			</li>
+			<li>
+				<a href="global.html#parseTopScope">parseTopScope</a>
+			</li>
+			<li>
+				<a href="global.html#pluginCreator">pluginCreator</a>
+			</li>
+			<li>
+				<a href="global.html#processPromise">processPromise</a>
+			</li>
+			<li>
+				<a href="global.html#replaceAt">replaceAt</a>
+			</li>
+			<li>
+				<a href="global.html#resolvePackages">resolvePackages</a>
+			</li>
+			<li>
+				<a href="global.html#runMigration">runMigration</a>
+			</li>
+			<li>
+				<a href="global.html#runSingleTransform">runSingleTransform</a>
+			</li>
+			<li>
+				<a href="global.html#safeTraverse">safeTraverse</a>
+			</li>
+			<li>
+				<a href="global.html#safeTraverseAndGetType">safeTraverseAndGetType</a>
+			</li>
+			<li>
+				<a href="global.html#serve">serve</a>
+			</li>
+			<li>
+				<a href="global.html#spawnChild">spawnChild</a>
+			</li>
+			<li>
+				<a href="global.html#spawnNPM">spawnNPM</a>
+			</li>
+			<li>
+				<a href="global.html#spawnNPMWithArg">spawnNPMWithArg</a>
+			</li>
+			<li>
+				<a href="global.html#spawnYarn">spawnYarn</a>
+			</li>
+			<li>
+				<a href="global.html#spawnYarnWithArg">spawnYarnWithArg</a>
+			</li>
+			<li>
+				<a href="global.html#transform">transform</a>
+			</li>
+			<li>
+				<a href="global.html#traverseAndGetProperties">traverseAndGetProperties</a>
+			</li>
+		</ul>
+	</nav>
 
-<br class="clear">
+	<br class="clear">
 
-<footer>
-    Documentation generated by <a href="https://github.com/jsdoc3/jsdoc">JSDoc 3.5.5</a> on Sat Jun 02 2018 17:44:07 GMT+0200 (CEST)
-</footer>
+	<footer>
+		Documentation generated by
+		<a href="https://github.com/jsdoc3/jsdoc">JSDoc 3.5.5</a> on Sat Jun 02 2018 17:44:07 GMT+0200 (CEST)
+	</footer>
 
-<script> prettyPrint(); </script>
-<script src="scripts/linenumber.js"> </script>
+	<script> prettyPrint(); </script>
+	<script src="scripts/linenumber.js"> </script>
 </body>
+
 </html>

--- a/docs/serve_index.js.html
+++ b/docs/serve_index.js.html
@@ -1,36 +1,37 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="utf-8">
-    <title>JSDoc: Source: serve/index.js</title>
 
-    <script src="scripts/prettify/prettify.js"> </script>
-    <script src="scripts/prettify/lang-css.js"> </script>
-    <!--[if lt IE 9]>
+<head>
+	<meta charset="utf-8">
+	<title>JSDoc: Source: serve/index.js</title>
+
+	<script src="scripts/prettify/prettify.js"> </script>
+	<script src="scripts/prettify/lang-css.js"> </script>
+	<!--[if lt IE 9]>
       <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
-    <link type="text/css" rel="stylesheet" href="styles/prettify-tomorrow.css">
-    <link type="text/css" rel="stylesheet" href="styles/jsdoc-default.css">
+	<link type="text/css" rel="stylesheet" href="styles/prettify-tomorrow.css">
+	<link type="text/css" rel="stylesheet" href="styles/jsdoc-default.css">
 </head>
 
 <body>
 
-<div id="main">
+	<div id="main">
 
-    <h1 class="page-title">Source: serve/index.js</h1>
-
-    
+		<h1 class="page-title">Source: serve/index.js</h1>
 
 
 
-    
-    <section>
-        <article>
-            <pre class="prettyprint source linenums"><code>"use strict";
+
+
+
+		<section>
+			<article>
+				<pre class="prettyprint source linenums"><code>"use strict";
 
 const inquirer = require("inquirer");
 const path = require("path");
-const chalk = require("chalk");
+const color = require("turbocolor");
 const spawn = require("cross-spawn");
 const List = require("@webpack-cli/webpack-scaffold").List;
 const processPromise = require("@webpack-cli/utils/resolve-packages")
@@ -85,7 +86,7 @@ function serve() {
 	if (!packageJSONPath) {
 		console.log(
 			"\n",
-			chalk.red("✖ Could not find your package.json file"),
+			color.red("✖ Could not find your package.json file"),
 			"\n"
 		);
 		process.exit(1);
@@ -106,14 +107,14 @@ function serve() {
 		if (!WDSPath) {
 			console.log(
 				"\n",
-				chalk.red(
+				color.red(
 					"✖ Could not find the webpack-dev-server dependency in node_modules root path"
 				)
 			);
 			console.log(
-				chalk.bold.green(" ✔︎"),
+				color.bold.green(" ✔︎"),
 				"Try this command:",
-				chalk.bold.green("rm -rf node_modules &amp;&amp; npm install")
+				color.bold.green("rm -rf node_modules &amp;&amp; npm install")
 			);
 			process.exit(1);
 		}
@@ -121,13 +122,13 @@ function serve() {
 	} else {
 		process.stdout.write(
 			"\n" +
-				chalk.bold(
+				color.bold(
 					"✖ We didn't find any webpack-dev-server dependency in your project,"
 				) +
 				"\n" +
-				chalk.bold.green("  'webpack serve'") +
+				color.bold.green("  'webpack serve'") +
 				" " +
-				chalk.bold("requires you to have it installed ") +
+				color.bold("requires you to have it installed ") +
 				"\n\n"
 		);
 		return inquirer
@@ -182,12 +183,12 @@ function serve() {
 							});
 						});
 				} else {
-					console.log(chalk.bold.red("✖ Serve aborted due cancelling"));
+					console.log(color.bold.red("✖ Serve aborted due cancelling"));
 					process.exitCode = 1;
 				}
 			})
 			.catch(err => {
-				console.log(chalk.red("✖ Serve aborted due to some errors"));
+				console.log(color.red("✖ Serve aborted due to some errors"));
 				console.error(err);
 				process.exitCode = 1;
 			});
@@ -201,25 +202,173 @@ module.exports = {
 	spawnYarnWithArg
 };
 </code></pre>
-        </article>
-    </section>
+			</article>
+		</section>
 
 
 
 
-</div>
+	</div>
 
-<nav>
-    <h2><a href="index.html">Home</a></h2><h3>Classes</h3><ul><li><a href="AddGenerator.html">AddGenerator</a></li><li><a href="InitGenerator.html">InitGenerator</a></li><li><a href="LoaderGenerator.html">LoaderGenerator</a></li><li><a href="PluginGenerator.html">PluginGenerator</a></li></ul><h3>Global</h3><ul><li><a href="global.html#addonGenerator">addonGenerator</a></li><li><a href="global.html#addOrUpdateConfigObject">addOrUpdateConfigObject</a></li><li><a href="global.html#addProperty">addProperty</a></li><li><a href="global.html#createIdentifierOrLiteral">createIdentifierOrLiteral</a></li><li><a href="global.html#createLiteral">createLiteral</a></li><li><a href="global.html#createOrUpdatePluginByName">createOrUpdatePluginByName</a></li><li><a href="global.html#createProperty">createProperty</a></li><li><a href="global.html#defineTest">defineTest</a></li><li><a href="global.html#findAndRemovePluginByName">findAndRemovePluginByName</a></li><li><a href="global.html#findInvocation">findInvocation</a></li><li><a href="global.html#findPluginsArrayAndRemoveIfEmpty">findPluginsArrayAndRemoveIfEmpty</a></li><li><a href="global.html#findPluginsByName">findPluginsByName</a></li><li><a href="global.html#findRootNodesByName">findRootNodesByName</a></li><li><a href="global.html#findVariableToPlugin">findVariableToPlugin</a></li><li><a href="global.html#generatorCopy">generatorCopy</a></li><li><a href="global.html#generatorCopyTpl">generatorCopyTpl</a></li><li><a href="global.html#getPackageManager">getPackageManager</a></li><li><a href="global.html#getPathToGlobalPackages">getPathToGlobalPackages</a></li><li><a href="global.html#getRequire">getRequire</a></li><li><a href="global.html#getRootPathModule">getRootPathModule</a></li><li><a href="global.html#isType">isType</a></li><li><a href="global.html#loaderCreator">loaderCreator</a></li><li><a href="global.html#makeLoaderName">makeLoaderName</a></li><li><a href="global.html#mapOptionsToTransform">mapOptionsToTransform</a></li><li><a href="global.html#parseMerge">parseMerge</a></li><li><a href="global.html#parseTopScope">parseTopScope</a></li><li><a href="global.html#pluginCreator">pluginCreator</a></li><li><a href="global.html#processPromise">processPromise</a></li><li><a href="global.html#replaceAt">replaceAt</a></li><li><a href="global.html#resolvePackages">resolvePackages</a></li><li><a href="global.html#runMigration">runMigration</a></li><li><a href="global.html#runSingleTransform">runSingleTransform</a></li><li><a href="global.html#safeTraverse">safeTraverse</a></li><li><a href="global.html#safeTraverseAndGetType">safeTraverseAndGetType</a></li><li><a href="global.html#serve">serve</a></li><li><a href="global.html#spawnChild">spawnChild</a></li><li><a href="global.html#spawnNPM">spawnNPM</a></li><li><a href="global.html#spawnNPMWithArg">spawnNPMWithArg</a></li><li><a href="global.html#spawnYarn">spawnYarn</a></li><li><a href="global.html#spawnYarnWithArg">spawnYarnWithArg</a></li><li><a href="global.html#transform">transform</a></li><li><a href="global.html#traverseAndGetProperties">traverseAndGetProperties</a></li></ul>
-</nav>
+	<nav>
+		<h2>
+			<a href="index.html">Home</a>
+		</h2>
+		<h3>Classes</h3>
+		<ul>
+			<li>
+				<a href="AddGenerator.html">AddGenerator</a>
+			</li>
+			<li>
+				<a href="InitGenerator.html">InitGenerator</a>
+			</li>
+			<li>
+				<a href="LoaderGenerator.html">LoaderGenerator</a>
+			</li>
+			<li>
+				<a href="PluginGenerator.html">PluginGenerator</a>
+			</li>
+		</ul>
+		<h3>Global</h3>
+		<ul>
+			<li>
+				<a href="global.html#addonGenerator">addonGenerator</a>
+			</li>
+			<li>
+				<a href="global.html#addOrUpdateConfigObject">addOrUpdateConfigObject</a>
+			</li>
+			<li>
+				<a href="global.html#addProperty">addProperty</a>
+			</li>
+			<li>
+				<a href="global.html#createIdentifierOrLiteral">createIdentifierOrLiteral</a>
+			</li>
+			<li>
+				<a href="global.html#createLiteral">createLiteral</a>
+			</li>
+			<li>
+				<a href="global.html#createOrUpdatePluginByName">createOrUpdatePluginByName</a>
+			</li>
+			<li>
+				<a href="global.html#createProperty">createProperty</a>
+			</li>
+			<li>
+				<a href="global.html#defineTest">defineTest</a>
+			</li>
+			<li>
+				<a href="global.html#findAndRemovePluginByName">findAndRemovePluginByName</a>
+			</li>
+			<li>
+				<a href="global.html#findInvocation">findInvocation</a>
+			</li>
+			<li>
+				<a href="global.html#findPluginsArrayAndRemoveIfEmpty">findPluginsArrayAndRemoveIfEmpty</a>
+			</li>
+			<li>
+				<a href="global.html#findPluginsByName">findPluginsByName</a>
+			</li>
+			<li>
+				<a href="global.html#findRootNodesByName">findRootNodesByName</a>
+			</li>
+			<li>
+				<a href="global.html#findVariableToPlugin">findVariableToPlugin</a>
+			</li>
+			<li>
+				<a href="global.html#generatorCopy">generatorCopy</a>
+			</li>
+			<li>
+				<a href="global.html#generatorCopyTpl">generatorCopyTpl</a>
+			</li>
+			<li>
+				<a href="global.html#getPackageManager">getPackageManager</a>
+			</li>
+			<li>
+				<a href="global.html#getPathToGlobalPackages">getPathToGlobalPackages</a>
+			</li>
+			<li>
+				<a href="global.html#getRequire">getRequire</a>
+			</li>
+			<li>
+				<a href="global.html#getRootPathModule">getRootPathModule</a>
+			</li>
+			<li>
+				<a href="global.html#isType">isType</a>
+			</li>
+			<li>
+				<a href="global.html#loaderCreator">loaderCreator</a>
+			</li>
+			<li>
+				<a href="global.html#makeLoaderName">makeLoaderName</a>
+			</li>
+			<li>
+				<a href="global.html#mapOptionsToTransform">mapOptionsToTransform</a>
+			</li>
+			<li>
+				<a href="global.html#parseMerge">parseMerge</a>
+			</li>
+			<li>
+				<a href="global.html#parseTopScope">parseTopScope</a>
+			</li>
+			<li>
+				<a href="global.html#pluginCreator">pluginCreator</a>
+			</li>
+			<li>
+				<a href="global.html#processPromise">processPromise</a>
+			</li>
+			<li>
+				<a href="global.html#replaceAt">replaceAt</a>
+			</li>
+			<li>
+				<a href="global.html#resolvePackages">resolvePackages</a>
+			</li>
+			<li>
+				<a href="global.html#runMigration">runMigration</a>
+			</li>
+			<li>
+				<a href="global.html#runSingleTransform">runSingleTransform</a>
+			</li>
+			<li>
+				<a href="global.html#safeTraverse">safeTraverse</a>
+			</li>
+			<li>
+				<a href="global.html#safeTraverseAndGetType">safeTraverseAndGetType</a>
+			</li>
+			<li>
+				<a href="global.html#serve">serve</a>
+			</li>
+			<li>
+				<a href="global.html#spawnChild">spawnChild</a>
+			</li>
+			<li>
+				<a href="global.html#spawnNPM">spawnNPM</a>
+			</li>
+			<li>
+				<a href="global.html#spawnNPMWithArg">spawnNPMWithArg</a>
+			</li>
+			<li>
+				<a href="global.html#spawnYarn">spawnYarn</a>
+			</li>
+			<li>
+				<a href="global.html#spawnYarnWithArg">spawnYarnWithArg</a>
+			</li>
+			<li>
+				<a href="global.html#transform">transform</a>
+			</li>
+			<li>
+				<a href="global.html#traverseAndGetProperties">traverseAndGetProperties</a>
+			</li>
+		</ul>
+	</nav>
 
-<br class="clear">
+	<br class="clear">
 
-<footer>
-    Documentation generated by <a href="https://github.com/jsdoc3/jsdoc">JSDoc 3.5.5</a> on Sat Jun 02 2018 17:44:07 GMT+0200 (CEST)
-</footer>
+	<footer>
+		Documentation generated by
+		<a href="https://github.com/jsdoc3/jsdoc">JSDoc 3.5.5</a> on Sat Jun 02 2018 17:44:07 GMT+0200 (CEST)
+	</footer>
 
-<script> prettyPrint(); </script>
-<script src="scripts/linenumber.js"> </script>
+	<script> prettyPrint(); </script>
+	<script src="scripts/linenumber.js"> </script>
 </body>
+
 </html>

--- a/docs/utils_modify-config-helper.js.html
+++ b/docs/utils_modify-config-helper.js.html
@@ -1,36 +1,37 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="utf-8">
-    <title>JSDoc: Source: utils/modify-config-helper.js</title>
 
-    <script src="scripts/prettify/prettify.js"> </script>
-    <script src="scripts/prettify/lang-css.js"> </script>
-    <!--[if lt IE 9]>
+<head>
+	<meta charset="utf-8">
+	<title>JSDoc: Source: utils/modify-config-helper.js</title>
+
+	<script src="scripts/prettify/prettify.js"> </script>
+	<script src="scripts/prettify/lang-css.js"> </script>
+	<!--[if lt IE 9]>
       <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
-    <link type="text/css" rel="stylesheet" href="styles/prettify-tomorrow.css">
-    <link type="text/css" rel="stylesheet" href="styles/jsdoc-default.css">
+	<link type="text/css" rel="stylesheet" href="styles/prettify-tomorrow.css">
+	<link type="text/css" rel="stylesheet" href="styles/jsdoc-default.css">
 </head>
 
 <body>
 
-<div id="main">
+	<div id="main">
 
-    <h1 class="page-title">Source: utils/modify-config-helper.js</h1>
-
-    
+		<h1 class="page-title">Source: utils/modify-config-helper.js</h1>
 
 
 
-    
-    <section>
-        <article>
-            <pre class="prettyprint source linenums"><code>"use strict";
+
+
+
+		<section>
+			<article>
+				<pre class="prettyprint source linenums"><code>"use strict";
 
 const fs = require("fs");
 const path = require("path");
-const chalk = require("chalk");
+const color = require("turbocolor");
 const yeoman = require("yeoman-environment");
 const runTransform = require("./scaffold");
 const Generator = require("yeoman-generator");
@@ -81,10 +82,10 @@ module.exports = function modifyHelperUtil(action, generator, packages) {
 			configModule = tmpConfig;
 		} catch (err) {
 			console.error(
-				chalk.red("\nCould not find a yeoman configuration file.\n")
+				color.red("\nCould not find a yeoman configuration file.\n")
 			);
 			console.error(
-				chalk.red(
+				color.red(
 					"\nPlease make sure to use 'this.config.set('configuration', this.configuration);' at the end of the generator.\n"
 				)
 			);
@@ -102,25 +103,173 @@ module.exports = function modifyHelperUtil(action, generator, packages) {
 	});
 };
 </code></pre>
-        </article>
-    </section>
+			</article>
+		</section>
 
 
 
 
-</div>
+	</div>
 
-<nav>
-    <h2><a href="index.html">Home</a></h2><h3>Classes</h3><ul><li><a href="AddGenerator.html">AddGenerator</a></li><li><a href="InitGenerator.html">InitGenerator</a></li><li><a href="LoaderGenerator.html">LoaderGenerator</a></li><li><a href="PluginGenerator.html">PluginGenerator</a></li></ul><h3>Global</h3><ul><li><a href="global.html#addonGenerator">addonGenerator</a></li><li><a href="global.html#addOrUpdateConfigObject">addOrUpdateConfigObject</a></li><li><a href="global.html#addProperty">addProperty</a></li><li><a href="global.html#createIdentifierOrLiteral">createIdentifierOrLiteral</a></li><li><a href="global.html#createLiteral">createLiteral</a></li><li><a href="global.html#createOrUpdatePluginByName">createOrUpdatePluginByName</a></li><li><a href="global.html#createProperty">createProperty</a></li><li><a href="global.html#defineTest">defineTest</a></li><li><a href="global.html#findAndRemovePluginByName">findAndRemovePluginByName</a></li><li><a href="global.html#findInvocation">findInvocation</a></li><li><a href="global.html#findPluginsArrayAndRemoveIfEmpty">findPluginsArrayAndRemoveIfEmpty</a></li><li><a href="global.html#findPluginsByName">findPluginsByName</a></li><li><a href="global.html#findRootNodesByName">findRootNodesByName</a></li><li><a href="global.html#findVariableToPlugin">findVariableToPlugin</a></li><li><a href="global.html#generatorCopy">generatorCopy</a></li><li><a href="global.html#generatorCopyTpl">generatorCopyTpl</a></li><li><a href="global.html#getPackageManager">getPackageManager</a></li><li><a href="global.html#getPathToGlobalPackages">getPathToGlobalPackages</a></li><li><a href="global.html#getRequire">getRequire</a></li><li><a href="global.html#getRootPathModule">getRootPathModule</a></li><li><a href="global.html#isType">isType</a></li><li><a href="global.html#loaderCreator">loaderCreator</a></li><li><a href="global.html#makeLoaderName">makeLoaderName</a></li><li><a href="global.html#mapOptionsToTransform">mapOptionsToTransform</a></li><li><a href="global.html#parseMerge">parseMerge</a></li><li><a href="global.html#parseTopScope">parseTopScope</a></li><li><a href="global.html#pluginCreator">pluginCreator</a></li><li><a href="global.html#processPromise">processPromise</a></li><li><a href="global.html#replaceAt">replaceAt</a></li><li><a href="global.html#resolvePackages">resolvePackages</a></li><li><a href="global.html#runMigration">runMigration</a></li><li><a href="global.html#runSingleTransform">runSingleTransform</a></li><li><a href="global.html#safeTraverse">safeTraverse</a></li><li><a href="global.html#safeTraverseAndGetType">safeTraverseAndGetType</a></li><li><a href="global.html#serve">serve</a></li><li><a href="global.html#spawnChild">spawnChild</a></li><li><a href="global.html#spawnNPM">spawnNPM</a></li><li><a href="global.html#spawnNPMWithArg">spawnNPMWithArg</a></li><li><a href="global.html#spawnYarn">spawnYarn</a></li><li><a href="global.html#spawnYarnWithArg">spawnYarnWithArg</a></li><li><a href="global.html#transform">transform</a></li><li><a href="global.html#traverseAndGetProperties">traverseAndGetProperties</a></li></ul>
-</nav>
+	<nav>
+		<h2>
+			<a href="index.html">Home</a>
+		</h2>
+		<h3>Classes</h3>
+		<ul>
+			<li>
+				<a href="AddGenerator.html">AddGenerator</a>
+			</li>
+			<li>
+				<a href="InitGenerator.html">InitGenerator</a>
+			</li>
+			<li>
+				<a href="LoaderGenerator.html">LoaderGenerator</a>
+			</li>
+			<li>
+				<a href="PluginGenerator.html">PluginGenerator</a>
+			</li>
+		</ul>
+		<h3>Global</h3>
+		<ul>
+			<li>
+				<a href="global.html#addonGenerator">addonGenerator</a>
+			</li>
+			<li>
+				<a href="global.html#addOrUpdateConfigObject">addOrUpdateConfigObject</a>
+			</li>
+			<li>
+				<a href="global.html#addProperty">addProperty</a>
+			</li>
+			<li>
+				<a href="global.html#createIdentifierOrLiteral">createIdentifierOrLiteral</a>
+			</li>
+			<li>
+				<a href="global.html#createLiteral">createLiteral</a>
+			</li>
+			<li>
+				<a href="global.html#createOrUpdatePluginByName">createOrUpdatePluginByName</a>
+			</li>
+			<li>
+				<a href="global.html#createProperty">createProperty</a>
+			</li>
+			<li>
+				<a href="global.html#defineTest">defineTest</a>
+			</li>
+			<li>
+				<a href="global.html#findAndRemovePluginByName">findAndRemovePluginByName</a>
+			</li>
+			<li>
+				<a href="global.html#findInvocation">findInvocation</a>
+			</li>
+			<li>
+				<a href="global.html#findPluginsArrayAndRemoveIfEmpty">findPluginsArrayAndRemoveIfEmpty</a>
+			</li>
+			<li>
+				<a href="global.html#findPluginsByName">findPluginsByName</a>
+			</li>
+			<li>
+				<a href="global.html#findRootNodesByName">findRootNodesByName</a>
+			</li>
+			<li>
+				<a href="global.html#findVariableToPlugin">findVariableToPlugin</a>
+			</li>
+			<li>
+				<a href="global.html#generatorCopy">generatorCopy</a>
+			</li>
+			<li>
+				<a href="global.html#generatorCopyTpl">generatorCopyTpl</a>
+			</li>
+			<li>
+				<a href="global.html#getPackageManager">getPackageManager</a>
+			</li>
+			<li>
+				<a href="global.html#getPathToGlobalPackages">getPathToGlobalPackages</a>
+			</li>
+			<li>
+				<a href="global.html#getRequire">getRequire</a>
+			</li>
+			<li>
+				<a href="global.html#getRootPathModule">getRootPathModule</a>
+			</li>
+			<li>
+				<a href="global.html#isType">isType</a>
+			</li>
+			<li>
+				<a href="global.html#loaderCreator">loaderCreator</a>
+			</li>
+			<li>
+				<a href="global.html#makeLoaderName">makeLoaderName</a>
+			</li>
+			<li>
+				<a href="global.html#mapOptionsToTransform">mapOptionsToTransform</a>
+			</li>
+			<li>
+				<a href="global.html#parseMerge">parseMerge</a>
+			</li>
+			<li>
+				<a href="global.html#parseTopScope">parseTopScope</a>
+			</li>
+			<li>
+				<a href="global.html#pluginCreator">pluginCreator</a>
+			</li>
+			<li>
+				<a href="global.html#processPromise">processPromise</a>
+			</li>
+			<li>
+				<a href="global.html#replaceAt">replaceAt</a>
+			</li>
+			<li>
+				<a href="global.html#resolvePackages">resolvePackages</a>
+			</li>
+			<li>
+				<a href="global.html#runMigration">runMigration</a>
+			</li>
+			<li>
+				<a href="global.html#runSingleTransform">runSingleTransform</a>
+			</li>
+			<li>
+				<a href="global.html#safeTraverse">safeTraverse</a>
+			</li>
+			<li>
+				<a href="global.html#safeTraverseAndGetType">safeTraverseAndGetType</a>
+			</li>
+			<li>
+				<a href="global.html#serve">serve</a>
+			</li>
+			<li>
+				<a href="global.html#spawnChild">spawnChild</a>
+			</li>
+			<li>
+				<a href="global.html#spawnNPM">spawnNPM</a>
+			</li>
+			<li>
+				<a href="global.html#spawnNPMWithArg">spawnNPMWithArg</a>
+			</li>
+			<li>
+				<a href="global.html#spawnYarn">spawnYarn</a>
+			</li>
+			<li>
+				<a href="global.html#spawnYarnWithArg">spawnYarnWithArg</a>
+			</li>
+			<li>
+				<a href="global.html#transform">transform</a>
+			</li>
+			<li>
+				<a href="global.html#traverseAndGetProperties">traverseAndGetProperties</a>
+			</li>
+		</ul>
+	</nav>
 
-<br class="clear">
+	<br class="clear">
 
-<footer>
-    Documentation generated by <a href="https://github.com/jsdoc3/jsdoc">JSDoc 3.5.5</a> on Sat Jun 02 2018 17:44:07 GMT+0200 (CEST)
-</footer>
+	<footer>
+		Documentation generated by
+		<a href="https://github.com/jsdoc3/jsdoc">JSDoc 3.5.5</a> on Sat Jun 02 2018 17:44:07 GMT+0200 (CEST)
+	</footer>
 
-<script> prettyPrint(); </script>
-<script src="scripts/linenumber.js"> </script>
+	<script> prettyPrint(); </script>
+	<script src="scripts/linenumber.js"> </script>
 </body>
+
 </html>

--- a/docs/utils_npm-packages-exists.js.html
+++ b/docs/utils_npm-packages-exists.js.html
@@ -1,33 +1,34 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="utf-8">
-    <title>JSDoc: Source: utils/npm-packages-exists.js</title>
 
-    <script src="scripts/prettify/prettify.js"> </script>
-    <script src="scripts/prettify/lang-css.js"> </script>
-    <!--[if lt IE 9]>
+<head>
+	<meta charset="utf-8">
+	<title>JSDoc: Source: utils/npm-packages-exists.js</title>
+
+	<script src="scripts/prettify/prettify.js"> </script>
+	<script src="scripts/prettify/lang-css.js"> </script>
+	<!--[if lt IE 9]>
       <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
-    <link type="text/css" rel="stylesheet" href="styles/prettify-tomorrow.css">
-    <link type="text/css" rel="stylesheet" href="styles/jsdoc-default.css">
+	<link type="text/css" rel="stylesheet" href="styles/prettify-tomorrow.css">
+	<link type="text/css" rel="stylesheet" href="styles/jsdoc-default.css">
 </head>
 
 <body>
 
-<div id="main">
+	<div id="main">
 
-    <h1 class="page-title">Source: utils/npm-packages-exists.js</h1>
-
-    
+		<h1 class="page-title">Source: utils/npm-packages-exists.js</h1>
 
 
 
-    
-    <section>
-        <article>
-            <pre class="prettyprint source linenums"><code>"use strict";
-const chalk = require("chalk");
+
+
+
+		<section>
+			<article>
+				<pre class="prettyprint source linenums"><code>"use strict";
+const color = require("turbocolor");
 const isLocalPath = require("./is-local-path");
 const npmExists = require("./npm-exists");
 const resolvePackages = require("./resolve-packages").resolvePackages;
@@ -65,8 +66,8 @@ module.exports = function npmPackagesExists(pkg) {
 			addon.slice(0, WEBPACK_SCAFFOLD_PREFIX.length) !== WEBPACK_SCAFFOLD_PREFIX
 		) {
 			throw new TypeError(
-				chalk.bold(`${addon} isn't a valid name.\n`) +
-					chalk.red(
+				color.bold(`${addon} isn't a valid name.\n`) +
+					color.red(
 						`\nIt should be prefixed with '${WEBPACK_SCAFFOLD_PREFIX}', but have different suffix.\n`
 					)
 			);
@@ -90,25 +91,173 @@ module.exports = function npmPackagesExists(pkg) {
 	});
 };
 </code></pre>
-        </article>
-    </section>
+			</article>
+		</section>
 
 
 
 
-</div>
+	</div>
 
-<nav>
-    <h2><a href="index.html">Home</a></h2><h3>Classes</h3><ul><li><a href="AddGenerator.html">AddGenerator</a></li><li><a href="InitGenerator.html">InitGenerator</a></li><li><a href="LoaderGenerator.html">LoaderGenerator</a></li><li><a href="PluginGenerator.html">PluginGenerator</a></li></ul><h3>Global</h3><ul><li><a href="global.html#addonGenerator">addonGenerator</a></li><li><a href="global.html#addOrUpdateConfigObject">addOrUpdateConfigObject</a></li><li><a href="global.html#addProperty">addProperty</a></li><li><a href="global.html#createIdentifierOrLiteral">createIdentifierOrLiteral</a></li><li><a href="global.html#createLiteral">createLiteral</a></li><li><a href="global.html#createOrUpdatePluginByName">createOrUpdatePluginByName</a></li><li><a href="global.html#createProperty">createProperty</a></li><li><a href="global.html#defineTest">defineTest</a></li><li><a href="global.html#findAndRemovePluginByName">findAndRemovePluginByName</a></li><li><a href="global.html#findInvocation">findInvocation</a></li><li><a href="global.html#findPluginsArrayAndRemoveIfEmpty">findPluginsArrayAndRemoveIfEmpty</a></li><li><a href="global.html#findPluginsByName">findPluginsByName</a></li><li><a href="global.html#findRootNodesByName">findRootNodesByName</a></li><li><a href="global.html#findVariableToPlugin">findVariableToPlugin</a></li><li><a href="global.html#generatorCopy">generatorCopy</a></li><li><a href="global.html#generatorCopyTpl">generatorCopyTpl</a></li><li><a href="global.html#getPackageManager">getPackageManager</a></li><li><a href="global.html#getPathToGlobalPackages">getPathToGlobalPackages</a></li><li><a href="global.html#getRequire">getRequire</a></li><li><a href="global.html#getRootPathModule">getRootPathModule</a></li><li><a href="global.html#isType">isType</a></li><li><a href="global.html#loaderCreator">loaderCreator</a></li><li><a href="global.html#makeLoaderName">makeLoaderName</a></li><li><a href="global.html#mapOptionsToTransform">mapOptionsToTransform</a></li><li><a href="global.html#parseMerge">parseMerge</a></li><li><a href="global.html#parseTopScope">parseTopScope</a></li><li><a href="global.html#pluginCreator">pluginCreator</a></li><li><a href="global.html#processPromise">processPromise</a></li><li><a href="global.html#replaceAt">replaceAt</a></li><li><a href="global.html#resolvePackages">resolvePackages</a></li><li><a href="global.html#runMigration">runMigration</a></li><li><a href="global.html#runSingleTransform">runSingleTransform</a></li><li><a href="global.html#safeTraverse">safeTraverse</a></li><li><a href="global.html#safeTraverseAndGetType">safeTraverseAndGetType</a></li><li><a href="global.html#serve">serve</a></li><li><a href="global.html#spawnChild">spawnChild</a></li><li><a href="global.html#spawnNPM">spawnNPM</a></li><li><a href="global.html#spawnNPMWithArg">spawnNPMWithArg</a></li><li><a href="global.html#spawnYarn">spawnYarn</a></li><li><a href="global.html#spawnYarnWithArg">spawnYarnWithArg</a></li><li><a href="global.html#transform">transform</a></li><li><a href="global.html#traverseAndGetProperties">traverseAndGetProperties</a></li></ul>
-</nav>
+	<nav>
+		<h2>
+			<a href="index.html">Home</a>
+		</h2>
+		<h3>Classes</h3>
+		<ul>
+			<li>
+				<a href="AddGenerator.html">AddGenerator</a>
+			</li>
+			<li>
+				<a href="InitGenerator.html">InitGenerator</a>
+			</li>
+			<li>
+				<a href="LoaderGenerator.html">LoaderGenerator</a>
+			</li>
+			<li>
+				<a href="PluginGenerator.html">PluginGenerator</a>
+			</li>
+		</ul>
+		<h3>Global</h3>
+		<ul>
+			<li>
+				<a href="global.html#addonGenerator">addonGenerator</a>
+			</li>
+			<li>
+				<a href="global.html#addOrUpdateConfigObject">addOrUpdateConfigObject</a>
+			</li>
+			<li>
+				<a href="global.html#addProperty">addProperty</a>
+			</li>
+			<li>
+				<a href="global.html#createIdentifierOrLiteral">createIdentifierOrLiteral</a>
+			</li>
+			<li>
+				<a href="global.html#createLiteral">createLiteral</a>
+			</li>
+			<li>
+				<a href="global.html#createOrUpdatePluginByName">createOrUpdatePluginByName</a>
+			</li>
+			<li>
+				<a href="global.html#createProperty">createProperty</a>
+			</li>
+			<li>
+				<a href="global.html#defineTest">defineTest</a>
+			</li>
+			<li>
+				<a href="global.html#findAndRemovePluginByName">findAndRemovePluginByName</a>
+			</li>
+			<li>
+				<a href="global.html#findInvocation">findInvocation</a>
+			</li>
+			<li>
+				<a href="global.html#findPluginsArrayAndRemoveIfEmpty">findPluginsArrayAndRemoveIfEmpty</a>
+			</li>
+			<li>
+				<a href="global.html#findPluginsByName">findPluginsByName</a>
+			</li>
+			<li>
+				<a href="global.html#findRootNodesByName">findRootNodesByName</a>
+			</li>
+			<li>
+				<a href="global.html#findVariableToPlugin">findVariableToPlugin</a>
+			</li>
+			<li>
+				<a href="global.html#generatorCopy">generatorCopy</a>
+			</li>
+			<li>
+				<a href="global.html#generatorCopyTpl">generatorCopyTpl</a>
+			</li>
+			<li>
+				<a href="global.html#getPackageManager">getPackageManager</a>
+			</li>
+			<li>
+				<a href="global.html#getPathToGlobalPackages">getPathToGlobalPackages</a>
+			</li>
+			<li>
+				<a href="global.html#getRequire">getRequire</a>
+			</li>
+			<li>
+				<a href="global.html#getRootPathModule">getRootPathModule</a>
+			</li>
+			<li>
+				<a href="global.html#isType">isType</a>
+			</li>
+			<li>
+				<a href="global.html#loaderCreator">loaderCreator</a>
+			</li>
+			<li>
+				<a href="global.html#makeLoaderName">makeLoaderName</a>
+			</li>
+			<li>
+				<a href="global.html#mapOptionsToTransform">mapOptionsToTransform</a>
+			</li>
+			<li>
+				<a href="global.html#parseMerge">parseMerge</a>
+			</li>
+			<li>
+				<a href="global.html#parseTopScope">parseTopScope</a>
+			</li>
+			<li>
+				<a href="global.html#pluginCreator">pluginCreator</a>
+			</li>
+			<li>
+				<a href="global.html#processPromise">processPromise</a>
+			</li>
+			<li>
+				<a href="global.html#replaceAt">replaceAt</a>
+			</li>
+			<li>
+				<a href="global.html#resolvePackages">resolvePackages</a>
+			</li>
+			<li>
+				<a href="global.html#runMigration">runMigration</a>
+			</li>
+			<li>
+				<a href="global.html#runSingleTransform">runSingleTransform</a>
+			</li>
+			<li>
+				<a href="global.html#safeTraverse">safeTraverse</a>
+			</li>
+			<li>
+				<a href="global.html#safeTraverseAndGetType">safeTraverseAndGetType</a>
+			</li>
+			<li>
+				<a href="global.html#serve">serve</a>
+			</li>
+			<li>
+				<a href="global.html#spawnChild">spawnChild</a>
+			</li>
+			<li>
+				<a href="global.html#spawnNPM">spawnNPM</a>
+			</li>
+			<li>
+				<a href="global.html#spawnNPMWithArg">spawnNPMWithArg</a>
+			</li>
+			<li>
+				<a href="global.html#spawnYarn">spawnYarn</a>
+			</li>
+			<li>
+				<a href="global.html#spawnYarnWithArg">spawnYarnWithArg</a>
+			</li>
+			<li>
+				<a href="global.html#transform">transform</a>
+			</li>
+			<li>
+				<a href="global.html#traverseAndGetProperties">traverseAndGetProperties</a>
+			</li>
+		</ul>
+	</nav>
 
-<br class="clear">
+	<br class="clear">
 
-<footer>
-    Documentation generated by <a href="https://github.com/jsdoc3/jsdoc">JSDoc 3.5.5</a> on Sat Jun 02 2018 17:44:07 GMT+0200 (CEST)
-</footer>
+	<footer>
+		Documentation generated by
+		<a href="https://github.com/jsdoc3/jsdoc">JSDoc 3.5.5</a> on Sat Jun 02 2018 17:44:07 GMT+0200 (CEST)
+	</footer>
 
-<script> prettyPrint(); </script>
-<script src="scripts/linenumber.js"> </script>
+	<script> prettyPrint(); </script>
+	<script src="scripts/linenumber.js"> </script>
 </body>
+
 </html>

--- a/docs/utils_resolve-packages.js.html
+++ b/docs/utils_resolve-packages.js.html
@@ -1,35 +1,36 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="utf-8">
-    <title>JSDoc: Source: utils/resolve-packages.js</title>
 
-    <script src="scripts/prettify/prettify.js"> </script>
-    <script src="scripts/prettify/lang-css.js"> </script>
-    <!--[if lt IE 9]>
+<head>
+	<meta charset="utf-8">
+	<title>JSDoc: Source: utils/resolve-packages.js</title>
+
+	<script src="scripts/prettify/prettify.js"> </script>
+	<script src="scripts/prettify/lang-css.js"> </script>
+	<!--[if lt IE 9]>
       <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
-    <link type="text/css" rel="stylesheet" href="styles/prettify-tomorrow.css">
-    <link type="text/css" rel="stylesheet" href="styles/jsdoc-default.css">
+	<link type="text/css" rel="stylesheet" href="styles/prettify-tomorrow.css">
+	<link type="text/css" rel="stylesheet" href="styles/jsdoc-default.css">
 </head>
 
 <body>
 
-<div id="main">
+	<div id="main">
 
-    <h1 class="page-title">Source: utils/resolve-packages.js</h1>
-
-    
+		<h1 class="page-title">Source: utils/resolve-packages.js</h1>
 
 
 
-    
-    <section>
-        <article>
-            <pre class="prettyprint source linenums"><code>"use strict";
+
+
+
+		<section>
+			<article>
+				<pre class="prettyprint source linenums"><code>"use strict";
 
 const path = require("path");
-const chalk = require("chalk");
+const color = require("turbocolor");
 
 const modifyConfigHelper = require("./modify-config-helper");
 
@@ -88,7 +89,7 @@ function resolvePackages(pkg) {
 			} catch (err) {
 				console.log(`Cannot find a generator at ${absolutePath}.`);
 				console.log("\nReason:\n");
-				console.error(chalk.bold.red(err));
+				console.error(color.bold.red(err));
 				process.exitCode = 1;
 			}
 
@@ -106,14 +107,14 @@ function resolvePackages(pkg) {
 					console.log("Package wasn't validated correctly..");
 					console.log("Submit an issue for", pkg, "if this persists");
 					console.log("\nReason: \n");
-					console.error(chalk.bold.red(err));
+					console.error(color.bold.red(err));
 					process.exitCode = 1;
 				}
 			})
 			.catch(err => {
 				console.log("Package couldn't be installed, aborting..");
 				console.log("\nReason: \n");
-				console.error(chalk.bold.red(err));
+				console.error(color.bold.red(err));
 				process.exitCode = 1;
 			})
 			.then(invokeGeneratorIfReady);
@@ -125,25 +126,173 @@ module.exports = {
 	processPromise
 };
 </code></pre>
-        </article>
-    </section>
+			</article>
+		</section>
 
 
 
 
-</div>
+	</div>
 
-<nav>
-    <h2><a href="index.html">Home</a></h2><h3>Classes</h3><ul><li><a href="AddGenerator.html">AddGenerator</a></li><li><a href="InitGenerator.html">InitGenerator</a></li><li><a href="LoaderGenerator.html">LoaderGenerator</a></li><li><a href="PluginGenerator.html">PluginGenerator</a></li></ul><h3>Global</h3><ul><li><a href="global.html#addonGenerator">addonGenerator</a></li><li><a href="global.html#addOrUpdateConfigObject">addOrUpdateConfigObject</a></li><li><a href="global.html#addProperty">addProperty</a></li><li><a href="global.html#createIdentifierOrLiteral">createIdentifierOrLiteral</a></li><li><a href="global.html#createLiteral">createLiteral</a></li><li><a href="global.html#createOrUpdatePluginByName">createOrUpdatePluginByName</a></li><li><a href="global.html#createProperty">createProperty</a></li><li><a href="global.html#defineTest">defineTest</a></li><li><a href="global.html#findAndRemovePluginByName">findAndRemovePluginByName</a></li><li><a href="global.html#findInvocation">findInvocation</a></li><li><a href="global.html#findPluginsArrayAndRemoveIfEmpty">findPluginsArrayAndRemoveIfEmpty</a></li><li><a href="global.html#findPluginsByName">findPluginsByName</a></li><li><a href="global.html#findRootNodesByName">findRootNodesByName</a></li><li><a href="global.html#findVariableToPlugin">findVariableToPlugin</a></li><li><a href="global.html#generatorCopy">generatorCopy</a></li><li><a href="global.html#generatorCopyTpl">generatorCopyTpl</a></li><li><a href="global.html#getPackageManager">getPackageManager</a></li><li><a href="global.html#getPathToGlobalPackages">getPathToGlobalPackages</a></li><li><a href="global.html#getRequire">getRequire</a></li><li><a href="global.html#getRootPathModule">getRootPathModule</a></li><li><a href="global.html#isType">isType</a></li><li><a href="global.html#loaderCreator">loaderCreator</a></li><li><a href="global.html#makeLoaderName">makeLoaderName</a></li><li><a href="global.html#mapOptionsToTransform">mapOptionsToTransform</a></li><li><a href="global.html#parseMerge">parseMerge</a></li><li><a href="global.html#parseTopScope">parseTopScope</a></li><li><a href="global.html#pluginCreator">pluginCreator</a></li><li><a href="global.html#processPromise">processPromise</a></li><li><a href="global.html#replaceAt">replaceAt</a></li><li><a href="global.html#resolvePackages">resolvePackages</a></li><li><a href="global.html#runMigration">runMigration</a></li><li><a href="global.html#runSingleTransform">runSingleTransform</a></li><li><a href="global.html#safeTraverse">safeTraverse</a></li><li><a href="global.html#safeTraverseAndGetType">safeTraverseAndGetType</a></li><li><a href="global.html#serve">serve</a></li><li><a href="global.html#spawnChild">spawnChild</a></li><li><a href="global.html#spawnNPM">spawnNPM</a></li><li><a href="global.html#spawnNPMWithArg">spawnNPMWithArg</a></li><li><a href="global.html#spawnYarn">spawnYarn</a></li><li><a href="global.html#spawnYarnWithArg">spawnYarnWithArg</a></li><li><a href="global.html#transform">transform</a></li><li><a href="global.html#traverseAndGetProperties">traverseAndGetProperties</a></li></ul>
-</nav>
+	<nav>
+		<h2>
+			<a href="index.html">Home</a>
+		</h2>
+		<h3>Classes</h3>
+		<ul>
+			<li>
+				<a href="AddGenerator.html">AddGenerator</a>
+			</li>
+			<li>
+				<a href="InitGenerator.html">InitGenerator</a>
+			</li>
+			<li>
+				<a href="LoaderGenerator.html">LoaderGenerator</a>
+			</li>
+			<li>
+				<a href="PluginGenerator.html">PluginGenerator</a>
+			</li>
+		</ul>
+		<h3>Global</h3>
+		<ul>
+			<li>
+				<a href="global.html#addonGenerator">addonGenerator</a>
+			</li>
+			<li>
+				<a href="global.html#addOrUpdateConfigObject">addOrUpdateConfigObject</a>
+			</li>
+			<li>
+				<a href="global.html#addProperty">addProperty</a>
+			</li>
+			<li>
+				<a href="global.html#createIdentifierOrLiteral">createIdentifierOrLiteral</a>
+			</li>
+			<li>
+				<a href="global.html#createLiteral">createLiteral</a>
+			</li>
+			<li>
+				<a href="global.html#createOrUpdatePluginByName">createOrUpdatePluginByName</a>
+			</li>
+			<li>
+				<a href="global.html#createProperty">createProperty</a>
+			</li>
+			<li>
+				<a href="global.html#defineTest">defineTest</a>
+			</li>
+			<li>
+				<a href="global.html#findAndRemovePluginByName">findAndRemovePluginByName</a>
+			</li>
+			<li>
+				<a href="global.html#findInvocation">findInvocation</a>
+			</li>
+			<li>
+				<a href="global.html#findPluginsArrayAndRemoveIfEmpty">findPluginsArrayAndRemoveIfEmpty</a>
+			</li>
+			<li>
+				<a href="global.html#findPluginsByName">findPluginsByName</a>
+			</li>
+			<li>
+				<a href="global.html#findRootNodesByName">findRootNodesByName</a>
+			</li>
+			<li>
+				<a href="global.html#findVariableToPlugin">findVariableToPlugin</a>
+			</li>
+			<li>
+				<a href="global.html#generatorCopy">generatorCopy</a>
+			</li>
+			<li>
+				<a href="global.html#generatorCopyTpl">generatorCopyTpl</a>
+			</li>
+			<li>
+				<a href="global.html#getPackageManager">getPackageManager</a>
+			</li>
+			<li>
+				<a href="global.html#getPathToGlobalPackages">getPathToGlobalPackages</a>
+			</li>
+			<li>
+				<a href="global.html#getRequire">getRequire</a>
+			</li>
+			<li>
+				<a href="global.html#getRootPathModule">getRootPathModule</a>
+			</li>
+			<li>
+				<a href="global.html#isType">isType</a>
+			</li>
+			<li>
+				<a href="global.html#loaderCreator">loaderCreator</a>
+			</li>
+			<li>
+				<a href="global.html#makeLoaderName">makeLoaderName</a>
+			</li>
+			<li>
+				<a href="global.html#mapOptionsToTransform">mapOptionsToTransform</a>
+			</li>
+			<li>
+				<a href="global.html#parseMerge">parseMerge</a>
+			</li>
+			<li>
+				<a href="global.html#parseTopScope">parseTopScope</a>
+			</li>
+			<li>
+				<a href="global.html#pluginCreator">pluginCreator</a>
+			</li>
+			<li>
+				<a href="global.html#processPromise">processPromise</a>
+			</li>
+			<li>
+				<a href="global.html#replaceAt">replaceAt</a>
+			</li>
+			<li>
+				<a href="global.html#resolvePackages">resolvePackages</a>
+			</li>
+			<li>
+				<a href="global.html#runMigration">runMigration</a>
+			</li>
+			<li>
+				<a href="global.html#runSingleTransform">runSingleTransform</a>
+			</li>
+			<li>
+				<a href="global.html#safeTraverse">safeTraverse</a>
+			</li>
+			<li>
+				<a href="global.html#safeTraverseAndGetType">safeTraverseAndGetType</a>
+			</li>
+			<li>
+				<a href="global.html#serve">serve</a>
+			</li>
+			<li>
+				<a href="global.html#spawnChild">spawnChild</a>
+			</li>
+			<li>
+				<a href="global.html#spawnNPM">spawnNPM</a>
+			</li>
+			<li>
+				<a href="global.html#spawnNPMWithArg">spawnNPMWithArg</a>
+			</li>
+			<li>
+				<a href="global.html#spawnYarn">spawnYarn</a>
+			</li>
+			<li>
+				<a href="global.html#spawnYarnWithArg">spawnYarnWithArg</a>
+			</li>
+			<li>
+				<a href="global.html#transform">transform</a>
+			</li>
+			<li>
+				<a href="global.html#traverseAndGetProperties">traverseAndGetProperties</a>
+			</li>
+		</ul>
+	</nav>
 
-<br class="clear">
+	<br class="clear">
 
-<footer>
-    Documentation generated by <a href="https://github.com/jsdoc3/jsdoc">JSDoc 3.5.5</a> on Sat Jun 02 2018 17:44:07 GMT+0200 (CEST)
-</footer>
+	<footer>
+		Documentation generated by
+		<a href="https://github.com/jsdoc3/jsdoc">JSDoc 3.5.5</a> on Sat Jun 02 2018 17:44:07 GMT+0200 (CEST)
+	</footer>
 
-<script> prettyPrint(); </script>
-<script src="scripts/linenumber.js"> </script>
+	<script> prettyPrint(); </script>
+	<script src="scripts/linenumber.js"> </script>
 </body>
+
 </html>

--- a/docs/utils_run-prettier.js.html
+++ b/docs/utils_run-prettier.js.html
@@ -1,36 +1,37 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="utf-8">
-    <title>JSDoc: Source: utils/run-prettier.js</title>
 
-    <script src="scripts/prettify/prettify.js"> </script>
-    <script src="scripts/prettify/lang-css.js"> </script>
-    <!--[if lt IE 9]>
+<head>
+	<meta charset="utf-8">
+	<title>JSDoc: Source: utils/run-prettier.js</title>
+
+	<script src="scripts/prettify/prettify.js"> </script>
+	<script src="scripts/prettify/lang-css.js"> </script>
+	<!--[if lt IE 9]>
       <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
-    <link type="text/css" rel="stylesheet" href="styles/prettify-tomorrow.css">
-    <link type="text/css" rel="stylesheet" href="styles/jsdoc-default.css">
+	<link type="text/css" rel="stylesheet" href="styles/prettify-tomorrow.css">
+	<link type="text/css" rel="stylesheet" href="styles/jsdoc-default.css">
 </head>
 
 <body>
 
-<div id="main">
+	<div id="main">
 
-    <h1 class="page-title">Source: utils/run-prettier.js</h1>
-
-    
+		<h1 class="page-title">Source: utils/run-prettier.js</h1>
 
 
 
-    
-    <section>
-        <article>
-            <pre class="prettyprint source linenums"><code>"use strict";
+
+
+
+		<section>
+			<article>
+				<pre class="prettyprint source linenums"><code>"use strict";
 
 const prettier = require("prettier");
 const fs = require("fs");
-const chalk = require("chalk");
+const color = require("turbocolor");
 
 /**
  *
@@ -55,7 +56,7 @@ module.exports = function runPrettier(outputPath, source, cb) {
 		} catch (err) {
 			process.stdout.write(
 				"\n" +
-					chalk.yellow(
+					color.yellow(
 						`WARNING: Could not apply prettier to ${outputPath}` +
 							" due validation error, but the file has been created\n"
 					)
@@ -71,25 +72,173 @@ module.exports = function runPrettier(outputPath, source, cb) {
 	return fs.writeFile(outputPath, source, "utf8", validateConfig);
 };
 </code></pre>
-        </article>
-    </section>
+			</article>
+		</section>
 
 
 
 
-</div>
+	</div>
 
-<nav>
-    <h2><a href="index.html">Home</a></h2><h3>Classes</h3><ul><li><a href="AddGenerator.html">AddGenerator</a></li><li><a href="InitGenerator.html">InitGenerator</a></li><li><a href="LoaderGenerator.html">LoaderGenerator</a></li><li><a href="PluginGenerator.html">PluginGenerator</a></li></ul><h3>Global</h3><ul><li><a href="global.html#addonGenerator">addonGenerator</a></li><li><a href="global.html#addOrUpdateConfigObject">addOrUpdateConfigObject</a></li><li><a href="global.html#addProperty">addProperty</a></li><li><a href="global.html#createIdentifierOrLiteral">createIdentifierOrLiteral</a></li><li><a href="global.html#createLiteral">createLiteral</a></li><li><a href="global.html#createOrUpdatePluginByName">createOrUpdatePluginByName</a></li><li><a href="global.html#createProperty">createProperty</a></li><li><a href="global.html#defineTest">defineTest</a></li><li><a href="global.html#findAndRemovePluginByName">findAndRemovePluginByName</a></li><li><a href="global.html#findInvocation">findInvocation</a></li><li><a href="global.html#findPluginsArrayAndRemoveIfEmpty">findPluginsArrayAndRemoveIfEmpty</a></li><li><a href="global.html#findPluginsByName">findPluginsByName</a></li><li><a href="global.html#findRootNodesByName">findRootNodesByName</a></li><li><a href="global.html#findVariableToPlugin">findVariableToPlugin</a></li><li><a href="global.html#generatorCopy">generatorCopy</a></li><li><a href="global.html#generatorCopyTpl">generatorCopyTpl</a></li><li><a href="global.html#getPackageManager">getPackageManager</a></li><li><a href="global.html#getPathToGlobalPackages">getPathToGlobalPackages</a></li><li><a href="global.html#getRequire">getRequire</a></li><li><a href="global.html#getRootPathModule">getRootPathModule</a></li><li><a href="global.html#isType">isType</a></li><li><a href="global.html#loaderCreator">loaderCreator</a></li><li><a href="global.html#makeLoaderName">makeLoaderName</a></li><li><a href="global.html#mapOptionsToTransform">mapOptionsToTransform</a></li><li><a href="global.html#parseMerge">parseMerge</a></li><li><a href="global.html#parseTopScope">parseTopScope</a></li><li><a href="global.html#pluginCreator">pluginCreator</a></li><li><a href="global.html#processPromise">processPromise</a></li><li><a href="global.html#replaceAt">replaceAt</a></li><li><a href="global.html#resolvePackages">resolvePackages</a></li><li><a href="global.html#runMigration">runMigration</a></li><li><a href="global.html#runSingleTransform">runSingleTransform</a></li><li><a href="global.html#safeTraverse">safeTraverse</a></li><li><a href="global.html#safeTraverseAndGetType">safeTraverseAndGetType</a></li><li><a href="global.html#serve">serve</a></li><li><a href="global.html#spawnChild">spawnChild</a></li><li><a href="global.html#spawnNPM">spawnNPM</a></li><li><a href="global.html#spawnNPMWithArg">spawnNPMWithArg</a></li><li><a href="global.html#spawnYarn">spawnYarn</a></li><li><a href="global.html#spawnYarnWithArg">spawnYarnWithArg</a></li><li><a href="global.html#transform">transform</a></li><li><a href="global.html#traverseAndGetProperties">traverseAndGetProperties</a></li></ul>
-</nav>
+	<nav>
+		<h2>
+			<a href="index.html">Home</a>
+		</h2>
+		<h3>Classes</h3>
+		<ul>
+			<li>
+				<a href="AddGenerator.html">AddGenerator</a>
+			</li>
+			<li>
+				<a href="InitGenerator.html">InitGenerator</a>
+			</li>
+			<li>
+				<a href="LoaderGenerator.html">LoaderGenerator</a>
+			</li>
+			<li>
+				<a href="PluginGenerator.html">PluginGenerator</a>
+			</li>
+		</ul>
+		<h3>Global</h3>
+		<ul>
+			<li>
+				<a href="global.html#addonGenerator">addonGenerator</a>
+			</li>
+			<li>
+				<a href="global.html#addOrUpdateConfigObject">addOrUpdateConfigObject</a>
+			</li>
+			<li>
+				<a href="global.html#addProperty">addProperty</a>
+			</li>
+			<li>
+				<a href="global.html#createIdentifierOrLiteral">createIdentifierOrLiteral</a>
+			</li>
+			<li>
+				<a href="global.html#createLiteral">createLiteral</a>
+			</li>
+			<li>
+				<a href="global.html#createOrUpdatePluginByName">createOrUpdatePluginByName</a>
+			</li>
+			<li>
+				<a href="global.html#createProperty">createProperty</a>
+			</li>
+			<li>
+				<a href="global.html#defineTest">defineTest</a>
+			</li>
+			<li>
+				<a href="global.html#findAndRemovePluginByName">findAndRemovePluginByName</a>
+			</li>
+			<li>
+				<a href="global.html#findInvocation">findInvocation</a>
+			</li>
+			<li>
+				<a href="global.html#findPluginsArrayAndRemoveIfEmpty">findPluginsArrayAndRemoveIfEmpty</a>
+			</li>
+			<li>
+				<a href="global.html#findPluginsByName">findPluginsByName</a>
+			</li>
+			<li>
+				<a href="global.html#findRootNodesByName">findRootNodesByName</a>
+			</li>
+			<li>
+				<a href="global.html#findVariableToPlugin">findVariableToPlugin</a>
+			</li>
+			<li>
+				<a href="global.html#generatorCopy">generatorCopy</a>
+			</li>
+			<li>
+				<a href="global.html#generatorCopyTpl">generatorCopyTpl</a>
+			</li>
+			<li>
+				<a href="global.html#getPackageManager">getPackageManager</a>
+			</li>
+			<li>
+				<a href="global.html#getPathToGlobalPackages">getPathToGlobalPackages</a>
+			</li>
+			<li>
+				<a href="global.html#getRequire">getRequire</a>
+			</li>
+			<li>
+				<a href="global.html#getRootPathModule">getRootPathModule</a>
+			</li>
+			<li>
+				<a href="global.html#isType">isType</a>
+			</li>
+			<li>
+				<a href="global.html#loaderCreator">loaderCreator</a>
+			</li>
+			<li>
+				<a href="global.html#makeLoaderName">makeLoaderName</a>
+			</li>
+			<li>
+				<a href="global.html#mapOptionsToTransform">mapOptionsToTransform</a>
+			</li>
+			<li>
+				<a href="global.html#parseMerge">parseMerge</a>
+			</li>
+			<li>
+				<a href="global.html#parseTopScope">parseTopScope</a>
+			</li>
+			<li>
+				<a href="global.html#pluginCreator">pluginCreator</a>
+			</li>
+			<li>
+				<a href="global.html#processPromise">processPromise</a>
+			</li>
+			<li>
+				<a href="global.html#replaceAt">replaceAt</a>
+			</li>
+			<li>
+				<a href="global.html#resolvePackages">resolvePackages</a>
+			</li>
+			<li>
+				<a href="global.html#runMigration">runMigration</a>
+			</li>
+			<li>
+				<a href="global.html#runSingleTransform">runSingleTransform</a>
+			</li>
+			<li>
+				<a href="global.html#safeTraverse">safeTraverse</a>
+			</li>
+			<li>
+				<a href="global.html#safeTraverseAndGetType">safeTraverseAndGetType</a>
+			</li>
+			<li>
+				<a href="global.html#serve">serve</a>
+			</li>
+			<li>
+				<a href="global.html#spawnChild">spawnChild</a>
+			</li>
+			<li>
+				<a href="global.html#spawnNPM">spawnNPM</a>
+			</li>
+			<li>
+				<a href="global.html#spawnNPMWithArg">spawnNPMWithArg</a>
+			</li>
+			<li>
+				<a href="global.html#spawnYarn">spawnYarn</a>
+			</li>
+			<li>
+				<a href="global.html#spawnYarnWithArg">spawnYarnWithArg</a>
+			</li>
+			<li>
+				<a href="global.html#transform">transform</a>
+			</li>
+			<li>
+				<a href="global.html#traverseAndGetProperties">traverseAndGetProperties</a>
+			</li>
+		</ul>
+	</nav>
 
-<br class="clear">
+	<br class="clear">
 
-<footer>
-    Documentation generated by <a href="https://github.com/jsdoc3/jsdoc">JSDoc 3.5.5</a> on Sat Jun 02 2018 17:44:07 GMT+0200 (CEST)
-</footer>
+	<footer>
+		Documentation generated by
+		<a href="https://github.com/jsdoc3/jsdoc">JSDoc 3.5.5</a> on Sat Jun 02 2018 17:44:07 GMT+0200 (CEST)
+	</footer>
 
-<script> prettyPrint(); </script>
-<script src="scripts/linenumber.js"> </script>
+	<script> prettyPrint(); </script>
+	<script src="scripts/linenumber.js"> </script>
 </body>
+
 </html>

--- a/docs/utils_scaffold.js.html
+++ b/docs/utils_scaffold.js.html
@@ -1,36 +1,37 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="utf-8">
-    <title>JSDoc: Source: utils/scaffold.js</title>
 
-    <script src="scripts/prettify/prettify.js"> </script>
-    <script src="scripts/prettify/lang-css.js"> </script>
-    <!--[if lt IE 9]>
+<head>
+	<meta charset="utf-8">
+	<title>JSDoc: Source: utils/scaffold.js</title>
+
+	<script src="scripts/prettify/prettify.js"> </script>
+	<script src="scripts/prettify/lang-css.js"> </script>
+	<!--[if lt IE 9]>
       <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
-    <link type="text/css" rel="stylesheet" href="styles/prettify-tomorrow.css">
-    <link type="text/css" rel="stylesheet" href="styles/jsdoc-default.css">
+	<link type="text/css" rel="stylesheet" href="styles/prettify-tomorrow.css">
+	<link type="text/css" rel="stylesheet" href="styles/jsdoc-default.css">
 </head>
 
 <body>
 
-<div id="main">
+	<div id="main">
 
-    <h1 class="page-title">Source: utils/scaffold.js</h1>
-
-    
+		<h1 class="page-title">Source: utils/scaffold.js</h1>
 
 
 
-    
-    <section>
-        <article>
-            <pre class="prettyprint source linenums"><code>"use strict";
+
+
+
+		<section>
+			<article>
+				<pre class="prettyprint source linenums"><code>"use strict";
 
 const path = require("path");
 const j = require("jscodeshift");
-const chalk = require("chalk");
+const color = require("turbocolor");
 const pEachSeries = require("p-each-series");
 
 const runPrettier = require("./run-prettier");
@@ -113,7 +114,7 @@ module.exports = function runTransform(webpackProperties, action) {
 	if (initActionNotDefined &amp;&amp; webpackProperties.config.item) {
 		process.stdout.write(
 			"\n" +
-				chalk.green(
+				color.green(
 					`Congratulations! ${
 						webpackProperties.config.item
 					} has been ${action}ed!\n`
@@ -122,32 +123,180 @@ module.exports = function runTransform(webpackProperties, action) {
 	} else {
 		process.stdout.write(
 			"\n" +
-				chalk.green(
+				color.green(
 					"Congratulations! Your new webpack configuration file has been created!\n"
 				)
 		);
 	}
 };
 </code></pre>
-        </article>
-    </section>
+			</article>
+		</section>
 
 
 
 
-</div>
+	</div>
 
-<nav>
-    <h2><a href="index.html">Home</a></h2><h3>Classes</h3><ul><li><a href="AddGenerator.html">AddGenerator</a></li><li><a href="InitGenerator.html">InitGenerator</a></li><li><a href="LoaderGenerator.html">LoaderGenerator</a></li><li><a href="PluginGenerator.html">PluginGenerator</a></li></ul><h3>Global</h3><ul><li><a href="global.html#addonGenerator">addonGenerator</a></li><li><a href="global.html#addOrUpdateConfigObject">addOrUpdateConfigObject</a></li><li><a href="global.html#addProperty">addProperty</a></li><li><a href="global.html#createIdentifierOrLiteral">createIdentifierOrLiteral</a></li><li><a href="global.html#createLiteral">createLiteral</a></li><li><a href="global.html#createOrUpdatePluginByName">createOrUpdatePluginByName</a></li><li><a href="global.html#createProperty">createProperty</a></li><li><a href="global.html#defineTest">defineTest</a></li><li><a href="global.html#findAndRemovePluginByName">findAndRemovePluginByName</a></li><li><a href="global.html#findInvocation">findInvocation</a></li><li><a href="global.html#findPluginsArrayAndRemoveIfEmpty">findPluginsArrayAndRemoveIfEmpty</a></li><li><a href="global.html#findPluginsByName">findPluginsByName</a></li><li><a href="global.html#findRootNodesByName">findRootNodesByName</a></li><li><a href="global.html#findVariableToPlugin">findVariableToPlugin</a></li><li><a href="global.html#generatorCopy">generatorCopy</a></li><li><a href="global.html#generatorCopyTpl">generatorCopyTpl</a></li><li><a href="global.html#getPackageManager">getPackageManager</a></li><li><a href="global.html#getPathToGlobalPackages">getPathToGlobalPackages</a></li><li><a href="global.html#getRequire">getRequire</a></li><li><a href="global.html#getRootPathModule">getRootPathModule</a></li><li><a href="global.html#isType">isType</a></li><li><a href="global.html#loaderCreator">loaderCreator</a></li><li><a href="global.html#makeLoaderName">makeLoaderName</a></li><li><a href="global.html#mapOptionsToTransform">mapOptionsToTransform</a></li><li><a href="global.html#parseMerge">parseMerge</a></li><li><a href="global.html#parseTopScope">parseTopScope</a></li><li><a href="global.html#pluginCreator">pluginCreator</a></li><li><a href="global.html#processPromise">processPromise</a></li><li><a href="global.html#replaceAt">replaceAt</a></li><li><a href="global.html#resolvePackages">resolvePackages</a></li><li><a href="global.html#runMigration">runMigration</a></li><li><a href="global.html#runSingleTransform">runSingleTransform</a></li><li><a href="global.html#safeTraverse">safeTraverse</a></li><li><a href="global.html#safeTraverseAndGetType">safeTraverseAndGetType</a></li><li><a href="global.html#serve">serve</a></li><li><a href="global.html#spawnChild">spawnChild</a></li><li><a href="global.html#spawnNPM">spawnNPM</a></li><li><a href="global.html#spawnNPMWithArg">spawnNPMWithArg</a></li><li><a href="global.html#spawnYarn">spawnYarn</a></li><li><a href="global.html#spawnYarnWithArg">spawnYarnWithArg</a></li><li><a href="global.html#transform">transform</a></li><li><a href="global.html#traverseAndGetProperties">traverseAndGetProperties</a></li></ul>
-</nav>
+	<nav>
+		<h2>
+			<a href="index.html">Home</a>
+		</h2>
+		<h3>Classes</h3>
+		<ul>
+			<li>
+				<a href="AddGenerator.html">AddGenerator</a>
+			</li>
+			<li>
+				<a href="InitGenerator.html">InitGenerator</a>
+			</li>
+			<li>
+				<a href="LoaderGenerator.html">LoaderGenerator</a>
+			</li>
+			<li>
+				<a href="PluginGenerator.html">PluginGenerator</a>
+			</li>
+		</ul>
+		<h3>Global</h3>
+		<ul>
+			<li>
+				<a href="global.html#addonGenerator">addonGenerator</a>
+			</li>
+			<li>
+				<a href="global.html#addOrUpdateConfigObject">addOrUpdateConfigObject</a>
+			</li>
+			<li>
+				<a href="global.html#addProperty">addProperty</a>
+			</li>
+			<li>
+				<a href="global.html#createIdentifierOrLiteral">createIdentifierOrLiteral</a>
+			</li>
+			<li>
+				<a href="global.html#createLiteral">createLiteral</a>
+			</li>
+			<li>
+				<a href="global.html#createOrUpdatePluginByName">createOrUpdatePluginByName</a>
+			</li>
+			<li>
+				<a href="global.html#createProperty">createProperty</a>
+			</li>
+			<li>
+				<a href="global.html#defineTest">defineTest</a>
+			</li>
+			<li>
+				<a href="global.html#findAndRemovePluginByName">findAndRemovePluginByName</a>
+			</li>
+			<li>
+				<a href="global.html#findInvocation">findInvocation</a>
+			</li>
+			<li>
+				<a href="global.html#findPluginsArrayAndRemoveIfEmpty">findPluginsArrayAndRemoveIfEmpty</a>
+			</li>
+			<li>
+				<a href="global.html#findPluginsByName">findPluginsByName</a>
+			</li>
+			<li>
+				<a href="global.html#findRootNodesByName">findRootNodesByName</a>
+			</li>
+			<li>
+				<a href="global.html#findVariableToPlugin">findVariableToPlugin</a>
+			</li>
+			<li>
+				<a href="global.html#generatorCopy">generatorCopy</a>
+			</li>
+			<li>
+				<a href="global.html#generatorCopyTpl">generatorCopyTpl</a>
+			</li>
+			<li>
+				<a href="global.html#getPackageManager">getPackageManager</a>
+			</li>
+			<li>
+				<a href="global.html#getPathToGlobalPackages">getPathToGlobalPackages</a>
+			</li>
+			<li>
+				<a href="global.html#getRequire">getRequire</a>
+			</li>
+			<li>
+				<a href="global.html#getRootPathModule">getRootPathModule</a>
+			</li>
+			<li>
+				<a href="global.html#isType">isType</a>
+			</li>
+			<li>
+				<a href="global.html#loaderCreator">loaderCreator</a>
+			</li>
+			<li>
+				<a href="global.html#makeLoaderName">makeLoaderName</a>
+			</li>
+			<li>
+				<a href="global.html#mapOptionsToTransform">mapOptionsToTransform</a>
+			</li>
+			<li>
+				<a href="global.html#parseMerge">parseMerge</a>
+			</li>
+			<li>
+				<a href="global.html#parseTopScope">parseTopScope</a>
+			</li>
+			<li>
+				<a href="global.html#pluginCreator">pluginCreator</a>
+			</li>
+			<li>
+				<a href="global.html#processPromise">processPromise</a>
+			</li>
+			<li>
+				<a href="global.html#replaceAt">replaceAt</a>
+			</li>
+			<li>
+				<a href="global.html#resolvePackages">resolvePackages</a>
+			</li>
+			<li>
+				<a href="global.html#runMigration">runMigration</a>
+			</li>
+			<li>
+				<a href="global.html#runSingleTransform">runSingleTransform</a>
+			</li>
+			<li>
+				<a href="global.html#safeTraverse">safeTraverse</a>
+			</li>
+			<li>
+				<a href="global.html#safeTraverseAndGetType">safeTraverseAndGetType</a>
+			</li>
+			<li>
+				<a href="global.html#serve">serve</a>
+			</li>
+			<li>
+				<a href="global.html#spawnChild">spawnChild</a>
+			</li>
+			<li>
+				<a href="global.html#spawnNPM">spawnNPM</a>
+			</li>
+			<li>
+				<a href="global.html#spawnNPMWithArg">spawnNPMWithArg</a>
+			</li>
+			<li>
+				<a href="global.html#spawnYarn">spawnYarn</a>
+			</li>
+			<li>
+				<a href="global.html#spawnYarnWithArg">spawnYarnWithArg</a>
+			</li>
+			<li>
+				<a href="global.html#transform">transform</a>
+			</li>
+			<li>
+				<a href="global.html#traverseAndGetProperties">traverseAndGetProperties</a>
+			</li>
+		</ul>
+	</nav>
 
-<br class="clear">
+	<br class="clear">
 
-<footer>
-    Documentation generated by <a href="https://github.com/jsdoc3/jsdoc">JSDoc 3.5.5</a> on Sat Jun 02 2018 17:44:07 GMT+0200 (CEST)
-</footer>
+	<footer>
+		Documentation generated by
+		<a href="https://github.com/jsdoc3/jsdoc">JSDoc 3.5.5</a> on Sat Jun 02 2018 17:44:07 GMT+0200 (CEST)
+	</footer>
 
-<script> prettyPrint(); </script>
-<script src="scripts/linenumber.js"> </script>
+	<script> prettyPrint(); </script>
+	<script src="scripts/linenumber.js"> </script>
 </body>
+
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -18262,6 +18262,11 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "turbocolor": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/turbocolor/-/turbocolor-2.0.1.tgz",
+      "integrity": "sha1-AKmOAJ3Bhzd/kLL6bxqcl+ME4OM="
+    },
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     }
   },
   "dependencies": {
-    "chalk": "^2.4.1",
+    "turbocolor": "^2.0.1",
     "cross-spawn": "^6.0.5",
     "enhanced-resolve": "^4.0.0",
     "global-modules-path": "^2.1.0",

--- a/packages/generators/init-generator.js
+++ b/packages/generators/init-generator.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const Generator = require("yeoman-generator");
-const chalk = require("chalk");
+const color = require("turbocolor");
 const logSymbols = require("log-symbols");
 
 const Input = require("@webpack-cli/webpack-scaffold").Input;
@@ -53,16 +53,16 @@ module.exports = class InitGenerator extends Generator {
 		process.stdout.write(
 			"\n" +
 				logSymbols.info +
-				chalk.blue(" INFO ") +
+				color.blue(" INFO ") +
 				"For more information and a detailed description of each question, have a look at " +
-				chalk.bold.green(
+				color.bold.green(
 					"https://github.com/webpack/webpack-cli/blob/master/INIT.md"
 				) +
 				"\n"
 		);
 		process.stdout.write(
 			logSymbols.info +
-				chalk.blue(" INFO ") +
+				color.blue(" INFO ") +
 				"Alternatively, run `webpack(-cli) --help` for usage info." +
 				"\n\n"
 		);

--- a/packages/generators/package.json
+++ b/packages/generators/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@webpack-cli/utils": "^0.0.8",
     "@webpack-cli/webpack-scaffold": "^0.0.8",
-    "chalk": "^2.4.1",
+    "turbocolor": "^2.0.1",
     "glob-all": "^3.1.0",
     "inquirer-autocomplete-prompt": "^0.12.2",
     "lodash": "^4.17.10",

--- a/packages/init/init.js
+++ b/packages/init/init.js
@@ -2,7 +2,7 @@
 
 const path = require("path");
 const j = require("jscodeshift");
-const chalk = require("chalk");
+const color = require("turbocolor");
 const pEachSeries = require("p-each-series");
 
 const runPrettier = require("@webpack-cli/utils/run-prettier");
@@ -77,7 +77,7 @@ module.exports = function runTransform(webpackProperties, action) {
 	if (initActionNotDefined && webpackProperties.config.item) {
 		process.stdout.write(
 			"\n" +
-				chalk.green(
+				color.green(
 					`Congratulations! ${
 						webpackProperties.config.item
 					} has been ${action}ed!\n`
@@ -86,7 +86,7 @@ module.exports = function runTransform(webpackProperties, action) {
 	} else {
 		process.stdout.write(
 			"\n" +
-				chalk.green(
+				color.green(
 					"Congratulations! Your new webpack configuration file has been created!\n"
 				)
 		);

--- a/packages/init/package.json
+++ b/packages/init/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@webpack-cli/generators": "^0.0.8",
     "@webpack-cli/utils": "^0.0.8",
-    "chalk": "^2.4.1",
+    "turbocolor": "^2.0.1",
     "jscodeshift": "^0.5.0",
     "p-each-series": "^1.0.0"
   }

--- a/packages/migrate/index.js
+++ b/packages/migrate/index.js
@@ -2,7 +2,7 @@
 
 const fs = require("fs");
 const path = require("path");
-const chalk = require("chalk");
+const color = require("turbocolor");
 const diff = require("diff");
 const inquirer = require("inquirer");
 const PLazy = require("p-lazy");
@@ -28,7 +28,7 @@ module.exports = function migrate(...args) {
 	const filePaths = args.slice(3);
 	if (!filePaths.length) {
 		const errMsg = "\n ✖ Please specify a path to your webpack config \n ";
-		console.error(chalk.red(errMsg));
+		console.error(color.red(errMsg));
 		return;
 	}
 	const currentConfigPath = path.resolve(process.cwd(), filePaths[0]);
@@ -48,7 +48,7 @@ module.exports = function migrate(...args) {
 			])
 			.then(ans => {
 				if (!ans["confirmPath"]) {
-					console.error(chalk.red("✖ ︎Migration aborted due no output path"));
+					console.error(color.red("✖ ︎Migration aborted due no output path"));
 					return;
 				}
 				outputConfigPath = path.resolve(process.cwd(), filePaths[0]);
@@ -122,9 +122,9 @@ function runMigration(currentConfigPath, outputConfigPath) {
 			const diffOutput = diff.diffLines(ctx.source, result);
 			diffOutput.forEach(diffLine => {
 				if (diffLine.added) {
-					process.stdout.write(chalk.green(`+ ${diffLine.value}`));
+					process.stdout.write(color.green(`+ ${diffLine.value}`));
 				} else if (diffLine.removed) {
-					process.stdout.write(chalk.red(`- ${diffLine.value}`));
+					process.stdout.write(color.red(`- ${diffLine.value}`));
 				}
 			});
 			return inquirer
@@ -149,7 +149,7 @@ function runMigration(currentConfigPath, outputConfigPath) {
 							}
 						]);
 					} else {
-						console.log(chalk.red("✖ Migration aborted"));
+						console.log(color.red("✖ Migration aborted"));
 					}
 				})
 				.then(answer => {
@@ -167,7 +167,7 @@ function runMigration(currentConfigPath, outputConfigPath) {
 						);
 						if (webpackOptionsValidationErrors.length) {
 							console.log(
-								chalk.red(
+								color.red(
 									"\n✖ Your configuration validation wasn't successful \n"
 								)
 							);
@@ -179,17 +179,17 @@ function runMigration(currentConfigPath, outputConfigPath) {
 						}
 					}
 					console.log(
-						chalk.green(
+						color.green(
 							`\n✔︎ New webpack config file is at ${outputConfigPath}.`
 						)
 					);
 					console.log(
-						chalk.green(
+						color.green(
 							"✔︎ Heads up! Updating to the latest version could contain breaking changes."
 						)
 					);
 					console.log(
-						chalk.green(
+						color.green(
 							"✔︎ Plugin and loader dependencies may need to be updated."
 						)
 					);
@@ -197,7 +197,7 @@ function runMigration(currentConfigPath, outputConfigPath) {
 		})
 		.catch(err => {
 			const errMsg = "\n ✖ ︎Migration aborted due to some errors: \n";
-			console.error(chalk.red(errMsg));
+			console.error(color.red(errMsg));
 			console.error(err);
 			process.exitCode = 1;
 		});

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@webpack-cli/utils": "^0.0.8",
-    "chalk": "^2.4.1",
+    "turbocolor": "^2.0.1",
     "diff": "^3.5.0",
     "inquirer": "^5.2.0",
     "jscodeshift": "^0.5.0",

--- a/packages/migrate/removeDeprecatedPlugins/removeDeprecatedPlugins.js
+++ b/packages/migrate/removeDeprecatedPlugins/removeDeprecatedPlugins.js
@@ -1,4 +1,4 @@
-const chalk = require("chalk");
+const color = require("turbocolor");
 const utils = require("@webpack-cli/utils/ast-utils");
 
 /**
@@ -35,8 +35,8 @@ module.exports = function(j, ast, source) {
 				}
 			} else {
 				console.log(`
-${chalk.red("Please remove deprecated plugins manually. ")}
-See ${chalk.underline(
+${color.red("Please remove deprecated plugins manually. ")}
+See ${color.underline(
 		"https://webpack.js.org/guides/migrating/"
 	)} for more information.`);
 			}

--- a/packages/serve/index.js
+++ b/packages/serve/index.js
@@ -2,7 +2,7 @@
 
 const inquirer = require("inquirer");
 const path = require("path");
-const chalk = require("chalk");
+const color = require("turbocolor");
 const spawn = require("cross-spawn");
 const List = require("@webpack-cli/webpack-scaffold").List;
 const processPromise = require("@webpack-cli/utils/resolve-packages")
@@ -57,7 +57,7 @@ function serve() {
 	if (!packageJSONPath) {
 		console.log(
 			"\n",
-			chalk.red("✖ Could not find your package.json file"),
+			color.red("✖ Could not find your package.json file"),
 			"\n"
 		);
 		process.exit(1);
@@ -78,14 +78,14 @@ function serve() {
 		if (!WDSPath) {
 			console.log(
 				"\n",
-				chalk.red(
+				color.red(
 					"✖ Could not find the webpack-dev-server dependency in node_modules root path"
 				)
 			);
 			console.log(
-				chalk.bold.green(" ✔︎"),
+				color.bold.green(" ✔︎"),
 				"Try this command:",
-				chalk.bold.green("rm -rf node_modules && npm install")
+				color.bold.green("rm -rf node_modules && npm install")
 			);
 			process.exit(1);
 		}
@@ -93,14 +93,14 @@ function serve() {
 	} else {
 		process.stdout.write(
 			"\n" +
-				chalk.bold(
-					"✖ We didn't find any webpack-dev-server dependency in your project,"
-				) +
-				"\n" +
-				chalk.bold.green("  'webpack serve'") +
-				" " +
-				chalk.bold("requires you to have it installed ") +
-				"\n\n"
+			color.bold(
+				"✖ We didn't find any webpack-dev-server dependency in your project,"
+			) +
+			"\n" +
+			color.bold.green("  'webpack serve'") +
+			" " +
+			color.bold("requires you to have it installed ") +
+			"\n\n"
 		);
 		return inquirer
 			.prompt([
@@ -154,12 +154,12 @@ function serve() {
 							});
 						});
 				} else {
-					console.log(chalk.bold.red("✖ Serve aborted due cancelling"));
+					console.log(color.bold.red("✖ Serve aborted due cancelling"));
 					process.exitCode = 1;
 				}
 			})
 			.catch(err => {
-				console.log(chalk.red("✖ Serve aborted due to some errors"));
+				console.log(color.red("✖ Serve aborted due to some errors"));
 				console.error(err);
 				process.exitCode = 1;
 			});

--- a/packages/serve/package.json
+++ b/packages/serve/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "dependencies": {
     "@webpack-cli/webpack-scaffold": "^0.0.8",
-    "chalk": "^2.4.1",
+    "turbocolor": "^2.0.1",
     "cross-spawn": "^6.0.5",
     "inquirer": "^5.2.0"
   }

--- a/packages/utils/modify-config-helper.js
+++ b/packages/utils/modify-config-helper.js
@@ -2,7 +2,7 @@
 
 const fs = require("fs");
 const path = require("path");
-const chalk = require("chalk");
+const color = require("turbocolor");
 const yeoman = require("yeoman-environment");
 const Generator = require("yeoman-generator");
 const logSymbols = require("log-symbols");
@@ -29,22 +29,22 @@ module.exports = function modifyHelperUtil(action, generator, configFile, packag
 		if (webpackConfigExists) {
 			process.stdout.write(
 				"\n" +
-					logSymbols.success +
-					chalk.green(" SUCCESS ") +
-					"Found config " +
-					chalk.cyan(configFile + "\n") +
-					"\n"
+				logSymbols.success +
+				color.green(" SUCCESS ") +
+				"Found config " +
+				color.cyan(configFile + "\n") +
+				"\n"
 			);
 		} else {
 			process.stdout.write(
 				"\n" +
-					logSymbols.error +
-					chalk.red(" ERROR ") +
-					chalk.cyan(configFile) +
-					" not found. Please specify a valid path to your webpack config like " +
-					chalk.white("$ ") +
-					chalk.cyan(`webpack-cli ${action} webpack.dev.js`) +
-					"\n"
+				logSymbols.error +
+				color.red(" ERROR ") +
+				color.cyan(configFile) +
+				" not found. Please specify a valid path to your webpack config like " +
+				color.white("$ ") +
+				color.cyan(`webpack-cli ${action} webpack.dev.js`) +
+				"\n"
 			);
 			return;
 		}
@@ -80,10 +80,10 @@ module.exports = function modifyHelperUtil(action, generator, configFile, packag
 			configModule = tmpConfig;
 		} catch (err) {
 			console.error(
-				chalk.red("\nCould not find a yeoman configuration file.\n")
+				color.red("\nCould not find a yeoman configuration file.\n")
 			);
 			console.error(
-				chalk.red(
+				color.red(
 					"\nPlease make sure to use 'this.config.set('configuration', this.configuration);' at the end of the generator.\n"
 				)
 			);

--- a/packages/utils/npm-packages-exists.js
+++ b/packages/utils/npm-packages-exists.js
@@ -1,5 +1,5 @@
 "use strict";
-const chalk = require("chalk");
+const color = require("turbocolor");
 const isLocalPath = require("./is-local-path");
 const npmExists = require("./npm-exists");
 const resolvePackages = require("./resolve-packages").resolvePackages;
@@ -37,10 +37,10 @@ module.exports = function npmPackagesExists(pkg) {
 			addon.slice(0, WEBPACK_SCAFFOLD_PREFIX.length) !== WEBPACK_SCAFFOLD_PREFIX
 		) {
 			throw new TypeError(
-				chalk.bold(`${addon} isn't a valid name.\n`) +
-					chalk.red(
-						`\nIt should be prefixed with '${WEBPACK_SCAFFOLD_PREFIX}', but have different suffix.\n`
-					)
+				color.bold(`${addon} isn't a valid name.\n`) +
+				color.red(
+					`\nIt should be prefixed with '${WEBPACK_SCAFFOLD_PREFIX}', but have different suffix.\n`
+				)
 			);
 		}
 

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -12,7 +12,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "chalk": "^2.4.1",
+    "turbocolor": "^2.0.1",
     "cross-spawn": "^6.0.5",
     "global-modules": "^1.0.0",
     "got": "^8.3.1",

--- a/packages/utils/resolve-packages.js
+++ b/packages/utils/resolve-packages.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const path = require("path");
-const chalk = require("chalk");
+const color = require("turbocolor");
 
 const modifyConfigHelper = require("./modify-config-helper");
 
@@ -60,7 +60,7 @@ function resolvePackages(pkg) {
 			} catch (err) {
 				console.log(`Cannot find a generator at ${absolutePath}.`);
 				console.log("\nReason:\n");
-				console.error(chalk.bold.red(err));
+				console.error(color.bold.red(err));
 				process.exitCode = 1;
 			}
 
@@ -78,14 +78,14 @@ function resolvePackages(pkg) {
 					console.log("Package wasn't validated correctly..");
 					console.log("Submit an issue for", pkg, "if this persists");
 					console.log("\nReason: \n");
-					console.error(chalk.bold.red(err));
+					console.error(color.bold.red(err));
 					process.exitCode = 1;
 				}
 			})
 			.catch(err => {
 				console.log("Package couldn't be installed, aborting..");
 				console.log("\nReason: \n");
-				console.error(chalk.bold.red(err));
+				console.error(color.bold.red(err));
 				process.exitCode = 1;
 			})
 			.then(invokeGeneratorIfReady);

--- a/packages/utils/run-prettier.js
+++ b/packages/utils/run-prettier.js
@@ -2,7 +2,7 @@
 
 const prettier = require("prettier");
 const fs = require("fs");
-const chalk = require("chalk");
+const color = require("turbocolor");
 
 /**
  *
@@ -27,10 +27,10 @@ module.exports = function runPrettier(outputPath, source, cb) {
 		} catch (err) {
 			process.stdout.write(
 				"\n" +
-					chalk.yellow(
-						`WARNING: Could not apply prettier to ${outputPath}` +
-							" due validation error, but the file has been created\n"
-					)
+				color.yellow(
+					`WARNING: Could not apply prettier to ${outputPath}` +
+					" due validation error, but the file has been created\n"
+				)
 			);
 			prettySource = source;
 			error = err;

--- a/packages/utils/scaffold.js
+++ b/packages/utils/scaffold.js
@@ -2,7 +2,7 @@
 
 const path = require("path");
 const j = require("jscodeshift");
-const chalk = require("chalk");
+const color = require("turbocolor");
 const pEachSeries = require("p-each-series");
 
 const runPrettier = require("./run-prettier");
@@ -85,7 +85,7 @@ module.exports = function runTransform(webpackProperties, action) {
 	if (initActionNotDefined && webpackProperties.config.item) {
 		process.stdout.write(
 			"\n" +
-				chalk.green(
+				color.green(
 					`Congratulations! ${
 						webpackProperties.config.item
 					} has been ${action}ed!\n`
@@ -94,7 +94,7 @@ module.exports = function runTransform(webpackProperties, action) {
 	} else {
 		process.stdout.write(
 			"\n" +
-				chalk.green(
+				color.green(
 					"Congratulations! Your new webpack configuration file has been created!\n"
 				)
 		);


### PR DESCRIPTION
Hello webpack-cli maintainers! 👋 

This PR basically swaps chalk for [Turbocolor](https://github.com/jorgebucaran/turbocolor).

---

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

Swaps one library for another that uses the same API, but it's lighter (no deps) and has significantly better load/runtime performance (~>20x faster). 

**Did you add tests for your changes?**

Same tests pass, so should be good.

**If relevant, did you update the documentation?**

I did, is it good?

**Summary**

It should give you a small perf boost as turbocolor loads **_>20x_** faster and applies styles **_>18x_** faster than chalk for the same API (see [benchmarks](https://github.com/jorgebucaran/turbocolor/tree/master/bench#benchmarks)). Node.js >=v4 supported.

<pre>
# Load Time
chalk: 15.190ms
<b>turbocolor: 0.777ms</b>

# All Colors
chalk × 8,729 ops/sec
<b>turbocolor × 158,383 ops/sec</b>

# Chained Colors
chalk × 1,838 ops/sec
<b>turbocolor × 39,830 ops/sec</b>

# Nested Colors
chalk × 4,049 ops/sec
<b>turbocolor × 59,833 ops/sec</b>
</pre>

**Does this PR introduce a breaking change?**
No!

---

Let me know if this is acceptable to you and if I need to change anything. Cheers!