### PR TITLE
Support `export default` from configuration files.

### DIFF
--- a/lib/groups/config.js
+++ b/lib/groups/config.js
@@ -41,6 +41,14 @@ class ConfigGroup extends GroupHelper {
         };
     }
 
+    require(path) {
+        const result = require(path);
+        if (result && result.__esModule && result.default) {
+            return result.default;
+        }
+        return result;
+    }
+
     requireConfig(configPath) {
         const { register } = this.args;
 
@@ -48,7 +56,7 @@ class ConfigGroup extends GroupHelper {
             if (register && register.length) {
                 module.paths.unshift(resolve(process.cwd(), 'node_modules'));
                 register.forEach(dep => {
-                    const isRelative = ["./", "../", ".\\", "..\\"].some(start => dep.startsWith(start));
+                    const isRelative = ['./', '../', '.\\', '..\\'].some(start => dep.startsWith(start));
                     if (isRelative) {
                         require(resolve(process.cwd(), dep));
                     } else {
@@ -56,7 +64,7 @@ class ConfigGroup extends GroupHelper {
                     }
                 });
             }
-            return require(configPath);
+            return this.require(configPath);
         })();
     }
 
@@ -110,7 +118,7 @@ class ConfigGroup extends GroupHelper {
         const { merge } = this.args;
         if (merge) {
             const newConfigPath = this.resolveFilePath(merge, 'webpack.base');
-            const newConfig = newConfigPath ? require(newConfigPath) : null;
+            const newConfig = newConfigPath ? this.require(newConfigPath) : null;
             this.opts['options'] = require('webpack-merge')(this.opts['options'], newConfig);
         }
     }


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Feature.

**Did you add tests for your changes?**

Nope 😢 Tested it locally? Not sure how to add tests or what tests one would like to see.

**If relevant, did you update the documentation?**

Not necessary hopefully, since I imagine people want ES modules as config files to just work™.

**Summary**

This changes adds a `require` wrapper to the `config` group that allows it to detect and return the default export of ES modules. This is useful when your configuration is a TS(X) file or something that is being transpiled by babel.

**Does this PR introduce a breaking change?**

Nope!

**Other information**

If one could possibly publish `webpack-cli@4.0.0-alpha-6` with these changes that would be 👌 