### PR TITLE
tests: add tests for entry defaults, try to set better defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,8 +24,8 @@ coverage
 
 # Test Compilation
 test/js/*
-test/binCases/**/bin/
-test/binCases/**/**/bin/
+test/**/bin/
+test/**/**/bin/
 # lerna log
 lerna-debug.log
 

--- a/build/changelog-generator/index.js
+++ b/build/changelog-generator/index.js
@@ -5,6 +5,7 @@
  *  Based on: https://github.com/GoogleChrome/lighthouse/blob/master/build/changelog-generator/
  */
 'use strict';
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
 const readFileSync = require('fs').readFileSync;
 const resolve = require('path').resolve;
 const mainTemplate = readFileSync(resolve(__dirname, 'templates/template.hbs')).toString();

--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -5,7 +5,7 @@ const cmdArgs = require('command-line-args');
 require('./utils/process-log');
 
 const isFlagPresent = (args, flag) => args.find(arg => [flag, `--${flag}`].includes(arg));
-const normalizeFlags = (args, cmd) => args.slice(2).filter(arg => arg.indexOf('--') < 0 && arg !== cmd.name && arg !== cmd.alias);
+const stripDashedFlags = (args, cmd) => args.slice(2).filter(arg => ~arg.indexOf('--') && arg !== cmd.name && arg !== cmd.alias);
 
 const isCommandUsed = commands =>
     commands.find(cmd => {
@@ -27,18 +27,24 @@ async function runCLI(cli, commandIsUsed) {
 
     if (commandIsUsed) {
         commandIsUsed.defaultOption = true;
-        args = normalizeFlags(process.argv, commandIsUsed);
+        args = stripDashedFlags(process.argv, commandIsUsed);
         return await cli.runCommand(commandIsUsed, ...args);
     } else {
-        args = cmdArgs(core, { stopAtFirstUnknown: false });
         try {
+        args = cmdArgs(core, { stopAtFirstUnknown: false });
             const result = await cli.run(args, core);
             if (!result) {
                 return;
             }
         } catch (err) {
+
+            // TODO: normalzie and retry args when keys are same
+
+            if(err.name === 'UNKNOWN_VALUE') {
+                process.cliLogger.error(`Parse Error (unknown argument): ${err.value}`);
+                return;
+            }
             process.cliLogger.error(err);
-            process.exit(1);
         }
     }
 }

--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -38,7 +38,7 @@ async function runCLI(cli, commandIsUsed) {
             }
         } catch (err) {
 
-            // TODO: normalzie and retry args when keys are same
+            // TODO: normalize and retry args when keys are same
 
             if(err.name === 'UNKNOWN_VALUE') {
                 process.cliLogger.error(`Parse Error (unknown argument): ${err.value}`);

--- a/lib/utils/dev-config.js
+++ b/lib/utils/dev-config.js
@@ -4,7 +4,7 @@ const JsConfigWebpackPlugin = require('js-config-webpack-plugin');
 
 module.exports = {
     mode: 'development',
-
+    entry: './index.js',
     plugins: [new webpack.ProgressPlugin(), new JsConfigWebpackPlugin()],
 
     optimization: {

--- a/lib/webpack-cli.js
+++ b/lib/webpack-cli.js
@@ -1,4 +1,5 @@
-const { join } = require('path');
+const { join, resolve, parse } = require('path');
+const { existsSync } = require('fs');
 const GroupHelper = require('./utils/group-helper');
 const Compiler = require('./utils/compiler');
 
@@ -32,9 +33,21 @@ class webpackCLI extends GroupHelper {
 
     checkDefaults(groupResult) {
         const { options } = groupResult;
-        if (!options.entry) {
-            this.shouldUseMem = true;
+        if(options.entry && options.entry === './index.js') {
+            const normalizedEntry = resolve(options.entry);
+            if(!existsSync(normalizedEntry)) {
+                try {
+                    const parsedPath = parse(normalizedEntry);
+                    const secondEntryDefault = join(parsedPath.dir, 'src', 'index.js');
+                    if(existsSync(secondEntryDefault)) {
+                        groupResult.options.entry = secondEntryDefault;
+                    }
+                } catch(err) {
+                    groupResult.options.entry = normalizedEntry;
+                }
+            }
         }
+        return groupResult;
     }
 
     resolveGroups() {
@@ -93,8 +106,8 @@ class webpackCLI extends GroupHelper {
     async run(args, yargsOptions) {
         await this.setMappedGroups(args, yargsOptions);
         await this.resolveGroups();
-        const groupResult = await this.runOptionGroups();
-        this.checkDefaults(groupResult);
+        let groupResult = await this.runOptionGroups();
+        groupResult = this.checkDefaults(groupResult);
         const webpack = await Compiler(groupResult, this.shouldUseMem);
         return webpack;
     }

--- a/packages/webpack-scaffold/index.ts
+++ b/packages/webpack-scaffold/index.ts
@@ -1,6 +1,8 @@
 import * as jscodeshift from "jscodeshift";
 import * as Generator from "yeoman-generator";
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 export function createArrowFunction(value: string): string {
 	return `() => '${value}'`;
 }

--- a/test/config/basic/basic-config.test.js
+++ b/test/config/basic/basic-config.test.js
@@ -3,8 +3,8 @@ const { stat } = require('fs');
 const { resolve, sep } = require('path');
 const { run, extractSummary } = require('../../utils/test-utils');
 
-describe('config flag test : Basic config file', () => {
-    it(' Output Directory as basic/bin, create a file name bundle.js inside bin', done => {
+describe('basic config file', () => {
+    it('Has Output Directory as basic/bin, creates a file name bundle.js', done => {
         const { stdout } = run(__dirname, ['-c', resolve(__dirname, 'webpack.config.js')]);
         const summary = extractSummary(stdout);
         const outputDir = 'basic/bin';

--- a/test/entry/defaults-empty/entry-single-arg.test.js
+++ b/test/entry/defaults-empty/entry-single-arg.test.js
@@ -9,7 +9,7 @@ describe('single entry flag empty project', () => {
     it('sets default entry, compiles but throw missing entry module error', done => {
         const { stdout, stderr } = run(__dirname);
         const summary = extractSummary(stdout);
-        const outputDir = 'entry/bin';
+        const outputDir = 'defaults-empty/bin';
         const outDirectoryFromCompiler = summary['Output Directory'].split(sep);
         const outDirToMatch = outDirectoryFromCompiler.slice(outDirectoryFromCompiler.length - 2, outDirectoryFromCompiler.length).join('/');
         expect(outDirToMatch).toContain(outputDir);

--- a/test/entry/defaults-empty/entry-single-arg.test.js
+++ b/test/entry/defaults-empty/entry-single-arg.test.js
@@ -3,15 +3,17 @@
 const { stat } = require('fs');
 const { resolve } = require('path');
 
-const { run, extractSummary } = require('../utils/test-utils');
+const { run, extractSummary } = require('../../utils/test-utils');
 
-describe('single entry flag', () => {
-    it('compile but throw missing entry module error', done => {
+describe('single entry flag empty project', () => {
+    it('sets default entry, compiles but throw missing entry module error', done => {
         const { stdout, stderr } = run(__dirname);
         const summary = extractSummary(stdout);
-        const outputDir = 'entry/bin';
+        const outputDir = 'entry/defaults-empty/bin';
+
         expect(summary['Output Directory']).toContain(outputDir);
-        expect(stderr).toContain('Entry module not found');
+        // eslint-disable-next-line
+        expect(stderr).toContain('Entry module not found: Error: Can\'t resolve \'./index.js\'');
         stat(resolve(__dirname, './bin'), (err, stats) => {
             expect(err).toBe(null);
             expect(stats.isDirectory()).toBe(true);

--- a/test/entry/defaults-index/entry-multi-args.test.js
+++ b/test/entry/defaults-index/entry-multi-args.test.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const { stat } = require('fs');
+const { resolve } = require('path');
+
+const { run, extractSummary } = require('../../utils/test-utils');
+
+describe('single entry flag index present', () => {
+    it('finds default index file and compiles successfully', done => {
+        const { stdout, stderr } = run(__dirname);
+        const summary = extractSummary(stdout);
+        const outputDir = 'entry/defaults-index/bin';
+
+        expect(summary['Output Directory']).toContain(outputDir);
+        // eslint-disable-next-line
+        expect(stderr).not.toContain('Entry module not found: Error: Can\'t resolve \'./index.js\'');
+        stat(resolve(__dirname, './bin/bundle.js'), (err, stats) => {
+            expect(err).toBe(null);
+            expect(stats.isFile()).toBe(true);
+            done();
+        });
+    });
+
+    it('finds default index file, compiles and overrides with flags successfully', done => {
+        const { stdout, stderr } = run(__dirname, ['output', 'bin/main.js']);
+        expect(stderr).toBe(undefined);
+        const summary = extractSummary(stdout);
+        const outputDir = 'entry/defaults-index/bin';
+
+        expect(summary['Output Directory']).toContain(outputDir);
+        // eslint-disable-next-line
+        expect(stderr).not.toContain('Entry module not found: Error: Can\'t resolve \'./index.js\'');
+        stat(resolve(__dirname, './bin/main.js'), (err, stats) => {
+            expect(err).toBe(null);
+            expect(stats.isFile()).toBe(true);
+            done();
+        });
+    });
+});

--- a/test/utils/test-utils.js
+++ b/test/utils/test-utils.js
@@ -1,5 +1,5 @@
 'use strict';
-
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
 const path = require('path');
 const fs = require('fs');
 const execa = require('execa');
@@ -7,7 +7,7 @@ const { sync: spawnSync } = execa;
 const { Writable } = require('readable-stream');
 
 const WEBPACK_PATH = path.resolve(__dirname, '../../cli.js');
-
+const ENABLE_LOG_COMPILATION = process.env.ENABLE_PIPE || false;
 /**
  * Description
  *
@@ -23,7 +23,9 @@ function run(testCase, args = []) {
     const result = spawnSync(WEBPACK_PATH, argsWithOutput, {
         cwd,
         reject: false,
+        stdio: ENABLE_LOG_COMPILATION ? 'inherit' : 'pipe',
     });
+
     return result;
 }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Adds tests for entries, test if `./src/index.js` is present and set that default if it exists.

**Did you add tests for your changes?**
Yes bby
**If relevant, did you update the documentation?**
N/A
**Summary**
Adds tests, improves code

**Does this PR introduce a breaking change?**
N/A
**Other information**

Keep in mind 1 of the cases fails, because we cannot override mixed arguments yet, I'll try to get that to work. For instance:

`webpack-cli --entry index.js entry index2.js` will fail because we have duplicate keys. Same goes for the opposite scenario or if we have `webpack-cli --entry index.js --entry index2.js`

in case of using `--` twice, we can convert those two into an array, which will be the best case, but for mixed arguments I think we need to decide to override the first key and set a notation that mixing conventions is not encouraged.

