### PR TITLE
chore(cli): colorize commands to run and package to be installed

### DIFF
--- a/lib/commands/external.js
+++ b/lib/commands/external.js
@@ -1,5 +1,5 @@
 const { prompt } = require('inquirer');
-
+const chalk = require('chalk');
 class ExternalCommand {
     static async runCommand(command, args = []) {
         const cp = require('child_process');
@@ -34,7 +34,6 @@ class ExternalCommand {
         const path = require('path');
         const fs = require('fs');
         const isYarn = fs.existsSync(path.resolve(process.cwd(), 'yarn.lock'));
-
         const packageManager = isYarn ? 'yarn' : 'npm';
         const options = ['install', '-D', scopeName];
 
@@ -43,8 +42,8 @@ class ExternalCommand {
         }
 
         const commandToBeRun = `${packageManager} ${options.join(' ')}`;
-        process.cliLogger.error(`The command moved into a separate package: ${name}`);
-        const question = `Would you like to install ${name}? (That will run ${commandToBeRun})`;
+        process.cliLogger.error(`The command moved into a separate package: ${chalk.keyword('orange')(name)}\n`);
+        const question = `Would you like to install ${name}? (That will run ${chalk.green(commandToBeRun)})`;
         const answer = await prompt([
             {
                 type: 'confirm',


### PR DESCRIPTION
colorize important things on the cli

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Colorized command that will run and the package name that will be installed.
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
No

**If relevant, did you update the documentation?**
No

**Summary**
![image](https://user-images.githubusercontent.com/21009455/63938831-62492c80-ca83-11e9-99cd-acd5eb231f80.png)

* Color the command that will run to install the packages, and the package name.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
lmk if other colors are more preferred!