### PR TITLE
chore(questions): makes default lang type to none

### DIFF
--- a/packages/generators/init-generator.ts
+++ b/packages/generators/init-generator.ts
@@ -139,8 +139,8 @@ export default class InitGenerator extends Generator {
 			self,
 			"langType",
 			"Will you use one of the below JS solutions?",
-			[LangType.ES6, LangType.Typescript, "No"],
-			LangType.ES6,
+			["No", LangType.ES6, LangType.Typescript],
+			"No",
 			this.autoGenerateConfig
 		);
 


### PR DESCRIPTION
made default language type in init command to none from es6


**What kind of change does this PR introduce?**
chore

**Did you add tests for your changes?**
Nopes

**If relevant, did you update the documentation?**
Nopes

**Summary**
In init the default language type is ES6, generally its none (NO), like styling.

**Motivation**
While working on the `init` package, I was supposed to run init command multiple numbers of time, hence it was quite tedious to select NO in language type.

Hence, IMO default lang type should be None.