### PR TITLE
fix(bin): use compiler.close API correctly for stats

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -251,7 +251,7 @@ For more information, see https://webpack.js.org/api/cli/.`);
 		const stdout = argv.silent
 			? {
 				write: () => {}
-			  } // eslint-disable-line
+				} // eslint-disable-line
 			: process.stdout;
 
 		function ifArg(name, fn, init) {
@@ -488,13 +488,18 @@ For more information, see https://webpack.js.org/api/cli/.`);
 				}
 				compiler.watch(watchOptions, compilerCallback);
 				if (outputOptions.infoVerbosity !== "none") console.error("\nwebpack is watching the files…\n");
-				if (compiler.close) compiler.close(compilerCallback);
 			} else {
-				compiler.run(compilerCallback);
-				if (compiler.close) compiler.close(compilerCallback);
+				compiler.run((err, stats) => {
+					if (compiler.close) {
+						compiler.close(err2 => {
+							compilerCallback(err || err2, stats);
+						});
+					} else {
+						compilerCallback(err, stats);
+					}
+				});
 			}
 		}
-
 		processOptions(options);
 	});
 })();


### PR DESCRIPTION
ISSUES CLOSED: #762

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
Bugfix

**Did you add tests for your changes?**
Will be done by @dhruvdutt in #758 

**If relevant, did you update the documentation?**
N/A

**Summary**
`compiler.close` was not calling the compiler callback correctly and therefore stats were null. In addition compiler will never close in watch mode. Removed. 
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
