### PR TITLE
chore(lint): fix ts lint warnings

### DIFF
--- a/packages/generators/add-generator.ts
+++ b/packages/generators/add-generator.ts
@@ -11,8 +11,8 @@ import { AutoComplete, Confirm, Input, List } from "@webpack-cli/webpack-scaffol
 
 import { SchemaProperties, WebpackOptions } from "./types";
 import { entryQuestions, generatePluginName } from "./utils";
-import * as webpackDevServerSchema from "webpack-dev-server/lib/options.json";
-import * as webpackSchema from "./utils/optionsSchema.json";
+import webpackDevServerSchema from "webpack-dev-server/lib/options.json";
+import webpackSchema from "./utils/optionsSchema.json";
 
 const PROPS: string[] = Array.from(PROP_TYPES.keys());
 


### PR DESCRIPTION
Fixed warnings for add-generator.ts
Changed the import statement in `add-generator.ts` 
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
refactoring

**Did you add tests for your changes?**
NA

**If relevant, did you update the documentation?**
NA

**Summary**
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
Linting errors on below lines of `add-generator.ts`
```
Property 'definitions' does not exist on type 'typeof import("*.json")'. L151
Type 'typeof import("*.json")' has no properties in common with type 'SchemaProperties'. L204
Property 'properties' does not exist on type 'typeof import("*.json")'. L158-161 
```


**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No
