### PR TITLE
fix(deps): move prettier from dependencies to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13213,7 +13213,8 @@
     "prettier": {
       "version": "1.18.2",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
-      "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw=="
+      "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==",
+      "dev": true
     },
     "prettier-eslint": {
       "version": "8.8.2",

--- a/package.json
+++ b/package.json
@@ -124,7 +124,6 @@
     "import-local": "2.0.0",
     "interpret": "1.2.0",
     "loader-utils": "1.2.3",
-    "prettier": "1.18.2",
     "supports-color": "5.5.0",
     "v8-compile-cache": "2.0.3",
     "yargs": "12.0.5"
@@ -164,6 +163,7 @@
     "lerna": "3.15.0",
     "lint-staged": "7.3.0",
     "nyc": "14.1.1",
+    "prettier": "1.18.2",
     "prettier-eslint-cli": "4.7.1",
     "readable-stream": "3.4.0",
     "rimraf": "2.6.3",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
bugfix

**Did you add tests for your changes?**
N/A

**If relevant, did you update the documentation?**
N/A

**Summary**
`prettier` is used during development of `webpack-cli` and does not need to be pulled in by all packages that use `webpack-cli`; thus it should be in `devDependencies`, not `dependencies`. (Bug introduced by #851.)

**Does this PR introduce a breaking change?**
No.
