### PR TITLE
chore(tests): PoC on new way of running integration tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5809,6 +5809,23 @@
       "requires": {
         "execa": "^0.10.0",
         "ip-regex": "^2.1.0"
+      },
+      "dependencies": {
+        "execa": {
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
+          "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        }
       }
     },
     "default-require-extensions": {
@@ -6613,17 +6630,39 @@
       }
     },
     "execa": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
-      "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+      "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+      "dev": true,
       "requires": {
         "cross-spawn": "^6.0.0",
-        "get-stream": "^3.0.0",
+        "get-stream": "^4.0.0",
         "is-stream": "^1.1.0",
         "npm-run-path": "^2.0.0",
         "p-finally": "^1.0.0",
         "signal-exit": "^3.0.0",
         "strip-eof": "^1.0.0"
+      },
+      "dependencies": {
+        "get-stream": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.0.0.tgz",
+          "integrity": "sha512-FneLKMENeOR7wOK0/ZXCh+lwqtnPwkeunJjRN28LPqzGvNAhYvrTAhXv6xDm4vsJ0M7lcRbIYHQudKsSy2RtSQ==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "pump": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+          "dev": true,
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        }
       }
     },
     "exit": {
@@ -14280,6 +14319,22 @@
         "execa": "^0.10.0",
         "lcid": "^2.0.0",
         "mem": "^4.0.0"
+      },
+      "dependencies": {
+        "execa": {
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
+          "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
+          "requires": {
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        }
       }
     },
     "os-shim": {

--- a/package.json
+++ b/package.json
@@ -67,9 +67,15 @@
       "json",
       "html"
     ],
