### PR TITLE
chore(serve): remove promise return from serve package

### DIFF
--- a/packages/serve/index.ts
+++ b/packages/serve/index.ts
@@ -12,7 +12,7 @@ import { core } from "../../lib/utils/cli-flags";
  * @param {String[]} args - args processed from the CLI
  * @returns {Function} invokes the devServer API
  */
-export default function serve(args): Promise<void | Function> {
+export default function serve(args): void {
 	const cli = new WebpackCLI();
 	// partial parsing usage: https://github.com/75lb/command-line-args/wiki/Partial-parsing
 
@@ -27,9 +27,7 @@ export default function serve(args): Promise<void | Function> {
 	if (webpackArgs && webpackArgs._all && typeof webpackArgs._all.hot !== 'undefined') {
 		finalArgs['hot'] = webpackArgs._all.hot;
 	}
-    return new Promise((resolve): void => {
-		cli.getCompiler(webpackArgs, core).then((compiler): void => {
-			startDevServer.default(compiler, finalArgs, resolve);
-		});
+	cli.getCompiler(webpackArgs, core).then((compiler): void => {
+		startDevServer.default(compiler, finalArgs);
 	});
 }

--- a/packages/serve/startDevServer.ts
+++ b/packages/serve/startDevServer.ts
@@ -6,11 +6,10 @@ import * as Server from "webpack-dev-server/lib/Server";
  *
  * @param {Object} compiler - a webpack compiler
  * @param {Object} options - devServer options
- * @param {Function} onListening - optional callback for when the server starts listening
  * 
  * @returns {Void} 
  */
-export default function startDevServer(compiler, options, onListening): void {
+export default function startDevServer(compiler, options): void {
     const firstWpOpt = compiler.compilers
         ? compiler.compilers[0].options
         : compiler.options;
@@ -32,9 +31,6 @@ export default function startDevServer(compiler, options, onListening): void {
     server.listen(socket || port, host, (err): void => {
         if (err) {
             throw err;
-        }
-        if (typeof onListening === 'function') {
-            onListening();
         }
     });
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
refactoring

**Did you add tests for your changes?**
No

**If relevant, did you update the documentation?**
No

**Summary**

I don't think there is a need for the `serve` package to return a Promise. Users should not be using the package for its API, and it is not logical exactly when the Promise should resolve.

As mentioned by @evilebottnawi here: https://github.com/webpack/webpack-cli/pull/1011#discussion_r329023815, there is no need to have an additional `onListening`.

**Does this PR introduce a breaking change?**

Yes

**Other information**
