### PR TITLE
chore(travis): temporary remove node stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,6 @@ cache:
     directories:
         - ~/.npm
 matrix:
-    include:
-        - os: linux
-          node_js: "stable"
-          env: JOB_PART=lint
-        - os: linux
-          node_js: "stable"
-          env: JOB_PART=integration
         - os: linux
           node_js: "10"
           env: JOB_PART=integration


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Removes node:stable from Travis to fix the currently broken CI as discussed in #864 

**Summary**
Closes #864 