### PR TITLE
cli: replace cli-table with cli-table3

### DIFF
--- a/lib/utils/compiler.js
+++ b/lib/utils/compiler.js
@@ -1,7 +1,7 @@
 const webpack = require('webpack');
 const fs = require('fs');
 const chalk = require('chalk');
-const Table = require('cli-table');
+const Table = require('cli-table3');
 
 function showEmojiConditionally(emoji) {
     if (process.stdout.isTTY && !process.platform === 'darwin') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3573,12 +3573,44 @@
         "restore-cursor": "^2.0.0"
       }
     },
-    "cli-table": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
-      "integrity": "sha1-9TsFJmqLGguTSz0IIebi3FkUriM=",
+    "cli-table3": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.5.1.tgz",
+      "integrity": "sha512-7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==",
       "requires": {
-        "colors": "1.0.3"
+        "colors": "^1.1.2",
+        "object-assign": "^4.1.0",
+        "string-width": "^2.1.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+        },
+        "colors": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
+          "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
+          "optional": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
       }
     },
     "cli-truncate": {
@@ -3735,11 +3767,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-    },
-    "colors": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
     },
     "columnify": {
       "version": "1.5.4",

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
   },
   "dependencies": {
     "ansi-escapes": "^4.2.0",
-    "cli-table": "^0.3.1",
+    "cli-table3": "^0.5.1",
     "command-line-args": "^5.1.1",
     "command-line-usage": "^6.0.2",
     "import-local": "^3.0.2",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

This PR replaces project dependency: `cli-table` with `cli-table3`

**Summary**

`cli-table` is a great package. However, it's not actively maintained (last commit was almost a year ago). `cli-table3` is a drop-in replacement, which is actively maintained and has some additional features, including:

* Ability to make cells span columns and/or rows.
* Ability to set custom styles per cell (border characters/colors, padding, etc).
* Vertical alignment (top, bottom, center).
* Automatic word wrapping.
* More robust truncation of cell text that contains ansi color characters.
* Better handling of text color that spans multiple lines.
* Exhaustive test suite including the entire original cli-table test suite.


**Does this PR introduce a breaking change?**

No.

**Other information**

There is also a package called `cli-table2`, but it's also not maintained and it's repository has been archived by the owner.
