### PR TITLE
docs(readme): add downloads badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 	</a>
 </div>
 
-<h1 align="center">Webpack CLI</h1>
+<h1 align="center">webpack CLI</h1>
 
 <p align="center">
   The official CLI of webpack

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 		<img width="200" height="200" src="https://webpack.js.org/assets/icon-square-big.svg">
 	</a>
 </div>
+
+<h1 align="center">Webpack CLI</h1>
+
 <p align="center">
   The official CLI of webpack
 </p>
@@ -15,8 +18,8 @@
 [![Code Climate](https://codeclimate.com/github/webpack/webpack-cli/badges/gpa.svg)](https://codeclimate.com/github/webpack/webpack-cli)
 [![chat on gitter](https://badges.gitter.im/webpack/webpack.svg)](https://gitter.im/webpack/webpack)
 [![Install Size](https://packagephobia.now.sh/badge?p=webpack-cli)](https://packagephobia.now.sh/result?p=webpack-cli)
+[![npm](https://img.shields.io/npm/dw/webpack-cli.svg)](https://www.npmjs.com/package/webpack-cli)
 
-# webpack CLI
 
 * [About](#about)
   - [How to install](#how-to-install)


### PR DESCRIPTION
Add downloads badge from npm which shows downloads per week

[![npm](https://img.shields.io/npm/dw/webpack-cli.svg)](https://www.npmjs.com/package/webpack-cli)

ISSUES CLOSED: #778

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
docs/feat
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
Yes

**If relevant, did you update the documentation?**
Yes

**Summary**
* Just added a simple npm downloads badge in readme which shows weekly downloads, can do it total, by year or month too as per feedback.
* Also placed the heading below the webpack image in readme which imo looks better, please suggest if this should be reverted. 😄 
![image](https://user-images.githubusercontent.com/21009455/53937719-ed98c500-40d3-11e9-97cf-f6a464bf0b1a.png)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
No