### PR TITLE
chore(ci): increase travis wait timer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install:
   - npm ci
   - npm install -g codecov
   - npm install -g eslint
-  - lerna bootstrap
+  - travis_wait lerna bootstrap
 
 jobs:
   include:


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Build related change

**Did you add tests for your changes?**
N/A

**If relevant, did you update the documentation?**
N/A

**Summary**
Since `lerna bootstrap` takes more than 10 minutes to complete especially on Node 6, the Travis build fails since no output is received for 10 minutes.
> `travis_wait` spawns a process and then writes a short line to the build log every minute for 20 minutes, extending the amount of time your command has to finish.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No

**Other information**
Closes ∞ issues