### PR TITLE
Fix jscodeshift import (fixes #1064)

### DIFF
--- a/packages/migrate/index.ts
+++ b/packages/migrate/index.ts
@@ -11,7 +11,7 @@ import runPrettier from "@webpack-cli/utils/run-prettier";
 
 import { transformations } from "./migrate";
 import { Node } from "./types/NodePath";
-import jscodeshift from "jscodeshift";
+import * as jscodeshift from "jscodeshift";
 
 declare let process: {
 	cwd: Function;


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Fixes #1064 

**Did you add tests for your changes?**
no :(
This requires testing the CLI itself (as the issue is in index.ts), and currently there are no such tests. I saw there are other CLI tests (for other commands), but none of them test a command which expects user input.
I found the [inquirer-test](https://github.com/ewnd9/inquirer-test) package which might be helpful, so let me know how you think I should proceed here.

**Summary**
jscodeshift doesn't expose a default import, changed it to import the exported function correctly.

**Does this PR introduce a breaking change?**
no