### PR TITLE
chore: changed the outDir to entry test

### DIFF
--- a/test/entry/entry-single-arg.test.js
+++ b/test/entry/entry-single-arg.test.js
@@ -10,7 +10,12 @@ describe('single entry flag', () => {
         const { stdout, stderr } = run(__dirname);
         const summary = extractSummary(stdout);
         const outputDir = 'entry/bin';
-        expect(summary['Output Directory']).toContain(outputDir);
+        const outDirectoryFromCompiler = summary['Output Directory'];
+        const outDirToMatch = outDirectoryFromCompiler
+            .split('\\')
+            .slice(outDirectoryFromCompiler.split('\\').length - 2, outDirectoryFromCompiler.split('\\').length)
+            .join('/');
+        expect(outDirToMatch).toContain(outputDir);
         expect(stderr).toContain('Entry module not found');
         stat(resolve(__dirname, './bin'), (err, stats) => {
             expect(err).toBe(null);

--- a/test/entry/entry-single-arg.test.js
+++ b/test/entry/entry-single-arg.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { stat } = require('fs');
-const { resolve } = require('path');
+const { resolve, sep } = require('path');
 
 const { run, extractSummary } = require('../utils/test-utils');
 
@@ -10,11 +10,8 @@ describe('single entry flag', () => {
         const { stdout, stderr } = run(__dirname);
         const summary = extractSummary(stdout);
         const outputDir = 'entry/bin';
-        const outDirectoryFromCompiler = summary['Output Directory'];
-        const outDirToMatch = outDirectoryFromCompiler
-            .split('\\')
-            .slice(outDirectoryFromCompiler.split('\\').length - 2, outDirectoryFromCompiler.split('\\').length)
-            .join('/');
+        const outDirectoryFromCompiler = summary['Output Directory'].split(sep);
+        const outDirToMatch = outDirectoryFromCompiler.slice(outDirectoryFromCompiler.length - 2, outDirectoryFromCompiler.length).join('/');
         expect(outDirToMatch).toContain(outputDir);
         expect(stderr).toContain('Entry module not found');
         stat(resolve(__dirname, './bin'), (err, stats) => {

--- a/test/entry/entry-single-arg.test.js
+++ b/test/entry/entry-single-arg.test.js
@@ -14,7 +14,7 @@ describe('single entry flag', () => {
         const outDirToMatch = outDirectoryFromCompiler.slice(outDirectoryFromCompiler.length - 2, outDirectoryFromCompiler.length).join('/');
         expect(outDirToMatch).toContain(outputDir);
         expect(stderr).toContain('Entry module not found');
-        stat(resolve(__dirname, './bin'), (err, stats) => {
+        stat(resolve(__dirname, 'bin'), (err, stats) => {
             expect(err).toBe(null);
             expect(stats.isDirectory()).toBe(true);
             done();

--- a/test/utils/test-utils.js
+++ b/test/utils/test-utils.js
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
 'use strict';
 
 const path = require('path');


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
refactoring/bugfix

**Did you add tests for your changes?**
NA

**If relevant, did you update the documentation?**
NA

**Summary**
the current matching method, the test is failing in windows as the `Output Director` is as follows
```
\\Path-to\\webpack-cli\\test\\entry\\bin
``` 
and this is been matched with `entry/bin` which is failing .
So if we refactored the current to just check with the last two directory, we can make it to pass

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No

**Other information**
Also disabled the `@typescript-eslint/explicit-function-return-type` for `test-utils` file as its causing to failed while committing.
 