### PR TITLE
docs(scaffolding): Correction of the webpack-merge configuration

### DIFF
--- a/SCAFFOLDING.md
+++ b/SCAFFOLDING.md
@@ -60,11 +60,17 @@ As with a regular webpack configuration, this property behaves the same. Inside 
 ```js
 this.options.env.configuration.dev.webpackOptions = {
 entry: '\'app.js\'',
-output: {....},
-merge: 'myConfig'
+output: {....}
 };
 ```
-If you want to use `webpack-merge`, you can supply `webpackOptions` with the merge property, and the configuration you want to merge it with. 
+
+### `myObj.merge` (optional)
+
+If you want to use `webpack-merge`, you can supply `merge` with the merge property, and the configuration you want to merge it with. 
+
+```js
+this.options.env.configuration.dev.merge = 'myConfig';
+```
 
 ### `myObj.topScope`(optional)
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**
You can reconnect configurations with merge, which according to the current documentation in SCAFFOLDING.md is not given.
After several attempts and my question on stackoverflow, i found the problem show in link under comment.
[webpack-scaffold-webpackoptions-merge-not-work-why](https://stackoverflow.com/questions/54350271/webpack-scaffold-webpackoptions-merge-not-work-why)

**Did you add tests for your changes?**
Yes I am currently creating a complex scaffold with webpack and will upload it to github as soon as I get there ready.

**If relevant, did you update the documentation?**
Yes, I have updated the documentation, so this is about the documentation. Webpack-CLI works powerfully, thanks for that.

**Summary**
The change improves a wrong documentation in the SCAFFOLDING.md to webpack-merge this is passed in the current file of the webpackOptions. And this does not work, i found out after looking into this file: [webpack-cli/utils/modify-config-helper.ts](https://github.com/webpack/webpack-cli/blob/eb06af8c2994cd1fea8d2c687de16bbf2f10095a/packages/utils/modify-config-helper.ts)

**Does this PR introduce a breaking change?**
The impact is that the documentation is corrected and you can connect its configs with merge, as this is just not possible according to the description in SCAFFOLDING.md.

**Other information**
Thanks to the whole Webpack team 🥇for Webpack
