### PR TITLE
cli(color): document --no-color option

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -83,7 +83,13 @@ For more information, see https://webpack.js.org/api/cli/.`);
 				return require("supports-color").stdout;
 			},
 			group: DISPLAY_GROUP,
-			describe: "Enables/Disables colors on the console"
+			describe: "Force colors on the console"
+		},
+		"no-color": {
+			type: "boolean",
+			alias: "no-colors",
+			group: DISPLAY_GROUP,
+			describe: "Force no colors on the console"
 		},
 		"sort-modules-by": {
 			type: "string",


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Add `--no-color` option to yargs so it shows in help.

**Did you add tests for your changes?**
No.

**If relevant, did you update the documentation?**
See webpack/webpack.js.org#2626.

**Summary**
[supports-color](https://github.com/chalk/supports-color) obeys both `--color` and `--no-color` options, but only `--color` is documented in help.

`--no-color` is a very useful feature and there’s no way to discover it without reading source code now.

**Does this PR introduce a breaking change?**
No.