### PR TITLE
Fix: fix postinstall lightercollective script when using --no-bin-links (#738)

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "travis:lint": "npm run build && npm run lint && npm run tslint",
     "tslint": "tslint -c tslint.json \"packages/**/*.ts\"",
     "watch": "npm run build && tsc -w",
-    "postinstall": "lightercollective"
+    "postinstall": "node ./../lightercollective/index.js"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bugfix

**Did you add tests for your changes?**
I tested this change manually, see summary

**If relevant, did you update the documentation?**
No

**Summary**
Bugfix for #738. The current `postinstall` script relies on `lightercollective` being available in `bin` which does not work when installing with `--no-bin-links`.

Manual tests were run with Yarn and NPM (with the same result). Yarn output below:

---

<details>
  <summary>Output without this change</summary>

```
PS D:\Dokumente\GitHub\test> yarn add webpack-cli --no-bin-links
yarn add v1.13.0
info No lockfile found.
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
warning " > webpack-cli@3.2.1" has unmet peer dependency "webpack@4.x.x".
[4/4] Building fresh packages...
error D:\Dokumente\GitHub\test\node_modules\webpack-cli: Command failed.
Exit code: 1
Command: lightercollective
Arguments:
Directory: D:\Dokumente\GitHub\test\node_modules\webpack-cli
Output:
Der Befehl "lightercollective" ist entweder falsch geschrieben oder
konnte nicht gefunden werden.
info Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.
```
</details>

<details>
  <summary>Output with this change</summary>

```
PS D:\Dokumente\GitHub\test> yarn add https://github.com/vintagesucks/webpack-cli#lightercollective-postinstall-fix --no-bin-links
yarn add v1.13.0
info No lockfile found.
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
warning " > webpack-cli@3.2.1" has unmet peer dependency "webpack@4.x.x".
[4/4] Building fresh packages...
success Saved lockfile.
success Saved 141 new dependencies.
info Direct dependencies
└─ webpack-cli@3.2.1
info All dependencies
├─ ansi-regex@2.1.1
├─ ansi-styles@3.2.1
├─ arr-flatten@1.1.0
├─ assign-symbols@1.0.0
├─ atob@2.1.2
├─ base@0.11.2
├─ big.js@5.2.2
├─ braces@2.3.2
├─ cache-base@1.0.1
├─ camelcase@5.0.0
├─ chalk@2.4.2
├─ class-utils@0.3.6
├─ cliui@4.1.0
├─ code-point-at@1.1.0
├─ collection-visit@1.0.0
├─ color-convert@1.9.3
├─ color-name@1.1.3
├─ copy-descriptor@0.1.1
├─ core-util-is@1.0.2
├─ cross-spawn@6.0.5
├─ debug@2.6.9
├─ decode-uri-component@0.2.0
├─ detect-file@1.0.0
├─ emojis-list@2.1.0
├─ end-of-stream@1.4.1
├─ enhanced-resolve@4.1.0
├─ errno@0.1.7
├─ escape-string-regexp@1.0.5
├─ execa@1.0.0
├─ expand-brackets@2.1.4
├─ expand-tilde@2.0.2
├─ extglob@2.0.4
├─ fill-range@4.0.0
├─ findup-sync@2.0.0
├─ for-in@1.0.2
├─ get-caller-file@1.0.3
├─ get-stream@4.1.0
├─ get-value@2.0.6
├─ global-modules-path@2.3.1
├─ global-prefix@1.0.2
├─ graceful-fs@4.1.15
├─ has-flag@3.0.0
├─ has-value@1.0.0
├─ has-values@1.0.0
├─ import-local@2.0.0
├─ inherits@2.0.3
├─ ini@1.3.5
├─ interpret@1.2.0
├─ invert-kv@2.0.0
├─ is-accessor-descriptor@1.0.0
├─ is-data-descriptor@1.0.0
├─ is-descriptor@1.0.2
├─ is-extglob@2.1.1
├─ is-fullwidth-code-point@2.0.0
├─ is-glob@3.1.0
├─ is-plain-object@2.0.4
├─ is-stream@1.1.0
├─ is-windows@1.0.2
├─ isarray@1.0.0
├─ isexe@2.0.0
├─ json5@1.0.1
├─ kind-of@3.2.2
├─ lcid@2.0.0
├─ lightercollective@0.1.0
├─ loader-utils@1.2.3
├─ locate-path@3.0.0
├─ map-age-cleaner@0.1.3
├─ map-visit@1.0.0
├─ mem@4.0.0
├─ memory-fs@0.4.1
├─ micromatch@3.1.10
├─ mimic-fn@1.2.0
├─ minimist@1.2.0
├─ mixin-deep@1.3.1
├─ ms@2.0.0
├─ nanomatch@1.2.13
├─ nice-try@1.0.5
├─ npm-run-path@2.0.2
├─ number-is-nan@1.0.1
├─ object-copy@0.1.0
├─ once@1.4.0
├─ os-locale@3.1.0
├─ p-defer@1.0.0
├─ p-finally@1.0.0
├─ p-is-promise@1.1.0
├─ p-limit@2.1.0
├─ p-locate@3.0.0
├─ p-try@2.0.0
├─ parse-passwd@1.0.0
├─ pascalcase@0.1.1
├─ path-exists@3.0.0
├─ path-key@2.0.1
├─ pkg-dir@3.0.0
├─ posix-character-classes@0.1.1
├─ process-nextick-args@2.0.0
├─ prr@1.0.1
├─ pump@3.0.0
├─ readable-stream@2.3.6
├─ repeat-element@1.1.3
├─ require-directory@2.1.1
├─ require-main-filename@1.0.1
├─ resolve-cwd@2.0.0
├─ resolve-dir@1.0.1
├─ resolve-from@3.0.0
├─ resolve-url@0.2.1
├─ ret@0.1.15
├─ safe-buffer@5.1.2
├─ semver@5.6.0
├─ set-blocking@2.0.0
├─ set-value@2.0.0
├─ shebang-command@1.2.0
├─ shebang-regex@1.0.0
├─ signal-exit@3.0.2
├─ snapdragon-node@2.1.1
├─ snapdragon-util@3.0.1
├─ source-map-resolve@0.5.2
├─ source-map-url@0.4.0
├─ source-map@0.5.7
├─ split-string@3.1.0
├─ static-extend@0.1.2
├─ string_decoder@1.1.1
├─ string-width@2.1.1
├─ strip-ansi@3.0.1
├─ strip-eof@1.0.0
├─ supports-color@5.5.0
├─ tapable@1.1.1
├─ to-regex-range@2.1.1
├─ union-value@1.0.0
├─ unset-value@1.0.0
├─ urix@0.1.0
├─ use@3.1.1
├─ util-deprecate@1.0.2
├─ v8-compile-cache@2.0.2
├─ webpack-cli@3.2.1
├─ which-module@2.0.0
├─ which@1.3.1
├─ wrap-ansi@2.1.0
├─ wrappy@1.0.2
├─ y18n@4.0.0
├─ yargs-parser@11.1.1
└─ yargs@12.0.5
Done in 15.49s.
```
</details>

---

**Does this PR introduce a breaking change?**
No

**Other information**
None