### PR TITLE
fix: improve checking file permission

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -342,14 +342,17 @@ For more information, see https://webpack.js.org/api/cli/.`);
 					const now = new Date();
 					if (now.getDay() === MONDAY) {
 						const { access, constants, statSync, utimesSync } = require("fs");
-						const lastPrint = statSync(openCollectivePath).atime;
+						const stat = statSync(openCollectivePath);
+						const lastPrint = stat.atime;
+						const fileOwnerId = stat.uid;
 						const lastPrintTS = new Date(lastPrint).getTime();
 						const timeSinceLastPrint = now.getTime() - lastPrintTS;
 						if (timeSinceLastPrint > SIX_DAYS) {
 							require(openCollectivePath);
 							// On windows we need to manually update the atime
+							// Updating utime requires process owner is as same as file owner
 							access(openCollectivePath, constants.W_OK, e => {
-								if (!e) utimesSync(openCollectivePath, now, now);
+								if (!e && fileOwnerId === process.getuid()) utimesSync(openCollectivePath, now, now);
 							});
 						}
 					}


### PR DESCRIPTION
**What kind of change does this PR introduce?**
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

improvement checking permission on open collective prompt EPERM error.

**Summary**

This error is related on https://github.com/webpack/webpack-cli/issues/870 and fixed https://github.com/webpack/webpack-cli/pull/876 but It looks not enough.

For example, It is happen EPERM when node_modules is owned by `root` and webpack-cli is executed by user excepted `root`.

It should check file and process owners are same because updating utime requires it.
