### PR TITLE
fix(prettier): add parser, filePath

### DIFF
--- a/packages/utils/run-prettier.ts
+++ b/packages/utils/run-prettier.ts
@@ -18,6 +18,8 @@ export default function runPrettier(outputPath: string, source: string, cb?: Fun
 		let error: object;
 		try {
 			prettySource = prettier.format(source, {
+				filepath: outputPath,
+				parser: "babylon",
 				singleQuote: true,
 				tabWidth: 1,
 				useTabs: true,


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bugfix

**Did you add tests for your changes?**
No

**If relevant, did you update the documentation?**
No

**Summary**
![image](https://user-images.githubusercontent.com/5961873/42949683-ef845284-8b8f-11e8-9f3a-d8d4c673a542.png)

Prettier shows warning currently that filePath and parser aren't specified.
It would throw errors in future major versions. [#4828](https://github.com/prettier/prettier/pull/4528)

This PR cleans the warning shown in the above image.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No

**Other information**
No