+    "coveragePathIgnorePatterns": [
+      "<rootDir>/test/testUtils.js"
+    ],
     "moduleNameMapper": {
-      "^.+\\.(ts)?$": "ts-jest"
-    }
+      "^.+\\.ts$": "ts-jest"
+    },
+    "watchPathIgnorePatterns": [
+      "<rootDir>/test/js/bin"
+    ]
   },
   "nyc": {
     "include": [
@@ -133,6 +139,7 @@
     "cz-customizable": "^5.2.0",
     "eslint": "^5.5.0",
     "eslint-plugin-node": "^7.0.1",
+    "execa": "^1.0.0",
     "husky": "^1.0.0",
     "jest": "^23.6.0",
     "jest-cli": "^23.6.0",

--- a/test/BinTestCases.test.js
+++ b/test/BinTestCases.test.js
@@ -5,6 +5,8 @@ const path = require("path");
 const fs = require("fs");
 const child_process = require("child_process");
 
+const migratedTests = ["config-name"];
+
 function spawn(args, options) {
 	return child_process.spawn(
 		process.execPath,
@@ -53,6 +55,7 @@ function findTestsRecursive(readPath) {
 	const isAnyTests = entries.indexOf("stdin.js") !== -1;
 
 	const folders = entries
+		.filter(entry => !migratedTests.includes(entry))
 		.map(entry => path.join(readPath, entry))
 		.filter(entry => fs.statSync(entry).isDirectory());
 

--- a/test/__tests__/config-name.test.js
+++ b/test/__tests__/config-name.test.js
@@ -1,0 +1,46 @@
+"usr strict";
+
+const run = require("../testUtils");
+
+test("found-many", () => {
+	const { code, stdout, stderr } = run("config-name/found-many", [
+		"--config", "./webpack.config.js",
+		"--config-name", "bar",
+		"--output-filename", "[name].js",
+		"--output-chunk-filename", "[id].chunk.js",
+		"--target", "async-node",
+		"--mode", "production",
+	]);
+
+	expect(code).toBe(0);
+	expect(stdout).toEqual(expect.anything());
+	expect(stdout[9]).toContain("./index2.js");
+	expect(stdout[17]).toContain("./index3.js");
+	expect(stderr).toHaveLength(0);
+});
+
+test("found-one", () => {
+	const { code, stdout, stderr } = run("config-name/found-one", [
+		"--config", "./webpack.config.js",
+		"--config-name", "bar",
+		"--output-filename", "[name].js",
+		"--output-chunk-filename", "[id].chunk.js",
+		"--target", "async-node",
+	]);
+
+	expect(code).toBe(0);
+	expect(stdout).toEqual(expect.anything());
+	expect(stdout[7]).toContain("./index2.js");
+	expect(stderr).toHaveLength(0);
+});
+
+test("not-found", () => {
+	const { code, stdout, stderr } = run("config-name/not-found", [
+		"--config", "./webpack.config.js",
+		"--config-name", "foo",
+	]);
+
+	expect(code).not.toBe(0);
+	expect(stdout).toHaveLength(0);
+	expect(stderr[0]).toContain("Configuration with name 'foo' was not found.");
+});

--- a/test/binCases/config-name/found-many/stdin.js
+++ b/test/binCases/config-name/found-many/stdin.js
@@ -1,9 +1,0 @@
-"use strict";
-
-module.exports = function testAssertions(code, stdout, stderr) {
-	expect(code).toBe(0);
-	expect(stdout).toEqual(expect.anything());
-	expect(stdout[9]).toContain("./index2.js");
-	expect(stdout[17]).toContain("./index3.js");
-	expect(stderr).toHaveLength(0);
-};

--- a/test/binCases/config-name/found-many/test.opts
+++ b/test/binCases/config-name/found-many/test.opts
@@ -1,6 +1,0 @@
---config ./webpack.config.js
---config-name bar
---output-filename [name].js
---output-chunk-filename [id].chunk.js
---target async-node
---mode production

--- a/test/binCases/config-name/found-one/stdin.js
+++ b/test/binCases/config-name/found-one/stdin.js
@@ -1,8 +1,0 @@
-"use strict";
-
-module.exports = function testAssertions(code, stdout, stderr) {
-	expect(code).toBe(0);
-	expect(stdout).toEqual(expect.anything());
-	expect(stdout[7]).toContain("./index2.js");
-	expect(stderr).toHaveLength(0);
-};

--- a/test/binCases/config-name/found-one/test.opts
+++ b/test/binCases/config-name/found-one/test.opts
@@ -1,5 +1,0 @@
---config ./webpack.config.js
---config-name bar
---output-filename [name].js
---output-chunk-filename [id].chunk.js
---target async-node

--- a/test/binCases/config-name/not-found/stdin.js
+++ b/test/binCases/config-name/not-found/stdin.js
@@ -1,7 +1,0 @@
-"use strict";
-
-module.exports = function testAssertions(code, stdout, stderr) {
-	expect(code).not.toBe(0);
-	expect(stdout).toHaveLength(0);
-	expect(stderr[0]).toContain("Configuration with name 'foo' was not found.");
-};

--- a/test/binCases/config-name/not-found/test.opts
+++ b/test/binCases/config-name/not-found/test.opts
@@ -1,2 +1,0 @@
---config ./webpack.config.js
---config-name foo

--- a/test/testUtils.js
+++ b/test/testUtils.js
@@ -1,0 +1,24 @@
+"use strict";
+
+const path = require("path");
+const { sync: spawnSync } = require("execa");
+
+const WEBPACK_PATH = path.resolve(__dirname, "../bin/cli.js");
+
+function runWebpack(testCase, args) {
+	const cwd = path.resolve(__dirname, "binCases", testCase);
+	const outputPath = path.resolve(__dirname, "js/bin", testCase);
+	const argsWithOutput = args.concat("--output-path", outputPath);
+
+	const result = spawnSync(WEBPACK_PATH, argsWithOutput, {
+		cwd,
+		reject: false,
+	});
+
+	result.stdout = result.stdout === "" ? [] : result.stdout.split("\n");
+	result.stderr = result.stderr === "" ? [] : result.stderr.split("\n");
+
+	return result;
+}
+
+module.exports = runWebpack;


### PR DESCRIPTION
**What kind of change does this PR introduce?**
An alternate way of running integration tests that are based on multiple test files, instead of one large one. This allows you to use Jest's filtering and watch mode.

**Did you add tests for your changes?**
Heh...

**If relevant, did you update the documentation?**
N/A

**Summary**
See https://github.com/facebook/jest/issues/7076

This is a quick start. We can do more for e.g. options, we can make it async instead of sync etc.. This is also missing your nyc wrapper, should be easy enough to re-add, though (I want https://github.com/facebook/jest/issues/5274 to be a thing...)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
Nope

**Other information**
This is very much in progress. I don't know if you wanna migrate all tests before merging, or do it piece by piece. I'm happy to help out, but I think you should set it up with the abstractions you want yourself. And the correct abstraction often reveal themselves as you migrate more and more tests.