### PR TITLE
refactor(module): module exporting

### DIFF
--- a/lib/utils/commands.js
+++ b/lib/utils/commands.js
@@ -9,5 +9,7 @@ const names = commands
     })
     .reduce((arr, val) => arr.concat(val), []);
 
-module.exports.names = names;
-module.exports.info = commands;
+module.exports = {
+    names,
+    info: commands,
+};

--- a/lib/utils/compiler.js
+++ b/lib/utils/compiler.js
@@ -252,5 +252,7 @@ async function webpackInstance(opts) {
     }
 }
 
-module.exports.getCompiler = getCompiler;
-module.exports.webpackInstance = webpackInstance;
+module.exports = {
+    getCompiler,
+    webpackInstance,
+};


### PR DESCRIPTION
**Summary**
`module.exports.a = a` can be written as `module.exports = {a:a}` or `module.exports = {a}`
If we have multiple exports from a single file then writing `module.exports.a = a` could be tedious task.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Refactoring
**Did you add tests for your changes?**
No
**If relevant, did you update the documentation?**
No

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No

**Other information**
NaN
