### PR TITLE
minor: Remove redundant multiple property of OptionDefinition cli-flags.js

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -4,6 +4,9 @@
 
 require('v8-compile-cache');
 
+// ! This file does initial checkup of versions and then runs the CLI
+
+// ? If a global and a local version is present of webpack cli, use the local version
 const importLocal = require('import-local');
 
 // Prefer the local installation of webpack-cli
@@ -11,11 +14,14 @@ if (importLocal(__filename)) {
     return;
 }
 process.title = 'webpack';
+// ? Send and update message in terminal if update is available
+// * webpack-logger is used the display coloured terminal messages with webpack logo
 process.cliLogger = require('webpack-log')({
     name: 'webpack',
 });
-
+// * upadate-notifier is used to make those update is available messages in terminal
 const updateNotifier = require('update-notifier');
+// * importing a .json file reuturns it as a js object
 const packageJson = require('./package.json');
 
 const notifier = updateNotifier({
@@ -31,6 +37,7 @@ const semver = require('semver');
 
 const version = packageJson.engines.node;
 
+// ? Check if current version of CLI is compatible with current version of JS
 if (!semver.satisfies(process.version, version)) {
     const rawVersion = version.replace(/[^\d\.]*/, '');
     process.cliLogger.error('webpack CLI requires at least Node v' + rawVersion + '. ' + 'You have ' + process.version + '.\n' + 'See https://webpack.js.org/ ' + 'for migration help and similar.');

--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -65,6 +65,7 @@ async function runCLI(cli, commandIsUsed) {
             // * Partial: true results in storing of unknown args in _unknown key
             // * if stopAtFirstUnkown was true, parsing would stop when an unknown argument was passed
             args = cmdArgs(core, { stopAtFirstUnknown: false, partial: true });
+            // * If any unknown arguments are passed
             if (args._unknown) {
                 resolveNegatedArgs(args);
                 args._unknown
@@ -113,6 +114,7 @@ async function runCLI(cli, commandIsUsed) {
     }
 }
 
+// * commandIsUsed is undefined if no args are passed
 const commandIsUsed = isCommandUsed(commands);
 const cli = new WebpackCLI();
 runCLI(cli, commandIsUsed);

--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -12,6 +12,7 @@ const normalizeFlags = (args, cmd) => {
     return removeCmdFromArgs(slicedArgs, cmd);
 };
 
+// ? Returns the command object if the name or alias of that commad is passed as args
 const isCommandUsed = commands =>
     commands.find(cmd => {
         return process.argv.includes(cmd.name) || process.argv.includes(cmd.alias);
@@ -44,6 +45,7 @@ async function runCLI(cli, commandIsUsed) {
     const helpFlagExists = isFlagPresent(process.argv, 'help');
     const versionFlagExists = isFlagPresent(process.argv, 'version');
 
+    // * Log Help and Version info if respective flags are present
     if (helpFlagExists) {
         cli.runHelp(process.argv);
         return;
@@ -52,12 +54,16 @@ async function runCLI(cli, commandIsUsed) {
         return;
     }
 
+    // * Returns args expect the passed command and the first two filename and dirname
     if (commandIsUsed) {
         commandIsUsed.defaultOption = true;
         args = normalizeFlags(process.argv, commandIsUsed);
         return await cli.runCommand(commandIsUsed, ...args);
     } else {
         try {
+            // * cmdArgs processes given args and returns them in an organised object
+            // * Partial: true results in storing of unknown args in _unknown key
+            // * if stopAtFirstUnkown was true, parsing would stop when an unknown argument was passed
             args = cmdArgs(core, { stopAtFirstUnknown: false, partial: true });
             if (args._unknown) {
                 resolveNegatedArgs(args);

--- a/lib/utils/cli-flags.js
+++ b/lib/utils/cli-flags.js
@@ -114,7 +114,6 @@ module.exports = {
         {
             name: 'entry',
             type: String,
-            multiple: false,
             defaultValue: null,
             defaultOption: true,
             group: BASIC_GROUP,

--- a/lib/utils/group-helper.js
+++ b/lib/utils/group-helper.js
@@ -21,6 +21,7 @@ class GroupHelper {
     }
 
     arrayToObject(arr) {
+        // * copy first keyvalue pair of the array objects to the return object
         if (!arr) {
             return;
         }

--- a/lib/webpack-cli.js
+++ b/lib/webpack-cli.js
@@ -17,6 +17,7 @@ const defaultCommands = {
 class WebpackCLI extends GroupHelper {
     constructor() {
         super();
+        // * map is similar to object but iterable by for...of loop 
         this.groupMap = new Map();
         this.groups = [];
         this.processingMessageBuffer = [];
@@ -30,6 +31,7 @@ class WebpackCLI extends GroupHelper {
     setGroupMap(key, val, yargsOptions) {
         const opt = yargsOptions.find(opt => opt.name === key);
         const groupName = opt.group;
+        //* remove the "options:" part in the group name and lowercase it
         const namePrefix = groupName.slice(0, groupName.length - 9).toLowerCase();
         if (this.groupMap.has(namePrefix)) {
             const pushToMap = this.groupMap.get(namePrefix);
@@ -74,12 +76,14 @@ class WebpackCLI extends GroupHelper {
     resolveGroups() {
         let mode;
         for (const [key, value] of this.groupMap.entries()) {
+            // * join paths
             const fileName = join(__dirname, 'groups', key);
             const GroupClass = require(fileName);
             if (key === 'config') {
                 value.push({ mode: mode });
             }
             const GroupInstance = new GroupClass(value);
+            console.log(GroupInstance.args);
             if (key === 'basic') {
                 if (GroupInstance.opts.outputOptions.dev) {
                     mode = 'dev';
@@ -143,6 +147,7 @@ class WebpackCLI extends GroupHelper {
     }
 
     async processArgs(args, yargsOptions) {
+        // * store args to this.groupMap
         await this.setMappedGroups(args, yargsOptions);
         await this.resolveGroups();
         const groupResult = await this.runOptionGroups();
@@ -156,6 +161,7 @@ class WebpackCLI extends GroupHelper {
     }
 
     async run(args, yargsOptions) {
+        //* args are the passed in arguments, yargsOptions are all the core
         const groupResult = await this.processArgs(args, yargsOptions);
         const webpack = await Compiler.webpackInstance(groupResult);
         return webpack;

--- a/lib/webpack-cli.js
+++ b/lib/webpack-cli.js
@@ -83,7 +83,6 @@ class WebpackCLI extends GroupHelper {
                 value.push({ mode: mode });
             }
             const GroupInstance = new GroupClass(value);
-            console.log(GroupInstance.args);
             if (key === 'basic') {
                 if (GroupInstance.opts.outputOptions.dev) {
                     mode = 'dev';
@@ -149,6 +148,7 @@ class WebpackCLI extends GroupHelper {
     async processArgs(args, yargsOptions) {
         // * store args to this.groupMap
         await this.setMappedGroups(args, yargsOptions);
+        // * Push groupInstance for each entry in this.groupMap to this.groups
         await this.resolveGroups();
         const groupResult = await this.runOptionGroups();
         return groupResult;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
- Refactor

**Did you add tests for your changes?**
- Not relevant

**If relevant, did you update the documentation?**
- Not relevant

**Summary**
The multiple property of the `optionDefinitions` object is set to true when the option expects multiple values to be passed via the command line. By default this property is `false`. There is no need to specify this explicitly. All the following `optionDefinitions` which do not expect multiple values don't specify it only this one does.
[Reference](https://github.com/75lb/command-line-args/blob/master/doc/option-definition.md#optionmultiple--boolean) to `command-line-args` docs.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
