### PR TITLE
Docs(next): changed init docs , added auto flag for the node 

### DIFF
--- a/packages/init/README.md
+++ b/packages/init/README.md
@@ -25,7 +25,7 @@ const init = require("@webpack-cli/init").default;
 init();
 
 // we're slicing node.process, ...myPacakges is a webpack-scaffold name/path
-init(null, null, ...myPacakges);
+init(null, null, null, ...myPacakges);
 
 // for auto flag to use the default configs
 init(null, null, null, "--auto")

--- a/packages/init/README.md
+++ b/packages/init/README.md
@@ -25,7 +25,10 @@ const init = require("@webpack-cli/init").default;
 init();
 
 // we're slicing node.process, ...myPacakges is a webpack-scaffold name/path
-init([null, null, ...myPacakges]);
+init(null, null, ...myPacakges);
+
+// for auto flag to use the default configs
+init(null, null, null, "--auto")
 ```
 
 ### CLI (via `webpack-cli`)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
refactoring

**Did you add tests for your changes?**
NA

**If relevant, did you update the documentation?**
NA

**Summary**
as in the init package, its using `args.slice(3)` in order to detect whether any custom scaffold or `--auto` flag is passed or not, in the init docs it was 
`init([null,null,..myPackages])`

**there are two conflicts with this**

- in the `init/index.ts`, in `initializeInquirer` the arguments are spread so its actually converting it into array , so if there is `init([ ])` used to call the API, then its actually spreading it and making array of array `[ [ ] ]`, and it will create an error, as there won't be any **3rd** index so it will be skipped

- there are 3 arguments mentioned in the docs which are passing to the method, so as its `slice(3)` again the scaffold will be skipped

Also 
I added docs for running the `init` using node for `--auto` flag too

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
NA