### PR TITLE
docs(serve): update docs to use webpack-dev-server

### DIFF
--- a/bin/config/optionsSchema.json
+++ b/bin/config/optionsSchema.json
@@ -1680,7 +1680,7 @@
         ]
       },
       "serve": {
-        "description": "Options for webpack-serve",
+        "description": "Options for webpack-dev-server",
         "type": "object"
       },
       "stats": {

--- a/packages/serve/README.md
+++ b/packages/serve/README.md
@@ -4,7 +4,7 @@
 
 ## Description
 
-This package contains the logic to run webpack-dev-server to serve your webpack app and provide live reloading.
+This package contains the logic to run [webpack-dev-server](https://github.com/webpack/webpack-dev-server) to serve your webpack app and provide live reloading.
 
 ## Installation
 

--- a/packages/serve/README.md
+++ b/packages/serve/README.md
@@ -4,7 +4,7 @@
 
 ## Description
 
-This package contains the logic to run webpack-serve without using webpack-serve directly.
+This package contains the logic to run webpack-dev-server to serve your webpack app and provide live reloading.
 
 ## Installation
 


### PR DESCRIPTION
update docs to use webpack-dev-server

ISSUES CLOSED: #846

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
docs
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
NA

**If relevant, did you update the documentation?**
yes

**Summary**
* Update serve package docs to use webpack-dev-server, webpack-serve is deprecated.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
NA