### PR TITLE
fix(generator): fixed the support of native plugins in add command

### DIFF
--- a/packages/generators/add-generator.ts
+++ b/packages/generators/add-generator.ts
@@ -291,6 +291,13 @@ export default class AddGenerator extends Generator {
 					 * find the names of each natively plugin and check if it matches
 					 */
 					if (action === "plugins") {
+						let answeredPluginName = answerToAction.actionAnswer
+						let isPrefixPresent = /webpack./.test(answeredPluginName);
+						if( isPrefixPresent ){
+							answeredPluginName = answeredPluginName.replace("webpack.","").trim()
+						}else{
+							answeredPluginName = answeredPluginName.trim()
+						}
 						const pluginExist: string = glob
 							.sync(["node_modules/webpack/lib/*Plugin.js", "node_modules/webpack/lib/**/*Plugin.js"])
 							.map(
@@ -300,7 +307,7 @@ export default class AddGenerator extends Generator {
 										.pop()
 										.replace(".js", "")
 							)
-							.find((p: string): boolean => p.toLowerCase().indexOf(answerToAction.actionAnswer) >= 0);
+							.find((p: string): boolean => p.indexOf(answeredPluginName) >= 0);
 
 						if (pluginExist) {
 							this.configuration.config.item = pluginExist;
@@ -315,8 +322,7 @@ export default class AddGenerator extends Generator {
 											.split("/")
 											.pop()
 											.replace(".json", "")
-											.toLowerCase()
-											.indexOf(answerToAction.actionAnswer) >= 0
+											.indexOf(answeredPluginName) >= 0
 								);
 							if (pluginsSchemaPath) {
 								const constructorPrefix: string =


### PR DESCRIPTION
Refactored the code to fix the error of supporting the native plugin in
add-generator. removed the toLowerCase() method, added the logic for
more general plugin name from the input

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
bugfix/refactoring

**Did you add tests for your changes?**
NA
**If relevant, did you update the documentation?**
NA
**Summary**
 fix https://github.com/webpack/webpack-cli/issues/906
fixed support for adding  native plugin in add-generator

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No

**Other information**
NA