### PR TITLE
fix(readme): add fallback badge for dependency status

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 [![Build Status](https://travis-ci.org/webpack/webpack-cli.svg)](https://travis-ci.org/webpack/webpack-cli)
 [![Build2 Status](https://dev.azure.com/webpack/webpack/_apis/build/status/webpack.webpack-cli)](https://dev.azure.com/webpack/webpack/_build/latest?definitionId=4)
 [![Dependency Status](https://david-dm.org/webpack/webpack-cli.svg)](https://david-dm.org/webpack/webpack-cli)
+[![deps][deps]][deps-url]
 [![Code Climate](https://codeclimate.com/github/webpack/webpack-cli/badges/gpa.svg)](https://codeclimate.com/github/webpack/webpack-cli)
 [![chat on gitter](https://badges.gitter.im/webpack/webpack.svg)](https://gitter.im/webpack/webpack)
 [![Install Size](https://packagephobia.now.sh/badge?p=webpack-cli)](https://packagephobia.now.sh/result?p=webpack-cli)
@@ -70,3 +71,5 @@ You can read more about [Scaffolding](./SCAFFOLDING.md) or check out the example
 
 The webpack family welcomes any contributor, small or big. We are happy to elaborate, guide you through the source code and find issues you might want to work on! To get started have a look at our [documentation on contributing](CONTRIBUTING.md).
 
+[deps]: https://img.shields.io/david/webpack/webpack.svg
+[deps-url]: https://david-dm.org/webpack/webpack-cli


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
bugfix

**Did you add tests for your changes?**
Didn't

**If relevant, did you update the documentation?**
Yes

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
Sometimes the badge is getting broken because `david-dm.org` is still unreliable by now.
So I added a fallback image for when this happens, the same is used on [webpack README](https://github.com/webpack/webpack/blob/master/README.md).

<img width="400" alt="captura de tela 2019-01-24 as 10 08 16" src="https://user-images.githubusercontent.com/14119096/51677444-d6d55d80-1fc0-11e9-80e2-4a309d37b7d9.png">


**Does this PR introduce a breaking change?**
Doesn't.
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
