### PR TITLE
fix(init): refactored the init.ts success message

### DIFF
--- a/packages/init/init.ts
+++ b/packages/init/init.ts
@@ -77,13 +77,10 @@ export default function runTransform(webpackProperties: IWebpackProperties, acti
 				console.error(err.message ? err.message : err);
 			});
 	});
-	let successMessage: string = ``;
 
+	let successMessage: string = `Congratulations! Your new webpack configuration file has been created!`;
 	if (initActionNotDefined && webpackProperties.config.item) {
 		successMessage = `Congratulations! ${webpackProperties.config.item} has been ${action}ed!`;
-
-	} else {
-		successMessage = "Congratulations! Your new webpack configuration file has been created!";
 
 	}
 	process.stdout.write("\n" + chalk.green(`${successMessage}\n`));

--- a/packages/init/init.ts
+++ b/packages/init/init.ts
@@ -77,22 +77,14 @@ export default function runTransform(webpackProperties: IWebpackProperties, acti
 				console.error(err.message ? err.message : err);
 			});
 	});
+	let successMessage: string = ``;
 
 	if (initActionNotDefined && webpackProperties.config.item) {
-		process.stdout.write(
-			"\n" +
-				chalk.green(
-					`Congratulations! ${
-						webpackProperties.config.item
-					} has been ${action}ed!\n`,
-				),
-		);
+		successMessage = `Congratulations! ${webpackProperties.config.item} has been ${action}ed!`;
+
 	} else {
-		process.stdout.write(
-			"\n" +
-				chalk.green(
-					"Congratulations! Your new webpack configuration file has been created!\n",
-				),
-		);
+		successMessage = "Congratulations! Your new webpack configuration file has been created!";
+
 	}
+	process.stdout.write("\n" + chalk.green(`${successMessage}\n`));
 }


### PR DESCRIPTION
Previously there was multiple `stdout.write` due to the presence of conditional statements. In this PR I have scrapped those repeating lines into a single `process.stdout.write`

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Refactoring

**Did you add tests for your changes?**
No

**If relevant, did you update the documentation?**
Can't say

**Does this PR introduce a breaking change?**
Probably not
