### PR TITLE
misc: not scaffold 'dist' if the user chooses default

### DIFF
--- a/packages/generators/init-generator.ts
+++ b/packages/generators/init-generator.ts
@@ -59,7 +59,6 @@ export default class InitGenerator extends Generator {
 		const self: this = this;
 		let regExpForStyles: string;
 		let ExtractUseProps: object[];
-		let outputPath: string = "dist";
 
 		process.stdout.write(
 			"\n" +
@@ -125,17 +124,9 @@ export default class InitGenerator extends Generator {
 						filename: "'[name].[chunkhash].js'",
 					};
 				}
-				if (outputTypeAnswer.outputType.length) {
-					outputPath = outputTypeAnswer.outputType;
-				}
-				// If entry is single and default output path is chosen
-				// output path is default to 'dist' by webpack
-				const isSingleEntry = typeof this.configuration.config.webpackOptions.entry === "string";
-				if (
-					!this.usingDefaults &&
-					!(outputTypeAnswer.outputType.length === 0 && isSingleEntry)
-				) {
-					this.configuration.config.webpackOptions.output.path = `path.resolve(__dirname, '${outputPath}')`;
+				if (!this.usingDefaults && outputTypeAnswer.outputType.length) {
+					this.configuration.config.webpackOptions.output.path =
+						`path.resolve(__dirname, '${outputTypeAnswer.outputType}')`;
 				}
 			})
 			.then((_: void) => {

--- a/packages/generators/init-generator.ts
+++ b/packages/generators/init-generator.ts
@@ -128,7 +128,13 @@ export default class InitGenerator extends Generator {
 				if (outputTypeAnswer.outputType.length) {
 					outputPath = outputTypeAnswer.outputType;
 				}
-				if (!this.usingDefaults) {
+				// If entry is single and default output path is chosen
+				// output path is default to 'dist' by webpack
+				const isSingleEntry = typeof this.configuration.config.webpackOptions.entry === "string";
+				if (
+					!this.usingDefaults &&
+					!(outputTypeAnswer.outputType.length === 0 && isSingleEntry)
+				) {
 					this.configuration.config.webpackOptions.output.path = `path.resolve(__dirname, '${outputPath}')`;
 				}
 			})


### PR DESCRIPTION
As mentioned in #708 , we don't need to scaffold the "dist" property in output path if the entry is single and output path is not chosen by the user.

**What kind of change does this PR introduce?**
misc
**Did you add tests for your changes?**
N/A
**If relevant, did you update the documentation?**

**Summary**

**Does this PR introduce a breaking change?**
No

**Other information**
