### PR TITLE
chore(dependencies): pin versions to support node 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "jest": "^23.6.0",
     "jest-cli": "^23.6.0",
     "lerna": "^3.4.0",
-    "lint-staged": "^7.2.2",
+    "lint-staged": "7.x.x",
     "nyc": "^13.0.1",
     "prettier-eslint-cli": "^4.7.1",
     "rimraf": "^2.6.2",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -13,7 +13,7 @@
     "chalk": "^2.4.1",
     "cross-spawn": "^6.0.5",
     "global-modules": "^1.0.0",
-    "got": "^8.3.2",
+    "got": "8.x.x",
     "jest": "^23.6.0",
     "jscodeshift": "^0.5.1",
     "log-symbols": "^2.2.0",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Dependencies pin

**Did you add tests for your changes?**
No

**If relevant, did you update the documentation?**
No

**Summary**
We need to start pinning dependencies that need minimum Node 8 version so that greenkeeper stops updating them.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No

**Other information**
Closes #661, #662, #664