### PR TITLE
chore: changed the package manager condition

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -80,7 +80,10 @@ For more information, see https://webpack.js.org/api/cli/.`);
 					instructions = `Install webpack to start bundling: \u001b[32m\n  $ npm install --save-dev ${moduleName}\n`;
 					const path = require("path");
 					const fs = require("fs");
-					if (fs.existsSync(path.resolve(process.cwd(), "yarn.lock"))) {
+					const isYarn =
+						fs.existsSync(path.resolve(process.cwd(), "yarn.lock")) ||
+						(process.env.npm_execpath !== undefined && process.env.npm_execpath.includes("yarn"));
+					if (isYarn) {
 						instructions = `Install webpack to start bundling: \u001b[32m\n $ yarn add ${moduleName} --dev\n`;
 					}
 					Error.stackTraceLimit = 1;

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -4,7 +4,8 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
 */
-
+const path = require("path");
+const fs = require("fs");
 const { NON_COMPILATION_ARGS } = require("./utils/constants");
 
 (function() {
@@ -78,8 +79,6 @@ For more information, see https://webpack.js.org/api/cli/.`);
 				if (moduleName === "webpack") {
 					errorMessage = `\n${moduleName} not installed`;
 					instructions = `Install webpack to start bundling: \u001b[32m\n  $ npm install --save-dev ${moduleName}\n`;
-					const path = require("path");
-					const fs = require("fs");
 					const isYarn =
 						fs.existsSync(path.resolve(process.cwd(), "yarn.lock")) ||
 						(process.env.npm_execpath !== undefined && process.env.npm_execpath.includes("yarn"));

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -78,8 +78,9 @@ For more information, see https://webpack.js.org/api/cli/.`);
 				if (moduleName === "webpack") {
 					errorMessage = `\n${moduleName} not installed`;
 					instructions = `Install webpack to start bundling: \u001b[32m\n  $ npm install --save-dev ${moduleName}\n`;
-
-					if (process.env.npm_execpath !== undefined && process.env.npm_execpath.includes("yarn")) {
+					const path = require("path");
+					const fs = require("fs");
+					if (fs.existsSync(path.resolve(process.cwd(), "yarn.lock"))) {
 						instructions = `Install webpack to start bundling: \u001b[32m\n $ yarn add ${moduleName} --dev\n`;
 					}
 					Error.stackTraceLimit = 1;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
refactoring

**Did you add tests for your changes?**
NA

**If relevant, did you update the documentation?**
NA

**Summary**
closes #953 
In the issue, I mentioned that 
```javascript
fs.existsSync(path.resolve(process.cwd(), "yarn.lock")) 

// to changed with 

process.env.npm_execpath !== undefined && process.env.npm_execpath.includes("yarn")

// in the prompt-command.js
```
but I did the opposite as that `process.env.npm_execpath` has most chance to result in `undefined`



**Does this PR introduce a breaking change?**
NA
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
NA