### PR TITLE
fix: removed process.getuid method as its not supported in winos

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -352,7 +352,13 @@ For more information, see https://webpack.js.org/api/cli/.`);
 							// On windows we need to manually update the atime
 							// Updating utime requires process owner is as same as file owner
 							access(openCollectivePath, constants.W_OK, e => {
-								if (!e) utimesSync(openCollectivePath, now, now);
+								if (process.platform === "darwin" || process.platform === "linux") {
+									const fileOwnerId = stat.uid;
+									if (!e && fileOwnerId === process.getuid())
+										utimesSync(openCollectivePath, now, now);
+								} else {
+									if (!e) utimesSync(openCollectivePath, now, now);
+								}
 							});
 						}
 					}

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -349,16 +349,10 @@ For more information, see https://webpack.js.org/api/cli/.`);
 						const timeSinceLastPrint = now.getTime() - lastPrintTS;
 						if (timeSinceLastPrint > SIX_DAYS) {
 							require(openCollectivePath);
-							// On windows we need to manually update the atime
-							// Updating utime requires process owner is as same as file owner
 							access(openCollectivePath, constants.W_OK, e => {
-								if (process.platform === "darwin" || process.platform === "linux") {
-									const fileOwnerId = stat.uid;
-									if (!e && fileOwnerId === process.getuid())
-										utimesSync(openCollectivePath, now, now);
-								} else {
+								try {
 									if (!e) utimesSync(openCollectivePath, now, now);
-								}
+								} catch (err) {}
 							});
 						}
 					}

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -345,7 +345,6 @@ For more information, see https://webpack.js.org/api/cli/.`);
 						const { access, constants, statSync, utimesSync } = require("fs");
 						const stat = statSync(openCollectivePath);
 						const lastPrint = stat.atime;
-						const fileOwnerId = stat.uid;
 						const lastPrintTS = new Date(lastPrint).getTime();
 						const timeSinceLastPrint = now.getTime() - lastPrintTS;
 						if (timeSinceLastPrint > SIX_DAYS) {
@@ -353,7 +352,7 @@ For more information, see https://webpack.js.org/api/cli/.`);
 							// On windows we need to manually update the atime
 							// Updating utime requires process owner is as same as file owner
 							access(openCollectivePath, constants.W_OK, e => {
-								if (!e && fileOwnerId === process.getuid()) utimesSync(openCollectivePath, now, now);
+								if (!e) utimesSync(openCollectivePath, now, now);
 							});
 						}
 					}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
bugfix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
NA

**If relevant, did you update the documentation?**
NA

**Summary**
fixes #962 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
So here is the thing
As far as I looked, windows seem to give `users sid` for a user and I guess there is no support for that to check with any file/folders as they don't keep that info with it 
*(maybe ! please comment if I am wrong about it)* 
So there is no way to check them with the file. the ` sid ` looks weird too.
```bash
H:\testing>WMIC useraccount get sid
SID
S-1-5-XX-352825XXXX-XXXXXXXXX-XXXXXXXXX-XXX
S-1-5-XX-352825XXXX-XXXXXXXXX-XXXXXXXXX-XXX
S-1-5-XX-352825XXXX-XXXXXXXXX-XXXXXXXXX-XXX
S-1-5-XX-352825XXXX-XXXXXXXXX-XXXXXXXXX-XXX
S-1-5-XX-352825XXXX-XXXXXXXXX-XXXXXXXXX-XXX
S-1-5-XX-352825XXXX-XXXXXXXXX-XXXXXXXXX-XXX
```
Also in windows as far as I know **`statSync("anyfile-or-folder").uid`**  will always be **0**
So I think removing that check seems fare or can add try-catch, at least it will be there for OSX users 
```javascript
try {
    if(fileOwnerId === process.getuid()){
        // actions code here , setting the utime
    }
} catch (error) {
    // setting the utime -- here
}
```
or no need for try-catch cause any way the timestamp needs to update in that file.

what say @evenstensberg @ematipico 