### PR TITLE
feat: better defaults (0CJS) with config generation

### DIFF
--- a/bin/utils/prompt-command.js
+++ b/bin/utils/prompt-command.js
@@ -48,9 +48,9 @@ const runWhenInstalled = (packages, pathForCmd, ...args) => {
 
 module.exports = function promptForInstallation(packages, ...args) {
 	const nameOfPackage = "@webpack-cli/" + packages;
-	let packageIsInstalled = false;
-	let pathForCmd;
-	try {
+	let packageIsInstalled = true;
+	let pathForCmd = "../../packages/init";
+	/* 	try {
 		const path = require("path");
 		const fs = require("fs");
 		pathForCmd = path.resolve(process.cwd(), "node_modules", "@webpack-cli", packages);
@@ -64,7 +64,7 @@ module.exports = function promptForInstallation(packages, ...args) {
 		packageIsInstalled = true;
 	} catch (err) {
 		packageIsInstalled = false;
-	}
+	} */
 	if (!packageIsInstalled) {
 		const path = require("path");
 		const fs = require("fs");

--- a/packages/generators/init-generator.ts
+++ b/packages/generators/init-generator.ts
@@ -234,7 +234,7 @@ export default class InitGenerator extends Generator {
 		(this.configuration.config.webpackOptions.plugins as string[]).push(`new workboxPlugin.GenerateSW({
 			swDest: 'sw.js',
 			clientsClaim: true,
-			skipWaiting: true,
+			skipWaiting: false,
 		})`);
 
 		// Chunksplitting

--- a/packages/generators/init-generator.ts
+++ b/packages/generators/init-generator.ts
@@ -200,6 +200,7 @@ export default class InitGenerator extends Generator {
 			}
 		}
 		if (this.usingDefaults) {
+			// Html webpack Plugin
 			this.dependencies.push("html-webpack-plugin");
 			const htmlWebpackDependency = "html-webpack-plugin";
 			const htmlwebpackPlugin = generatePluginName(htmlWebpackDependency);
@@ -211,12 +212,15 @@ export default class InitGenerator extends Generator {
 			(this.configuration.config.webpackOptions.plugins as string[]).push(`new ${htmlwebpackPlugin}({
 					template: 'index.html'
 				})`);
+
+			// webpack Dev Server
 			this.dependencies.push("webpack-dev-server");
 			this.configuration.config.webpackOptions.devServer = {
 				open: true
 			};
 		}
 
+		// TerserPlugin
 		this.dependencies.push("terser-webpack-plugin");
 		this.configuration.config.topScope.push(
 			tooltip.terser(),
@@ -224,9 +228,18 @@ export default class InitGenerator extends Generator {
 			"\n"
 		);
 
+		// PWA + offline support
+		this.configuration.config.topScope.push("const workboxPlugin = require('workbox-webpack-plugin');", "\n");
+		this.dependencies.push("workbox-webpack-plugin");
+		(this.configuration.config.webpackOptions.plugins as string[]).push(`new workboxPlugin.GenerateSW({
+			swDest: 'sw.js',
+			clientsClaim: true,
+			skipWaiting: true,
+		})`);
+
+		// Chunksplitting
 		this.configuration.config.webpackOptions.optimization = getDefaultOptimization(this.usingDefaults);
 		this.configuration.config.webpackOptions.mode = this.usingDefaults ? "'production'" : "'development'";
-
 		done();
 	}
 

--- a/packages/generators/init-generator.ts
+++ b/packages/generators/init-generator.ts
@@ -45,7 +45,7 @@ export default class InitGenerator extends Generator {
 	public constructor(args, opts) {
 		super(args, opts);
 
-		this.usingDefaults = false;
+		this.usingDefaults = true;
 		this.autoGenerateConfig = opts.autoSetDefaults ? true : false;
 
 		this.dependencies = ["webpack", "webpack-cli", "babel-plugin-syntax-dynamic-import"];
@@ -122,7 +122,7 @@ export default class InitGenerator extends Generator {
 			self,
 			"outputDir",
 			"In which folder do you want to store your generated bundles?",
-			"dist",
+			"'dist'",
 			this.autoGenerateConfig
 		);
 
@@ -131,13 +131,7 @@ export default class InitGenerator extends Generator {
 		if (!this.usingDefaults) {
 			this.configuration.config.webpackOptions.output = {
 				chunkFilename: "'[name].[chunkhash].js'",
-				filename: "'[name].[chunkhash].js'",
-				path: `path.resolve(__dirname, '${outputDir}')`
-			};
-		} else {
-			this.configuration.config.webpackOptions.output = {
-				filename: "'bundle.js'",
-				path: `path.resolve(__dirname, '${outputDir}')`
+				filename: "'[name].[chunkhash].js'"
 			};
 		}
 
@@ -164,13 +158,13 @@ export default class InitGenerator extends Generator {
 
 		({ ExtractUseProps, regExpForStyles } = styleQuestionHandler(self, stylingType));
 
-		if (this.isProd) {
+		if (this.usingDefaults) {
 			// Ask if the user wants to use extractPlugin
 			const { useExtractPlugin } = await Input(
 				self,
 				"useExtractPlugin",
 				"If you want to bundle your CSS files, what will you name the bundle? (press enter to skip)",
-				"null",
+				"'main.css'",
 				this.autoGenerateConfig
 			);
 
@@ -205,7 +199,7 @@ export default class InitGenerator extends Generator {
 				});
 			}
 		}
-		if (!this.isProd) {
+		if (this.usingDefaults) {
 			this.dependencies.push("html-webpack-plugin");
 			const htmlWebpackDependency = "html-webpack-plugin";
 			const htmlwebpackPlugin = generatePluginName(htmlWebpackDependency);
@@ -214,24 +208,24 @@ export default class InitGenerator extends Generator {
 				"\n",
 				tooltip.html()
 			);
-			(this.configuration.config.webpackOptions.plugins as string[]).push(`new ${htmlwebpackPlugin}()`);
-		}
-
-		if (!this.usingDefaults) {
+			(this.configuration.config.webpackOptions.plugins as string[]).push(`new ${htmlwebpackPlugin}({
+					template: 'index.html'
+				})`);
 			this.dependencies.push("webpack-dev-server");
 			this.configuration.config.webpackOptions.devServer = {
 				open: true
 			};
-		} else {
-			this.dependencies.push("terser-webpack-plugin");
-			this.configuration.config.topScope.push(
-				tooltip.terser(),
-				"const TerserPlugin = require('terser-webpack-plugin');",
-				"\n"
-			);
 		}
+
+		this.dependencies.push("terser-webpack-plugin");
+		this.configuration.config.topScope.push(
+			tooltip.terser(),
+			"const TerserPlugin = require('terser-webpack-plugin');",
+			"\n"
+		);
+
 		this.configuration.config.webpackOptions.optimization = getDefaultOptimization(this.usingDefaults);
-		this.configuration.config.webpackOptions.mode = this.usingDefaults ? "'development'" : "'production'";
+		this.configuration.config.webpackOptions.mode = this.usingDefaults ? "'production'" : "'development'";
 
 		done();
 	}
@@ -250,7 +244,7 @@ export default class InitGenerator extends Generator {
 		this.config.set("configuration", this.configuration);
 
 		const packageJsonTemplatePath = "./templates/package.json.js";
-		this.fs.extendJSON(this.destinationPath("package.json"), require(packageJsonTemplatePath)(this.isProd));
+		this.fs.extendJSON(this.destinationPath("package.json"), require(packageJsonTemplatePath)(this.usingDefaults));
 
 		const generateEntryFile = (entryPath: string, name: string): void => {
 			entryPath = entryPath.replace(/'/g, "");
@@ -258,7 +252,7 @@ export default class InitGenerator extends Generator {
 		};
 
 		// Generate entry file/files
-		const entry = this.configuration.config.webpackOptions.entry;
+		const entry = this.configuration.config.webpackOptions.entry || "./src/index.js";
 		if (typeof entry === "string") {
 			generateEntryFile(entry, "your main file!");
 		} else if (typeof entry === "object") {
@@ -267,6 +261,15 @@ export default class InitGenerator extends Generator {
 
 		// Generate README
 		this.fs.copyTpl(path.resolve(__dirname, "./templates/README.md"), this.destinationPath("README.md"), {});
+
+		// Generate HTML template file
+		if (this.usingDefaults) {
+			this.fs.copyTpl(
+				path.resolve(__dirname, "./templates/template.html"),
+				this.destinationPath("index.html"),
+				{}
+			);
+		}
 
 		// Genrate tsconfig
 		if (this.langType === LangType.Typescript) {

--- a/packages/generators/templates/package.json.js
+++ b/packages/generators/templates/package.json.js
@@ -1,8 +1,8 @@
-module.exports = isProd => {
+module.exports = usingDefaults => {
 	let scripts = {
 		build: "webpack"
 	};
-	if (!isProd) {
+	if (usingDefaults) {
 		scripts.start = "webpack-dev-server";
 	}
 

--- a/packages/generators/templates/template.html
+++ b/packages/generators/templates/template.html
@@ -1,11 +1,25 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <meta charset="utf-8">
-    <title>Webpack App</title>
-  </head>
-  <body>
-      <h1>Hello world!</h1>
-      <h2>Tip: Check your console</h2>
-  </body>
+	<head>
+		<meta charset="utf-8" />
+		<title>Webpack App</title>
+	</head>
+	<body>
+		<h1>Hello world!</h1>
+		<h2>Tip: Check your console</h2>
+		<script>
+			if ("serviceWorker" in navigator) {
+				window.addEventListener("load", () => {
+					navigator.serviceWorker
+						.register("/sw.js")
+						.then(registration => {
+							console.log("SW registered: ", registration);
+						})
+						.catch(registrationError => {
+							console.log("SW registration failed: ", registrationError);
+						});
+				});
+			}
+		</script>
+	</body>
 </html>

--- a/packages/generators/templates/template.html
+++ b/packages/generators/templates/template.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Webpack App</title>
+  </head>
+  <body>
+      <h1>Hello world!</h1>
+      <h2>Tip: Check your console</h2>
+  </body>
+</html>

--- a/packages/generators/utils/webpackConfig.ts
+++ b/packages/generators/utils/webpackConfig.ts
@@ -2,8 +2,9 @@ import { WebpackOptions } from "../types";
 
 export function getDefaultOptimization(usingDefaults: boolean): WebpackOptions["optimization"] {
 	let optimizationOptions;
-	if (usingDefaults) {
+	if (!usingDefaults) {
 		optimizationOptions = {
+			minimizer: ["new TerserPlugin()"],
 			splitChunks: {
 				cacheGroups: {
 					vendors: {
@@ -14,7 +15,7 @@ export function getDefaultOptimization(usingDefaults: boolean): WebpackOptions["
 				chunks: "'async'",
 				minChunks: 1,
 				minSize: 30000,
-				name: !this.isProd
+				name: !usingDefaults
 			}
 		};
 	} else {

--- a/packages/utils/scaffold.ts
+++ b/packages/utils/scaffold.ts
@@ -91,11 +91,11 @@ export default function runTransform(transformConfig: TransformConfig, action: s
 		}
 	);
 
-	const runCommand = getPackageManager() === "yarn" ? "yarn start" : "npm run start";
+	const runCommand = getPackageManager() === "yarn" ? "yarn build" : "npm run build";
 
 	let successMessage: string =
 		chalk.green(`Congratulations! Your new webpack configuration file has been created!\n\n`) +
-		`You can now run ${chalk.green(runCommand)} to run your project!\n\n`;
+		`You can now run ${chalk.green(runCommand)} to bundle your application!\n\n`;
 
 	if (initActionNotDefined && transformConfig.config.item) {
 		successMessage = chalk.green(`Congratulations! ${transformConfig.config.item} has been ${action}ed!\n`);


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Better default settings for init generator

**Did you add tests for your changes?**
N/A
**If relevant, did you update the documentation?**
N/A
**Summary**
Sets better defaults if user is in production and if the user is using defaults.

**Does this PR introduce a breaking change?**
N/A

**Other information**

After this is done, we can use the default config generated from `webpack init --auto` and use that as the default config for a webpack instance. After doing so, we can remove the `isUsingDefaults` logic from the generator (or most of it) and put it as a non-config requirement in the core cli.

## TODO:

- Prefetching
- other things that might come up
- More aggressive chunksplitting strategies on specialized builds