### PR TITLE
chore(ts): enables source map in the ts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ yarn.lock
 # source maps of docs
 docs/**/*.map
 junit.xml
+
+#typescript source maps
+packages/**/*.map

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -6,7 +6,8 @@
 		"skipLibCheck": true,
 		"target": "es6",
 		"lib": ["es6", "es2017"],
-		"resolveJsonModule": true
+		"resolveJsonModule": true,
+		"sourceMap": true
 	},
 	"include": ["packages/**/*.ts"],
 	"exclude": [


### PR DESCRIPTION
Enables the source maps for the ts compiled files for easy debugging.

https://code.visualstudio.com/docs/typescript/typescript-debugging#_javascript-source-map-support


**What kind of change does this PR introduce?**
feature

**Summary**
Setting breakpoints in the TS won't work as JS files are being used, with the help of source maps which has one to one mapping for each statement allows the editor to resolve the respective line in the JS file. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
While debugging ts files.
