### PR TITLE
docs: correct use of individual package in node env

### DIFF
--- a/packages/add/README.md
+++ b/packages/add/README.md
@@ -16,7 +16,7 @@ To run the scaffolding instance programmatically, install it as a dependency. Wh
 
 ### Node
 ```js
-const add = require("@webpack-cli/add");
+const add = require("@webpack-cli/add").default;
 add();
 ```
 

--- a/packages/generate-loader/README.md
+++ b/packages/generate-loader/README.md
@@ -17,7 +17,7 @@ To run the package programmatically, install it as a dependency. When using the 
 ### Node
 
 ```js
-const generateLoader = require("@webpack-cli/generate-loader");
+const generateLoader = require("@webpack-cli/generate-loader").default;
 generateLoader();
 ```
 

--- a/packages/generate-plugin/README.md
+++ b/packages/generate-plugin/README.md
@@ -16,7 +16,7 @@ To run the package programmatically, install it as a dependency. When using the 
 
 ### Node
 ```js
-const generatePlugin = require("@webpack-cli/generate-plugin");
+const generatePlugin = require("@webpack-cli/generate-plugin").default;
 generatePlugin();
 ```
 

--- a/packages/info/README.md
+++ b/packages/info/README.md
@@ -15,7 +15,7 @@ npm i -D @webpack-cli/info
 ### Node
 
 ```js
-const envinfo = require("@webpack-cli/info");
+const envinfo = require("@webpack-cli/info").default;
 envinfo();
 ```
 

--- a/packages/init/README.md
+++ b/packages/init/README.md
@@ -17,7 +17,7 @@ To run the package programmatically, install it as a dependency. When using the 
 ### Node
 
 ```js
-const init = require("@webpack-cli/init");
+const init = require("@webpack-cli/init").default;
 
 // this will run the default init instance
 init();

--- a/packages/migrate/README.md
+++ b/packages/migrate/README.md
@@ -16,7 +16,7 @@ To run the package programmatically, install it as a dependency. When using the 
 
 ### Node
 ```js
-const migrate = require("@webpack-cli/migrate");
+const migrate = require("@webpack-cli/migrate").default;
 
 // add null to mock process.env
 migrate(null, null, inputPath, outputPath);

--- a/packages/remove/README.md
+++ b/packages/remove/README.md
@@ -16,7 +16,7 @@ To run the scaffolding instance programmatically, install it as a dependency. Wh
 
 ### Node
 ```js
-const remove = require("@webpack-cli/remove");
+const remove = require("@webpack-cli/remove").default;
 remove();
 ```
 

--- a/packages/serve/README.md
+++ b/packages/serve/README.md
@@ -16,7 +16,7 @@ To run the scaffolding instance programmatically, install it as a dependency. Wh
 
 ### Node
 ```js
-const serve = require("@webpack-cli/serve");
+const serve = require("@webpack-cli/serve").serve;
 serve();
 ```
 

--- a/packages/update/README.md
+++ b/packages/update/README.md
@@ -16,7 +16,7 @@ To run the scaffolding instance programmatically, install it as a dependency. Wh
 
 ### Node
 ```js
-const update = require("@webpack-cli/update");
+const update = require("@webpack-cli/update").default;
 update();
 ```
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**
README docs

**Did you add tests for your changes?** NA

**If relevant, did you update the documentation?** NA

**Summary**
I found out while playing around with the examples given in the doc.
We transpile the `ts` files using babel which converts 

`export default [func/variables]` 
to 
``` bash
Object.defineProperty(exports, "__esModule", { value: true });
exports.default = default_1
```

**Does this PR introduce a breaking change?** No

