### PR TITLE
chore(add-generator): changed the naming of the plugin in config file

### DIFF
--- a/packages/generators/__tests__/add-generator.test.ts
+++ b/packages/generators/__tests__/add-generator.test.ts
@@ -1,0 +1,14 @@
+import { generatePluginName } from  "../utils/plugins"
+
+describe("generatePluginName", () => {
+	it("should return webpack Standard Plugin Name for Name : extract-text-webpack-plugin", () => {
+		const pluginName = generatePluginName("extract-text-webpack-plugin");
+		expect(pluginName).toEqual("ExtractTextWebpackPlugin");
+	});
+
+	it("should return webpack Standard Plugin Name for Name : webpack.DefinePlugin", () => {
+		const pluginName = generatePluginName("webpack.DefinePlugin");
+		expect(pluginName).toEqual("Webpack.DefinePlugin");
+	});
+});
+

--- a/packages/generators/__tests__/add-generator.test.ts
+++ b/packages/generators/__tests__/add-generator.test.ts
@@ -8,7 +8,7 @@ describe("generatePluginName", () => {
 
 	it("should return webpack Standard Plugin Name for Name : webpack.DefinePlugin", () => {
 		const pluginName = generatePluginName("webpack.DefinePlugin");
-		expect(pluginName).toEqual("Webpack.DefinePlugin");
+		expect(pluginName).toEqual("webpack.DefinePlugin");
 	});
 });
 

--- a/packages/generators/add-generator.ts
+++ b/packages/generators/add-generator.ts
@@ -11,26 +11,11 @@ import { AutoComplete, Confirm, Input, List } from "@webpack-cli/webpack-scaffol
 
 import { SchemaProperties, WebpackOptions } from "./types";
 import entryQuestions from "./utils/entry";
-
+import { generatePluginName } from "./utils/plugins";
 import webpackDevServerSchema from "webpack-dev-server/lib/options.json";
 import webpackSchema from "./utils/optionsSchema.json";
 const PROPS: string[] = Array.from(PROP_TYPES.keys());
 
-/**
- *
- * Replaces the string with a substring at the given index
- * https://gist.github.com/efenacigiray/9367920
- *
- * @param	{String} str - string to be modified
- * @param	{Number} index - index to replace from
- * @param	{String} replace - string to replace starting from index
- *
- * @returns	{String} string - The newly mutated string
- *
- */
-function replaceAt(str: string, index: number, replace: string): string {
-	return str.substring(0, index) + replace + str.substring(index + 1);
-}
 
 /**
  *
@@ -395,11 +380,7 @@ export default class AddGenerator extends Generator {
 								(p: boolean): void => {
 									if (p) {
 										this.dependencies.push(answerToAction.actionAnswer);
-										let myPluginNameArray = answerToAction.actionAnswer.split("-")
-										for (let i = 0; i < myPluginNameArray.length; i++) {
-											myPluginNameArray[i] = replaceAt(myPluginNameArray[i], 0, myPluginNameArray[i].charAt(0).toUpperCase());
-										}
-										const pluginName = myPluginNameArray.join("")
+										const pluginName = generatePluginName(answerToAction.actionAnswer)
 										this.configuration.config.topScope.push(
 											`const ${pluginName} = require("${answerToAction.actionAnswer}")`
 										);

--- a/packages/generators/add-generator.ts
+++ b/packages/generators/add-generator.ts
@@ -12,8 +12,8 @@ import { AutoComplete, Confirm, Input, List } from "@webpack-cli/webpack-scaffol
 import { SchemaProperties, WebpackOptions } from "./types";
 import entryQuestions from "./utils/entry";
 import { generatePluginName } from "./utils/plugins";
-import webpackDevServerSchema from "webpack-dev-server/lib/options.json";
-import webpackSchema from "./utils/optionsSchema.json";
+import * as webpackDevServerSchema from "webpack-dev-server/lib/options.json";
+import * as webpackSchema from "./utils/optionsSchema.json";
 const PROPS: string[] = Array.from(PROP_TYPES.keys());
 
 

--- a/packages/generators/add-generator.ts
+++ b/packages/generators/add-generator.ts
@@ -395,15 +395,11 @@ export default class AddGenerator extends Generator {
 								(p: boolean): void => {
 									if (p) {
 										this.dependencies.push(answerToAction.actionAnswer);
-										const normalizePluginName = answerToAction.actionAnswer.replace(
-											"-webpack-plugin",
-											"Plugin"
-										);
-										const pluginName = replaceAt(
-											normalizePluginName,
-											0,
-											normalizePluginName.charAt(0).toUpperCase()
-										);
+										let myPluginNameArray = answerToAction.actionAnswer.split("-")
+										for (let i = 0; i < myPluginNameArray.length; i++) {
+											myPluginNameArray[i] = replaceAt(myPluginNameArray[i], 0, myPluginNameArray[i].charAt(0).toUpperCase());
+										}
+										const pluginName = myPluginNameArray.join("")
 										this.configuration.config.topScope.push(
 											`const ${pluginName} = require("${answerToAction.actionAnswer}")`
 										);

--- a/packages/generators/utils/plugins.ts
+++ b/packages/generators/utils/plugins.ts
@@ -43,7 +43,7 @@ export const replaceAt = (str: string, index: number, replace: string) : string 
 export const generatePluginName = (rawPluginName: string): string => {
 	let myPluginNameArray : string[];
 	myPluginNameArray = rawPluginName.split("-");
-	if( myPluginNameArray.length <= 1 ){}
+	if(myPluginNameArray.length <= 1){}
 	else{
 		for (let i = 0; i < myPluginNameArray.length; i++) {
 			myPluginNameArray[i] = replaceAt(myPluginNameArray[i], 0, myPluginNameArray[i].charAt(0).toUpperCase());

--- a/packages/generators/utils/plugins.ts
+++ b/packages/generators/utils/plugins.ts
@@ -43,8 +43,11 @@ export const replaceAt = (str: string, index: number, replace: string) : string 
 export const generatePluginName = (rawPluginName: string): string => {
 	let myPluginNameArray : string[];
 	myPluginNameArray = rawPluginName.split("-");
-	for (let i = 0; i < myPluginNameArray.length; i++) {
-		myPluginNameArray[i] = replaceAt(myPluginNameArray[i], 0, myPluginNameArray[i].charAt(0).toUpperCase());
+	if( myPluginNameArray.length <= 1 ){}
+	else{
+		for (let i = 0; i < myPluginNameArray.length; i++) {
+			myPluginNameArray[i] = replaceAt(myPluginNameArray[i], 0, myPluginNameArray[i].charAt(0).toUpperCase());
+		}
 	}
 	return myPluginNameArray.join("")
 }

--- a/packages/generators/utils/plugins.ts
+++ b/packages/generators/utils/plugins.ts
@@ -43,11 +43,8 @@ export const replaceAt = (str: string, index: number, replace: string) : string 
 export const generatePluginName = (rawPluginName: string): string => {
 	let myPluginNameArray : string[];
 	myPluginNameArray = rawPluginName.split("-");
-	if(myPluginNameArray.length <= 1){}
-	else{
-		for (let i = 0; i < myPluginNameArray.length; i++) {
-			myPluginNameArray[i] = replaceAt(myPluginNameArray[i], 0, myPluginNameArray[i].charAt(0).toUpperCase());
-		}
+	for (let i = 0; i < myPluginNameArray.length && myPluginNameArray.length > 1 ; i++) {
+		myPluginNameArray[i] = replaceAt(myPluginNameArray[i], 0, myPluginNameArray[i].charAt(0).toUpperCase());
 	}
 	return myPluginNameArray.join("")
 }

--- a/packages/generators/utils/plugins.ts
+++ b/packages/generators/utils/plugins.ts
@@ -43,7 +43,8 @@ export const replaceAt = (str: string, index: number, replace: string) : string 
 export const generatePluginName = (rawPluginName: string): string => {
 	let myPluginNameArray : string[];
 	myPluginNameArray = rawPluginName.split("-");
-	for (let i = 0; i < myPluginNameArray.length && myPluginNameArray.length > 1 ; i++) {
+	const pluginArrLength : number = myPluginNameArray.length;
+	for (let i = 0; i < pluginArrLength && pluginArrLength > 1 ; i++) {
 		myPluginNameArray[i] = replaceAt(myPluginNameArray[i], 0, myPluginNameArray[i].charAt(0).toUpperCase());
 	}
 	return myPluginNameArray.join("")

--- a/packages/generators/utils/plugins.ts
+++ b/packages/generators/utils/plugins.ts
@@ -1,3 +1,4 @@
+
 /**
  *
  * Callable function with the initial plugins
@@ -6,6 +7,44 @@
  * that consists of terser-webpack-plugin
  */
 
