### PR TITLE
cli: fix watch options for array config

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -349,7 +349,8 @@ For more information, see https://webpack.js.org/api/cli/.`);
 				}
 			}
 			if (firstOptions.watch || options.watch) {
-				const watchOptions = firstOptions.watchOptions || firstOptions.watch || options.watch || {};
+				const watchOptions =
+					firstOptions.watchOptions || options.watchOptions || firstOptions.watch || options.watch || {};
 				if (watchOptions.stdin) {
 					process.stdin.on("end", function(_) {
 						process.exit(); // eslint-disable-line


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
bugfix

**Did you add tests for your changes?**
nope! I didn't see any existing tests for `processOptions`.

**If relevant, did you update the documentation?**
I did not, but this should make the current [docs on the watch options](https://webpack.js.org/api/cli/#watch-options) true for Webpack configs that are arrays.

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

webpack/webpack#4594 points out that watch options aren't being honored when the
Webpack config is an Array. In cases when it's an array, there may not
be a firstOptions.watchOptions, but there will be an options.watchOptions.

In the current implementation, when the Webpack compiler watch method is
called with watchOptions and the Webpack config is an array, watchOptions
will be `true` and not an object.

**I should also note that I don't have a ton of context into the intentions behind using the `watch` (which is a boolean) in the case that the other options are absent, and an object if `watch` is false on both options and firstOptions, so at the very least my goal with this PR is to give someone who has better context the information I found so that they can make a good decision on what's best to do here.**

<!-- Try to link to an open issue for more information. -->
webpack/webpack#4594 (not open, but still broken)

- I also noticed that although the above issue was specific to docker + Windows 10, this isn't working as expected in any system I've tested (in a Docker container, locally on MacOS) when the Webpack config export is an array.

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
It does not, this should be a seamless fallback in the case when the Webpack config is an array instead of an object that does the right thing when the CLI has watch-* flags.

## Testing/Repro 

- Created an [example repo and added a reproducible commit](https://github.com/chaseadamsio-forks/webpack-watch-cli-options-example/tree/621f1cc56891dda4bbf96c3a2e2267f3f55ae2bb)
- Added a `console.log` for `watchOptions` above the call to [`compiler.watch` in webpack-cli](https://github.com/webpack/webpack-cli/blob/91239ef5d959ab7bc2dd56843b6ec3168dffa152/bin/cli.js#L360) 
- Ran `webpack-watch-poll-cfg` from the example repo to verify the `watchOptions` from a webpack.config.js works as expected and received the following: 
```
yarn run webpack-watch-poll-cfg
yarn run v1.9.4
$ webpack --watch --config webpack-poll.config.js
watch options in compiler: { poll: 1000 }
```
- Ran `webpack-watch-poll-cli` from the example repo to verify the `watchOptions` from a CLI flag (`--watch-poll`) was incorrect (with an Array config):
```
yarn webpack-watch-poll-cli
yarn run v1.9.4
$ webpack --watch --watch-poll=500 --config webpack-basic.config.js
watch options in compiler: true
watch options in compiler: true
```
- Updated the [package.json to point to my fork in GitHub in this commit](https://github.com/chaseadamsio-forks/webpack-watch-cli-options-example/tree/c44ae8fb15784326f40f9df5390f5740d1171b8a)
- Ran `yarn install`
- Ran `webpack-watch-poll-cli` from the example repo to verify the `watchOptions` from a CLI flag (`--watch-poll`) works as expected with an Array config and received the following:
```
yarn webpack-watch-poll-cli
yarn run v1.9.4
$ webpack --watch --watch-poll=500 --config webpack-basic.config.js
watch options in compiler: { poll: 500 }
```