### PR TITLE
Fixed changelog link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
  <a name="3.1.0"></a>
 # 3.1.0 (2018-07-18)
-[Full Changelog](https://github.com/webpack/webpack-cli/compare/v3.0.8...v3.1.0)
+[Full Changelog](https://github.com/webpack/webpack-cli/compare/v3.0.8...v.3.1.0)
 
 ## New Features
 


### PR DESCRIPTION
Latest tag is v.3.1.0, not v3.1.0

Current (broken) link : https://github.com/webpack/webpack-cli/compare/v3.0.8...v3.1.0
New (fixed) link : https://github.com/webpack/webpack-cli/compare/v3.0.8...v.3.1.0