-export default function(): string[] {
+export default function (): string[] {
 	return ["new TerserPlugin()"];
+}
+
+/**
+ *
+ * Replaces the string with a substring at the given index
+ * https://gist.github.com/efenacigiray/9367920
+ *
+ * @param	{String} str - string to be modified
+ * @param	{Number} index - index to replace from
+ * @param	{String} replace - string to replace starting from index
+ *
+ * @returns	{String} string - The newly mutated string
+ *
+ */
+
+export const replaceAt = (str: string, index: number, replace: string) : string => {
+	return str.substring(0, index) + replace + str.substring(index + 1);
+}
+
+
+/**
+ *
+ * Generate a webpack standard webpack plugin name from the plugin name from the Answer
+ *
+ * @param	{String} rawPluginName - plugin name from answer
+ *
+ * @returns	{String} string - the webpack standard plugin name
+ *
+ */
+
+
+export const generatePluginName = (rawPluginName: string): string => {
+	let myPluginNameArray : string[];
+	myPluginNameArray = rawPluginName.split("-");
+	for (let i = 0; i < myPluginNameArray.length; i++) {
+		myPluginNameArray[i] = replaceAt(myPluginNameArray[i], 0, myPluginNameArray[i].charAt(0).toUpperCase());
+	}
+	return myPluginNameArray.join("")
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -4,7 +4,8 @@
 		"module": "commonjs",
 		"moduleResolution": "node",
 		"allowSyntheticDefaultImports": true,
-		"skipLibCheck": true
+		"skipLibCheck": true,
+		"resolveJsonModule": true,
 	},
 	"include": ["packages/**/*.ts"],
 	"exclude": [


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
refactoring/bugfix

**Did you add tests for your changes?**
Yes

**If relevant, did you update the documentation?**
NA

**Summary**
Changed the naming of the current naming of the webpack plugin in the `add-generator` to a better and standard way of naming. The earlier one was creating error name when passed something like `extract-text-webpack-plugin`, it would give the plugin in config file like this

**Bug**

```bash
	plugins: new Extract() - textPlugin,

```

**With this refractor**
It will output the config file plugin with this
```bash
plugins: new ExtractTextWebpackPlugin(),

```

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No

**Other information**
NA