### PR TITLE
misc: reduce hop for creating an issue

### DIFF
--- a/packages/utils/modify-config-helper.ts
+++ b/packages/utils/modify-config-helper.ts
@@ -123,7 +123,12 @@ export default function modifyHelperUtil(
 		);
 		return runTransform(transformConfig, action);
 	}).catch((err) => {
-		console.error(chalk.red("\nUnexpected Error, please file an issue to https://github.com/webpack/webpack-cli\n"));
+		console.error(
+			chalk.red(
+				// tslint:disable-next-line:max-line-length
+				"\nUnexpected Error, please file an issue to https://github.com/webpack/webpack-cli/issues/new?template=Bug_report.md \n",
+			),
+		);
 		console.error(err);
 	});
 }

--- a/packages/utils/modify-config-helper.ts
+++ b/packages/utils/modify-config-helper.ts
@@ -125,8 +125,10 @@ export default function modifyHelperUtil(
 	}).catch((err) => {
 		console.error(
 			chalk.red(
-				// tslint:disable-next-line:max-line-length
-				"\nUnexpected Error, please file an issue to https://github.com/webpack/webpack-cli/issues/new?template=Bug_report.md \n",
+				`
+Unexpected Error
+please file an issue here https://github.com/webpack/webpack-cli/issues/new?template=Bug_report.md
+				`,
 			),
 		);
 		console.error(err);


### PR DESCRIPTION
**What kind of change does this PR introduce?**
This is more of a **feasibility** kind of change for the benefit of Issue Raiser. Please feel free to close this PR if it adds a noise.

Currently, when we face any issue while running transformation we throw an error giving an URL
https://github.com/webpack/webpack-cli/issues

However, the bug reporter has to do one more hop to create an issue.

This PR changes that URL to  https://github.com/webpack/webpack-cli/issues/new?template=Bug_report.md

**Did you add tests for your changes?**  NA

**If relevant, did you update the documentation?** NA

**Does this PR introduce a breaking change?** NO
