### PR TITLE
[NEXT] BugFix: changed the path resolver call

### DIFF
--- a/lib/groups/output.js
+++ b/lib/groups/output.js
@@ -7,7 +7,7 @@ class OutputGroup extends GroupHelper {
     }
 
     resolveOptions() {
-        const { args } = this;
+        const { args, resolveFilePath } = this;
 
         this.opts = {
             options: {
@@ -21,7 +21,7 @@ class OutputGroup extends GroupHelper {
                 this.opts.options.output['path'] = outputInfo.dir ? path.resolve(process.cwd(), outputInfo.dir) : path.resolve(process.cwd(), 'dist');
                 this.opts.options.output.filename = outputInfo.base;
             } else {
-                this.opts.options.output['path'] = ArgsValidator.resolveFileDirectory(args.output, 'dist');
+                this.opts.options.output['path'] = resolveFilePath(args.output, 'dist');
                 this.opts.options.output.filename = 'bundle.js';
             }
         }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
bugfix

**Did you add tests for your changes?**
NA

**If relevant, did you update the documentation?**
NA

**Summary**
There was no `ArgsValidator` declared, and as far as the `resolveFileDirectory` is concerned, if it's being inherited from the `groupHelper` class then it should be  `resolveFilePath` , as there is no `resolveFileDirectory` declared as well 
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No

**Other information**
N/A