### PR TITLE
feat(opencollective prompt): add disable option

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,14 @@
 [![GitHub contributors](https://img.shields.io/github/contributors/webpack/webpack-cli.svg)](https://github.com/webpack/webpack-cli/graphs/contributors)
 
 - [About](#about)
-  - [How to install](#how-to-install)
-- [Getting Started](#getting-started)
+	- [How to install](#how-to-install)
+- [Packages](#packages)
+	- [Commands](#commands)
+	- [Utilities](#utilities)
+- [Getting started](#getting-started)
 - [webpack CLI Scaffolds](#webpack-cli-scaffolds)
-- [Commands](#commands)
-- [webpack.config.js](https://webpack.js.org/concepts/configuration/)
 - [Contributing and Internal Documentation](#contributing-and-internal-documentation)
+- [Open Collective](#open-collective)
 
 ## About
 
@@ -89,3 +91,9 @@ The webpack family welcomes any contributor, small or big. We are happy to elabo
 
 [deps]: https://img.shields.io/david/webpack/webpack.svg
 [deps-url]: https://david-dm.org/webpack/webpack-cli
+
+## Open Collective
+
+If you like **webpack** Please consider donating to our [Open Collective](https://opencollective.com/webpack) to help us maintain it.
+
+We show this message in the terminal once in a while, if you want you can disable it by setting the environment variable `DISABLE_OPENCOLLECTIVE=true` or `CI=true`.

--- a/README.md
+++ b/README.md
@@ -94,6 +94,6 @@ The webpack family welcomes any contributor, small or big. We are happy to elabo
 
 ## Open Collective
 
-If you like **webpack** Please consider donating to our [Open Collective](https://opencollective.com/webpack) to help us maintain it.
+If you like **webpack** Please consider donating to our [Open Collective](https://opencollective.com/webpack) to help us to maintain it.
 
-We show this message in the terminal once in a while, if you want you can disable it by setting the environment variable `DISABLE_OPENCOLLECTIVE=true` or `CI=true`.
+We show this message in the terminal once a week, if you want you can disable it by setting the environment variable `DISABLE_OPENCOLLECTIVE=true` or `CI=true`.

--- a/README.md
+++ b/README.md
@@ -94,6 +94,6 @@ The webpack family welcomes any contributor, small or big. We are happy to elabo
 
 ## Open Collective
 
-If you like **webpack** Please consider donating to our [Open Collective](https://opencollective.com/webpack) to help us to maintain it.
+If you like **webpack**, please consider donating to our [Open Collective](https://opencollective.com/webpack) to help us maintain it.
 
 We show this message in the terminal once a week, if you want you can disable it by setting the environment variable `DISABLE_OPENCOLLECTIVE=true` or `CI=true`.

--- a/bin/opencollective.js
+++ b/bin/opencollective.js
@@ -24,7 +24,7 @@ function printBadge() {
 	console.log("\n");
 	print(`${chalk.bold("Thanks for using")} ${chalk.bold.blue("Webpack!")}`);
 	print(`Please consider donating to our ${chalk.bold.blue("Open Collective")}`);
-	print("to help us maintain this package.");
+	print("to help us to maintain this package.");
 	console.log("\n\n");
 	print(`${emoji("👉")} ${chalk.bold.yellow(" Donate:")} ${chalk.reset.underline.yellow("https://opencollective.com/webpack/donate")}`);
 	console.log("\n");
@@ -33,6 +33,6 @@ function printBadge() {
 function isTrue(value) {
 	return !!value && value !== "0" && value !== "false";
 }
-var envDisable = isTrue(process.env.DISABLE_OPENCOLLECTIVE) || isTrue(process.env.CI);
+const envDisable = isTrue(process.env.DISABLE_OPENCOLLECTIVE) || isTrue(process.env.CI);
 
 if (!envDisable) printBadge();

--- a/bin/opencollective.js
+++ b/bin/opencollective.js
@@ -30,4 +30,9 @@ function printBadge() {
 	console.log("\n");
 }
 
-printBadge();
+function isTrue(value) {
+	return !!value && value !== "0" && value !== "false";
+}
+var envDisable = isTrue(process.env.DISABLE_OPENCOLLECTIVE) || isTrue(process.env.CI);
+
+if (!envDisable) printBadge();

--- a/bin/opencollective.js
+++ b/bin/opencollective.js
@@ -24,7 +24,7 @@ function printBadge() {
 	console.log("\n");
 	print(`${chalk.bold("Thanks for using")} ${chalk.bold.blue("Webpack!")}`);
 	print(`Please consider donating to our ${chalk.bold.blue("Open Collective")}`);
-	print("to help us to maintain this package.");
+	print("to help us maintain this package.");
 	console.log("\n\n");
 	print(`${emoji("👉")} ${chalk.bold.yellow(" Donate:")} ${chalk.reset.underline.yellow("https://opencollective.com/webpack/donate")}`);
 	console.log("\n");


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Allows disabling the open collective prompt.

Following [opencollective-postinstall](https://github.com/opencollective/opencollective-postinstall/blob/master/index.js#L7), our prompt is disabled if `DISABLE_OPENCOLLECTIVE` or `CI` env variables are set to `true`

**If relevant, did you update the documentation?**
Yes

**Summary**
Closes #854 

**Other information**
This is an alternative PR to #856 