### PR TITLE
chore: Remove redundant multiple property of OptionDefinition cli-flags.js 

### DIFF
--- a/lib/utils/cli-flags.js
+++ b/lib/utils/cli-flags.js
@@ -114,7 +114,6 @@ module.exports = {
         {
             name: 'entry',
             type: String,
-            multiple: false,
             defaultValue: null,
             defaultOption: true,
             group: BASIC_GROUP,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
- Refactor

**Did you add tests for your changes?**
- Not relevant

**If relevant, did you update the documentation?**
- Not relevant

**Summary**
The multiple property of the `optionDefinitions` object is set to true when the option expects multiple values to be passed via the command line. By default this property is `false`. There is no need to specify this explicitly. All the following `optionDefinitions` which do not expect multiple values don't specify it only this one does.
[Reference](https://github.com/75lb/command-line-args/blob/master/doc/option-definition.md#optionmultiple--boolean) to `command-line-args` docs.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
Nope
