### PR TITLE
fix(bin, serve): force default package export, add serve default

### DIFF
--- a/bin/utils/prompt-command.js
+++ b/bin/utils/prompt-command.js
@@ -37,6 +37,15 @@ const npmGlobalRoot = () => {
 	});
 };
 
+const runWhenInstalled = (packages, pathForCmd, ...args) => {
+	const package = require(pathForCmd);
+	const func = package.default;
+	if (typeof func !== 'function') {
+		throw new Error(`@webpack-cli/${packages} failed to export a default function`);
+	}
+	return func(...args);
+}
+
 module.exports = function promptForInstallation(packages, ...args) {
 	const nameOfPackage = "@webpack-cli/" + packages;
 	let packageIsInstalled = false;
@@ -113,10 +122,7 @@ module.exports = function promptForInstallation(packages, ...args) {
 							}
 
 							pathForCmd = path.resolve(process.cwd(), "node_modules", "@webpack-cli", packages);
-							if (packages === "serve") {
-								return require(pathForCmd).default.serve();
-							}
-							return require(pathForCmd).default(...args); //eslint-disable-line
+							return runWhenInstalled(packages, pathForCmd, ...args);
 						})
 						.catch(error => {
 							console.error(error);
@@ -132,6 +138,6 @@ module.exports = function promptForInstallation(packages, ...args) {
 			}
 		});
 	} else {
-		require(pathForCmd).default(...args); // eslint-disable-line
+		return runWhenInstalled(packages, pathForCmd, ...args);
 	}
 };

--- a/packages/serve/README.md
+++ b/packages/serve/README.md
@@ -16,7 +16,7 @@ To run the scaffolding instance programmatically, install it as a dependency. Wh
 
 ### Node
 ```js
-const serve = require("@webpack-cli/serve").serve;
+const serve = require("@webpack-cli/serve").default;
 serve();
 ```
 

--- a/packages/serve/index.ts
+++ b/packages/serve/index.ts
@@ -47,11 +47,11 @@ const getRootPathModule = (dep: string): string => path.resolve(process.cwd(), d
  *
  * Prompts for installing the devServer and running it
  *
- * @param {Object} args - args processed from the CLI
+ * @param {String[]} args - args processed from the CLI
  * @returns {Function} invokes the devServer API
  */
 
-function serve() {
+export default function serve(...args: string[]) {
 	const packageJSONPath = getRootPathModule("package.json");
 	if (!packageJSONPath) {
 		console.error(
@@ -170,7 +170,7 @@ function serve() {
 	}
 }
 
-export = {
+export {
 	getRootPathModule,
 	serve,
 	spawnNPMWithArg,

--- a/packages/serve/index.ts
+++ b/packages/serve/index.ts
@@ -169,10 +169,3 @@ export default function serve(...args: string[]) {
 			});
 	}
 }
-
-export {
-	getRootPathModule,
-	serve,
-	spawnNPMWithArg,
-	spawnYarnWithArg,
-};


### PR DESCRIPTION
ISSUES CLOSED: #572

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

This PR introduces a bugfix for the serve package to export a default function, and a more useful error message when a package does not export a default function.
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

No, I could not seem to find any tests relating to the packages, eg. serve, init. If you would like me to write tests I can, I might just need some guidance.

**If relevant, did you update the documentation?**

No

**Summary**

I ran into this issue: https://github.com/webpack/webpack-cli/pull/589 while trying `webpack-cli serve`. The reason for the issue is that `serve` does not export a default function. There was a PR earlier about this that never got finished https://github.com/webpack/webpack-cli/pull/589. `serve` still has problems, but I think those should be addressed in a separate PR.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
The changes in serve are not breaking, but the changes in bin are breaking for serve if you do not consider the changes I made. I'm not exactly sure how the npm publishing process works for these multiple packages. If everything is published at the same time, there is no problem, and if serve is published before the bin, there is no problem. In any case, serve seems to still have other problems with the current webpack-cli version outside of this.

**Other information**
