### PR TITLE
chore(deps): upgrade import-local from 3.0.1 to 3.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "convert-source-map": "^1.1.0",
         "debug": "^4.1.0",
         "json5": "^2.1.0",
-        "lodash": "^4.17.13",
+        "lodash": "^4.17.11",
         "resolve": "^1.3.2",
         "semver": "^5.4.1",
         "source-map": "^0.5.0"
@@ -75,7 +75,7 @@
       "requires": {
         "@babel/types": "^7.5.0",
         "jsesc": "^2.5.1",
-        "lodash": "^4.17.13",
+        "lodash": "^4.17.11",
         "source-map": "^0.5.0",
         "trim-right": "^1.0.1"
       }
@@ -177,7 +177,7 @@
         "@babel/types": "^7.5.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
-        "lodash": "^4.17.13"
+        "lodash": "^4.17.11"
       },
       "dependencies": {
         "debug": {
@@ -204,7 +204,7 @@
       "dev": true,
       "requires": {
         "esutils": "^2.0.2",
-        "lodash": "^4.17.13",
+        "lodash": "^4.17.11",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -231,7 +231,7 @@
         "babel-polyfill": "6.26.0",
         "chalk": "2.3.1",
         "get-stdin": "7.0.0",
-        "lodash": "4.17.13",
+        "lodash": "4.17.11",
         "meow": "5.0.0",
         "resolve-from": "5.0.0",
         "resolve-global": "1.0.0"
@@ -249,7 +249,7 @@
           }
         },
         "lodash": {
-          "version": "4.17.13",
+          "version": "4.17.11",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.13.tgz",
           "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
           "dev": true
@@ -281,11 +281,11 @@
       "integrity": "sha512-rhBO79L9vXeb26JU+14cxZQq46KyyVqlo31C33VIe7oJndUtWrDhZTvMjJeB1pdXh4EU4XWdMo+yzBmuypFgig==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.13"
+        "lodash": "4.17.11"
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.13",
+          "version": "4.17.11",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.13.tgz",
           "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
           "dev": true
@@ -337,11 +337,11 @@
         "@commitlint/parse": "^8.0.0",
         "@commitlint/rules": "^8.0.0",
         "babel-runtime": "^6.23.0",
-        "lodash": "4.17.13"
+        "lodash": "4.17.11"
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.13",
+          "version": "4.17.11",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.13.tgz",
           "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
           "dev": true
@@ -358,12 +358,12 @@
         "@commitlint/resolve-extends": "^8.0.0",
         "babel-runtime": "^6.23.0",
         "cosmiconfig": "^5.2.0",
-        "lodash": "4.17.13",
+        "lodash": "4.17.11",
         "resolve-from": "^5.0.0"
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.13",
+          "version": "4.17.11",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.13.tgz",
           "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
           "dev": true
@@ -384,7 +384,7 @@
       "requires": {
         "conventional-changelog-angular": "^1.3.3",
         "conventional-commits-parser": "^2.1.0",
-        "lodash": "^4.17.13"
+        "lodash": "^4.17.11"
       }
     },
     "@commitlint/read": {
@@ -407,13 +407,13 @@
       "requires": {
         "babel-runtime": "6.26.0",
         "import-fresh": "^3.0.0",
-        "lodash": "4.17.13",
+        "lodash": "4.17.11",
         "resolve-from": "^5.0.0",
         "resolve-global": "^1.0.0"
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.13",
+          "version": "4.17.11",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.13.tgz",
           "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
           "dev": true
@@ -5054,7 +5054,7 @@
         "js-yaml": "^3.13.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.3.0",
-        "lodash": "^4.17.13",
+        "lodash": "^4.17.11",
         "minimatch": "^3.0.4",
         "mkdirp": "^0.5.1",
         "natural-compare": "^1.4.0",
@@ -7215,9 +7215,9 @@
       "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM="
     },
     "import-local": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.1.tgz",
-      "integrity": "sha512-XlabwTJ9tPOdyjnGdGvxUMnUhmhlnJhdYjp5e8UDb2fO+5Gto1Frlg66ixVAf1Os+zQlrKt3QlTCVodyxYBZjQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.2.tgz",
+      "integrity": "sha512-vjL3+w0oulAVZ0hBHnxa/Nm5TAurf9YLQJDhqRZyqb+VKGOB6LU8t9H1Nr5CIo16vh9XfJTOoHwU0B71S557gA==",
       "requires": {
         "pkg-dir": "^4.2.0",
         "resolve-cwd": "^3.0.0"
@@ -11320,7 +11320,7 @@
       "integrity": "sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.13"
+        "lodash": "^4.17.11"
       }
     },
     "request-promise-native": {
@@ -12206,7 +12206,7 @@
       "dev": true,
       "requires": {
         "ajv": "^6.9.1",
-        "lodash": "^4.17.13",
+        "lodash": "^4.17.11",
         "slice-ansi": "^2.1.0",
         "string-width": "^3.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "ansi-escapes": "^4.2.0",
     "cli-table": "^0.3.1",
     "command-line-args": "^5.1.1",
-    "import-local": "^3.0.1",
+    "import-local": "^3.0.2",
     "terser-webpack-plugin": "^1.3.0",
     "update-notifier": "^3.0.1",
     "v8-compile-cache": "^2.0.3",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
Update dependency

**Did you add tests for your changes?**

No

**If relevant, did you update the documentation?**

N/A

**Summary**

I am on Windows 7, Node v8.12.0

I was trying to run `webpack-cli` through an npm script where `webpack-cli` was linked with `npm link`. I found that it was not getting past this conditional: https://github.com/webpack/webpack-cli/blob/8141e0e7b429ebd09b1c6e8bc61a4f065cf72dc3/cli.js#L10. Updating `import-local` to 3.0.2 solved the issue, though I have not really investigated why.

**Does this PR introduce a breaking change?**

No

**Other information**
