### PR TITLE
tests(migration): including requested changes

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -12,7 +12,6 @@ module.exports = {
 		"body-leading-blank": [1, "always"],
 		"footer-leading-blank": [1, "always"],
 		"header-max-length": [2, "always", 80],
-		lang: [0, "always", "eng"],
 		"scope-case": [2, "always", "lowerCase"],
 		"scope-empty": [0, "never"],
 		"subject-case": [2, "never", ["sentence-case", "start-case", "pascal-case", "upper-case"]],

--- a/packages/migrate/bannerPlugin/__tests__/bannerPlugin.test.ts
+++ b/packages/migrate/bannerPlugin/__tests__/bannerPlugin.test.ts
@@ -1,6 +1,8 @@
 import defineTest from "@webpack-cli/utils/defineTest";
 import { join } from "path";
 
-defineTest(join(__dirname, ".."), "bannerPlugin", "bannerPlugin-0");
-defineTest(join(__dirname, ".."), "bannerPlugin", "bannerPlugin-1");
-defineTest(join(__dirname, ".."), "bannerPlugin", "bannerPlugin-2");
+const dirName: string = join(__dirname, "..");
+
+defineTest(dirName, "bannerPlugin", "bannerPlugin-0");
+defineTest(dirName, "bannerPlugin", "bannerPlugin-1");
+defineTest(dirName, "bannerPlugin", "bannerPlugin-2");

--- a/packages/migrate/commonsChunkPlugin/__tests__/commonsChunkPlugin.test.ts
+++ b/packages/migrate/commonsChunkPlugin/__tests__/commonsChunkPlugin.test.ts
@@ -1,30 +1,32 @@
 import defineTest from "@webpack-cli/utils/defineTest";
 import { join } from "path";
 
-defineTest(join(__dirname, ".."), "commonsChunkPlugin", "commonsChunkPlugin-0");
-defineTest(join(__dirname, ".."), "commonsChunkPlugin", "commonsChunkPlugin-1");
-defineTest(join(__dirname, ".."), "commonsChunkPlugin", "commonsChunkPlugin-2");
-defineTest(join(__dirname, ".."), "commonsChunkPlugin", "commonsChunkPlugin-3");
-defineTest(join(__dirname, ".."), "commonsChunkPlugin", "commonsChunkPlugin-4");
-defineTest(join(__dirname, ".."), "commonsChunkPlugin", "commonsChunkPlugin-5");
+const dirName: string = join(__dirname, "..");
+
+defineTest(dirName, "commonsChunkPlugin", "commonsChunkPlugin-0");
+defineTest(dirName, "commonsChunkPlugin", "commonsChunkPlugin-1");
+defineTest(dirName, "commonsChunkPlugin", "commonsChunkPlugin-2");
+defineTest(dirName, "commonsChunkPlugin", "commonsChunkPlugin-3");
+defineTest(dirName, "commonsChunkPlugin", "commonsChunkPlugin-4");
+defineTest(dirName, "commonsChunkPlugin", "commonsChunkPlugin-5");
 defineTest(
-  join(__dirname, ".."),
+  dirName,
   "commonsChunkPlugin",
   "commonsChunkPlugin-6a",
 );
 defineTest(
-  join(__dirname, ".."),
+  dirName,
   "commonsChunkPlugin",
   "commonsChunkPlugin-6b",
 );
 defineTest(
-  join(__dirname, ".."),
+  dirName,
   "commonsChunkPlugin",
   "commonsChunkPlugin-6c",
 );
 defineTest(
-  join(__dirname, ".."),
+  dirName,
   "commonsChunkPlugin",
   "commonsChunkPlugin-6d",
 );
-defineTest(join(__dirname, ".."), "commonsChunkPlugin", "commonsChunkPlugin-7");
+defineTest(dirName, "commonsChunkPlugin", "commonsChunkPlugin-7");

--- a/packages/migrate/extractTextPlugin/__tests__/extractTextPlugin.test.ts
+++ b/packages/migrate/extractTextPlugin/__tests__/extractTextPlugin.test.ts
@@ -1,4 +1,5 @@
 import defineTest from "@webpack-cli/utils/defineTest";
 import { join } from "path";
 
-defineTest(join(__dirname, ".."), "extractTextPlugin");
+const dirName: string = join(__dirname, "..");
+defineTest(dirName, "extractTextPlugin");

--- a/packages/migrate/index.ts
+++ b/packages/migrate/index.ts
@@ -17,7 +17,7 @@ declare var process: {
 	webpackModule: {
 		validate: Function;
 		WebpackOptionsValidationError: {
-			new(errors: string[]): {
+			new: (errors: string[]) => {
 				message: string;
 			};
 		};

--- a/packages/migrate/loaderOptionsPlugin/__tests__/loaderOptionsPlugin.test.ts
+++ b/packages/migrate/loaderOptionsPlugin/__tests__/loaderOptionsPlugin.test.ts
@@ -1,22 +1,25 @@
 import defineTest from "@webpack-cli/utils/defineTest";
 import { join } from "path";
+
+const dirName: string = join(__dirname, "..");
+
 defineTest(
-  join(__dirname, ".."),
+  dirName,
   "loaderOptionsPlugin",
   "loaderOptionsPlugin-0",
 );
 defineTest(
-  join(__dirname, ".."),
+  dirName,
   "loaderOptionsPlugin",
   "loaderOptionsPlugin-1",
 );
 defineTest(
-  join(__dirname, ".."),
+  dirName,
   "loaderOptionsPlugin",
   "loaderOptionsPlugin-2",
 );
 defineTest(
-  join(__dirname, ".."),
+  dirName,
   "loaderOptionsPlugin",
   "loaderOptionsPlugin-3",
 );

--- a/packages/migrate/loaders/__tests__/loaders.test.ts
+++ b/packages/migrate/loaders/__tests__/loaders.test.ts
@@ -1,12 +1,14 @@
 import defineTest from "@webpack-cli/utils/defineTest";
 import { join } from "path";
 
-defineTest(join(__dirname, ".."), "loaders", "loaders-0");
-defineTest(join(__dirname, ".."), "loaders", "loaders-1");
-defineTest(join(__dirname, ".."), "loaders", "loaders-2");
-defineTest(join(__dirname, ".."), "loaders", "loaders-3");
-defineTest(join(__dirname, ".."), "loaders", "loaders-4");
-defineTest(join(__dirname, ".."), "loaders", "loaders-5");
-defineTest(join(__dirname, ".."), "loaders", "loaders-6");
-defineTest(join(__dirname, ".."), "loaders", "loaders-7");
-defineTest(join(__dirname, ".."), "loaders", "loaders-8");
+const dirName: string = join(__dirname, "..");
+
+defineTest(dirName, "loaders", "loaders-0");
+defineTest(dirName, "loaders", "loaders-1");
+defineTest(dirName, "loaders", "loaders-2");
+defineTest(dirName, "loaders", "loaders-3");
+defineTest(dirName, "loaders", "loaders-4");
+defineTest(dirName, "loaders", "loaders-5");
+defineTest(dirName, "loaders", "loaders-6");
+defineTest(dirName, "loaders", "loaders-7");
+defineTest(dirName, "loaders", "loaders-8");

--- a/packages/migrate/migrate.ts
+++ b/packages/migrate/migrate.ts
@@ -40,12 +40,25 @@ const transformsObject: ITransformsObject = {
 	removeDeprecatedPluginsTransform,
 	commonsChunkPluginTransform,
 };
+
+interface ILazyTransformObject {
+	loadersTransform?: (ast: object, source: string) => pLazy<{}>;
+	resolveTransform?: (ast: object, source: string) => pLazy<{}>;
+	removeJsonLoaderTransform?: (ast: object, source: string) => pLazy<{}>;
+	uglifyJsPluginTransform?: (ast: object, source: string) => pLazy<{}>;
+	loaderOptionsPluginTransform?: (ast: object, source: string) => pLazy<{}>;
+	bannerPluginTransform?: (ast: object, source: string) => pLazy<{}>;
+	extractTextPluginTransform?: (ast: object, source: string) => pLazy<{}>;
+	noEmitOnErrorsPluginTransform?: (ast: object, source: string) => pLazy<{}>;
+	removeDeprecatedPluginsTransform?: (ast: object, source: string) => pLazy<{}>;
+	commonsChunkPluginTransform?: (ast: object, source: string) => pLazy<{}>;
+}
 /* tslint:enable object-literal-sort-keys */
 
-export const transformations: any =
+export const transformations: ILazyTransformObject =
 	Object
 		.keys(transformsObject)
-		.reduce((res: object, key: string): object => {
+		.reduce((res: object, key: string): ILazyTransformObject => {
 			res[key] = (ast: object, source: string) =>
 				transformSingleAST(ast, source, transformsObject[key]);
 			return res;

--- a/packages/migrate/moduleConcatenationPlugin/__tests__/moduleConcatenationPlugin.test.ts
+++ b/packages/migrate/moduleConcatenationPlugin/__tests__/moduleConcatenationPlugin.test.ts
@@ -1,18 +1,20 @@
 import defineTest from "@webpack-cli/utils/defineTest";
 import { join } from "path";
 
+const dirName: string = join(__dirname, "..");
+
 defineTest(
-  join(__dirname, ".."),
+  dirName,
   "moduleConcatenationPlugin",
   "moduleConcatenationPlugin-0",
 );
 defineTest(
-  join(__dirname, ".."),
+  dirName,
   "moduleConcatenationPlugin",
   "moduleConcatenationPlugin-1",
 );
 defineTest(
-  join(__dirname, ".."),
+  dirName,
   "moduleConcatenationPlugin",
   "moduleConcatenationPlugin-2",
 );

--- a/packages/migrate/namedModulesPlugin/__tests__/namedModulesPlugin.test.ts
+++ b/packages/migrate/namedModulesPlugin/__tests__/namedModulesPlugin.test.ts
@@ -1,5 +1,8 @@
 import defineTest from "@webpack-cli/utils/defineTest";
 import { join } from "path";
-defineTest(join(__dirname, ".."), "namedModulesPlugin", "namedModulesPlugin-0");
-defineTest(join(__dirname, ".."), "namedModulesPlugin", "namedModulesPlugin-1");
-defineTest(join(__dirname, ".."), "namedModulesPlugin", "namedModulesPlugin-2");
+
+const dirName: string = join(__dirname, "..");
+
+defineTest(dirName, "namedModulesPlugin", "namedModulesPlugin-0");
+defineTest(dirName, "namedModulesPlugin", "namedModulesPlugin-1");
+defineTest(dirName, "namedModulesPlugin", "namedModulesPlugin-2");

--- a/packages/migrate/noEmitOnErrorsPlugin/__tests__/noEmitOnErrorsPlugin.test.ts
+++ b/packages/migrate/noEmitOnErrorsPlugin/__tests__/noEmitOnErrorsPlugin.test.ts
@@ -1,17 +1,20 @@
 import defineTest from "@webpack-cli/utils/defineTest";
 import { join } from "path";
+
+const dirName: string = join(__dirname, "..");
+
 defineTest(
-  join(__dirname, ".."),
+  dirName,
   "noEmitOnErrorsPlugin",
   "noEmitOnErrorsPlugin-0",
 );
 defineTest(
-  join(__dirname, ".."),
+  dirName,
   "noEmitOnErrorsPlugin",
   "noEmitOnErrorsPlugin-1",
 );
 defineTest(
-  join(__dirname, ".."),
+  dirName,
   "noEmitOnErrorsPlugin",
   "noEmitOnErrorsPlugin-2",
 );

--- a/packages/migrate/outputPath/__tests__/outputPath.test.ts
+++ b/packages/migrate/outputPath/__tests__/outputPath.test.ts
@@ -1,6 +1,8 @@
 import defineTest from "@webpack-cli/utils/defineTest";
 import { join } from "path";
 
-defineTest(join(__dirname, ".."), "outputPath", "outputPath-0");
-defineTest(join(__dirname, ".."), "outputPath", "outputPath-1");
-defineTest(join(__dirname, ".."), "outputPath", "outputPath-2");
+const dirName: string = join(__dirname, "..");
+
+defineTest(dirName, "outputPath", "outputPath-0");
+defineTest(dirName, "outputPath", "outputPath-1");
+defineTest(dirName, "outputPath", "outputPath-2");

--- a/packages/migrate/removeDeprecatedPlugins/__tests__/removeDeprecatedPlugins.test.ts
+++ b/packages/migrate/removeDeprecatedPlugins/__tests__/removeDeprecatedPlugins.test.ts
@@ -1,28 +1,30 @@
 import defineTest from "@webpack-cli/utils/defineTest";
 import { join } from "path";
 
+const dirName: string = join(__dirname, "..");
+
 defineTest(
-  join(__dirname, ".."),
+  dirName,
   "removeDeprecatedPlugins",
   "removeDeprecatedPlugins-0",
 );
 defineTest(
-  join(__dirname, ".."),
+  dirName,
   "removeDeprecatedPlugins",
   "removeDeprecatedPlugins-1",
 );
 defineTest(
-  join(__dirname, ".."),
+  dirName,
   "removeDeprecatedPlugins",
   "removeDeprecatedPlugins-2",
 );
 defineTest(
-  join(__dirname, ".."),
+  dirName,
   "removeDeprecatedPlugins",
   "removeDeprecatedPlugins-3",
 );
 defineTest(
-  join(__dirname, ".."),
+  dirName,
   "removeDeprecatedPlugins",
   "removeDeprecatedPlugins-4",
 );

--- a/packages/migrate/removeJsonLoader/__tests__/removeJsonLoader.test.ts
+++ b/packages/migrate/removeJsonLoader/__tests__/removeJsonLoader.test.ts
@@ -1,22 +1,25 @@
 import defineTest from "@webpack-cli/utils/defineTest";
-import * as path from "path";
+import { join } from "path";
+
+const dirName: string = join(__dirname, "..");
+
 defineTest(
-  path.join(__dirname, ".."),
+  dirName,
   "removeJsonLoader",
   "removeJsonLoader-0",
 );
 defineTest(
-  path.join(__dirname, ".."),
+  dirName,
   "removeJsonLoader",
   "removeJsonLoader-1",
 );
 defineTest(
-  path.join(__dirname, ".."),
+  dirName,
   "removeJsonLoader",
   "removeJsonLoader-2",
 );
 defineTest(
-  path.join(__dirname, ".."),
+  dirName,
   "removeJsonLoader",
   "removeJsonLoader-3",
 );

--- a/packages/migrate/resolve/__tests__/__snapshots__/resolve.test.ts.snap
+++ b/packages/migrate/resolve/__tests__/__snapshots__/resolve.test.ts.snap
@@ -1,26 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`resolve transforms correctly 1`] = `
-"const path = require(\\"patch\\");
+"const path = require(\\"path\\");
+const rootPath = path.resolve(\\"/src\\");
 module.exports = [
 	{
 		resolve: {
-			modules: [path.resolve(\\"/src\\")]
+			modules: [rootPath]
 		}
 	},
 	{
 		resolve: {
-			modules: [path.resolve(\\"/src\\")]
+			modules: [rootPath]
 		}
 	},
 	{
 		resolve: {
-			modules: [path.resolve(\\"/src\\"), \\"node_modules\\"]
+			modules: [rootPath, \\"node_modules\\"]
 		}
 	},
 	{
 		resolve: {
-            modules: [\\"node_modules\\", path.resolve(\\"/src\\")]
+            modules: [\\"node_modules\\", rootPath]
         }
 	}
 ];

--- a/packages/migrate/resolve/__tests__/__testfixtures__/resolve.input.js
+++ b/packages/migrate/resolve/__tests__/__testfixtures__/resolve.input.js
@@ -1,6 +1,5 @@
-const { resolve } = require("patch");
-
-const rootPath = resolve("/src");
+const path = require("path");
+const rootPath = path.resolve("/src");
 module.exports = [
 	{
 		resolve: {

--- a/packages/migrate/resolve/__tests__/__testfixtures__/resolve.input.js
+++ b/packages/migrate/resolve/__tests__/__testfixtures__/resolve.input.js
@@ -1,24 +1,26 @@
-const path = require("patch");
+const { resolve } = require("patch");
+
+const rootPath = resolve("/src");
 module.exports = [
 	{
 		resolve: {
-			root: path.resolve("/src")
+			root: rootPath
 		}
 	},
 	{
 		resolve: {
-			root: [path.resolve("/src")]
+			root: [rootPath]
 		}
 	},
 	{
 		resolve: {
-			root: [path.resolve("/src"), "node_modules"]
+			root: [rootPath, "node_modules"]
 		}
 	},
 	{
 		resolve: {
 			modules: ["node_modules"],
-			root: path.resolve("/src")
+			root: rootPath
 		}
 	}
 ];

--- a/packages/migrate/resolve/__tests__/resolve.test.ts
+++ b/packages/migrate/resolve/__tests__/resolve.test.ts
@@ -1,4 +1,5 @@
 import defineTest from "@webpack-cli/utils/defineTest";
 import { join } from "path";
 
-defineTest(join(__dirname, ".."), "resolve");
+const dirName: string = join(__dirname, "..");
+defineTest(dirName, "resolve");

--- a/packages/migrate/resolve/__tests__/resolve.test.ts
+++ b/packages/migrate/resolve/__tests__/resolve.test.ts
@@ -1,4 +1,4 @@
 import defineTest from "@webpack-cli/utils/defineTest";
-import * as path from "path";
+import { join } from "path";
 
-defineTest(path.join(__dirname, ".."), "resolve");
+defineTest(join(__dirname, ".."), "resolve");

--- a/packages/migrate/uglifyJsPlugin/__tests__/uglifyJsPlugin.test.ts
+++ b/packages/migrate/uglifyJsPlugin/__tests__/uglifyJsPlugin.test.ts
@@ -1,7 +1,10 @@
 import defineTest from "@webpack-cli/utils/defineTest";
 import { join } from "path";
-defineTest(join(__dirname, ".."), "uglifyJsPlugin", "uglifyJsPlugin-0");
-defineTest(join(__dirname, ".."), "uglifyJsPlugin", "uglifyJsPlugin-1");
-defineTest(join(__dirname, ".."), "uglifyJsPlugin", "uglifyJsPlugin-2");
-defineTest(join(__dirname, ".."), "uglifyJsPlugin", "uglifyJsPlugin-3");
-defineTest(join(__dirname, ".."), "uglifyJsPlugin", "uglifyJsPlugin-4");
+
+const dirName: string = join(__dirname, "..");
+
+defineTest(dirName, "uglifyJsPlugin", "uglifyJsPlugin-0");
+defineTest(dirName, "uglifyJsPlugin", "uglifyJsPlugin-1");
+defineTest(dirName, "uglifyJsPlugin", "uglifyJsPlugin-2");
+defineTest(dirName, "uglifyJsPlugin", "uglifyJsPlugin-3");
+defineTest(dirName, "uglifyJsPlugin", "uglifyJsPlugin-4");

--- a/packages/utils/__tests__/ast-utils.test.ts
+++ b/packages/utils/__tests__/ast-utils.test.ts
@@ -313,7 +313,7 @@ const a = { plugs: [] }
 
 			const root = ast.find(j.ObjectExpression);
 
-			utils.findRootNodesByName(j, root, "entry").forEach((p) => {
+			utils.findRootNodesByName(j, root, "entry").forEach((p: INode) => {
 				j(p).replaceWith(utils.addProperty(j, p, "entry", propertyValue, "add"));
 			});
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Includes changes requested in #613 

**Summary**

Before committing I had to solve those issues:

- Removed [deprecated](https://conventional-changelog.github.io/commitlint/#/reference-rules?id=lang-deprecated) `lang: [0, "always", "eng"]` from commitlint configuration. It gave me errors preventing me from committing:
    >RangeError: Found invalid rule names: lang. Supported rule names are: body-case, body-empty

- Fixed a tslint error:
```
 ERROR: packages/migrate/index.ts:20:4 - Type literal has only a call signature — use 
`new(errors: string[]) => {
    message: string;
},` instead.
```

Those are the actual changes:
1. Adds an interface to `transformations` in `packages/migrate/migrate.ts`
2. Refactor every test in `migrate/**/__tests__/**.test.ts` 
```ts
//before
defineTest(join(__dirname, ".."), "resolve");

//after
const dirName: string = path.join(__dirname, "..");
defineTest(dirName, "resolve");
```
3. Adds a type notation in `packages/utils/__tests__/ast-utils.test.ts`


4. I've also refactored `packages/migrate/resolve/__tests__/__testfixtures__/resolve.input.js` following [this](https://github.com/webpack/webpack-cli/pull/613/files#r241777569) comment.
There's something I don't understand well, changing `const path = require("path")` with `const {resolve} = require("path")` gives me an error:
<img width="813" alt="screenshot 2019-02-19 at 20 38 23" src="https://user-images.githubusercontent.com/11232797/53042459-9ca79080-3486-11e9-8c42-4d8cd5c68565.png">

Why does this happens?

Feedbacks are welcome :)