### PR TITLE
cli(color): fix color option

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -80,9 +80,7 @@ For more information, see https://webpack.js.org/api/cli/.`);
 			type: "boolean",
 			alias: "colors",
 			default: function supportsColor() {
-				if (process.stdout.isTTY === true) {
-					return require("supports-color").supportsColor;
-				}
+				return require("supports-color").stdout;
 			},
 			group: DISPLAY_GROUP,
 			describe: "Enables/Disables colors on the console"
@@ -324,10 +322,7 @@ For more information, see https://webpack.js.org/api/cli/.`);
 				}
 			});
 
-			if (
-				typeof outputOptions.colors === "undefined" &&
-				process.stdout.isTTY === true
-			)
+			if (typeof outputOptions.colors === "undefined")
 				outputOptions.colors = require("supports-color").stdout;
 
 			ifArg("sort-modules-by", function(value) {


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Fix `--color` option to use [supports-color](https://github.com/chalk/supports-color) properly.

**Did you add tests for your changes?**
No.

**If relevant, did you update the documentation?**
N/A
 
**Summary**
The `--color` option’s default is set to return
```js
return require("supports-color").supportsColor
```
Added in supports-color 5.0.0 (chalk/supports-color#64), `supportsColor` is a function and not the test result. Because a function is truthy, colours are enabled irrespective of TTY and `FORCE_COLOR` settings.

```js
return require("supports-color").stdout
```
is the correct way to use supports-color. It [checks](https://github.com/chalk/supports-color/blob/ed0fe39d600ff1c286b3948abbef88eaef4f8f27/index.js#L50) `process.env.isTTY` so there’s no need to do the same.

**Does this PR introduce a breaking change?**
No.

**Other information**
See #452 for the last attempted fix.