### PR TITLE
chore(bootstrap.js): refactor to use enums and switch in errs

### DIFF
--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -73,37 +73,46 @@ async function runCLI(cli, commandIsUsed) {
                 return;
             }
         } catch (err) {
-            if (err.name === 'UNKNOWN_VALUE') {
-                process.cliLogger.error(`Parse Error (unknown argument): ${err.value}`);
-                return;
-            } else if (err.name === 'ALREADY_SET') {
-                const argsMap = {};
-                const keysToDelete = [];
-                process.argv.forEach((arg, idx) => {
-                    const oldMapValue = argsMap[arg];
-                    argsMap[arg] = {
-                        value: process.argv[idx],
-                        pos: idx,
-                    };
-                    // Swap idx of overriden value
-                    if (oldMapValue) {
-                        argsMap[arg].pos = oldMapValue.pos;
-                        keysToDelete.push(idx + 1);
-                    }
-                });
-                // Filter out the value for the overriden key
-                const newArgKeys = Object.keys(argsMap).filter(arg => !keysToDelete.includes(argsMap[arg].pos));
-                // eslint-disable-next-line require-atomic-updates
-                process.argv = newArgKeys;
-                args = cmdArgs(core, { stopAtFirstUnknown: false, partial: true });
+            const errs = {
+                UNKNOWN_VALUE: 'UNKNOWN_VALUE',
+                ALREADY_SET: 'ALREADY_SET',
+            };
+            switch (err.name) {
+                case errs.UNKNOWN_VALUE: {
+                    process.cliLogger.error(`Parse Error (unknown argument): ${err.value}`);
+                    break;
+                }
+                case errs.ALREADY_SET: {
+                    const argsMap = {};
+                    const keysToDelete = [];
+                    process.argv.forEach((arg, idx) => {
+                        const oldMapValue = argsMap[arg];
+                        argsMap[arg] = {
+                            value: process.argv[idx],
+                            pos: idx,
+                        };
+                        // Swap idx of overriden value
+                        if (oldMapValue) {
+                            argsMap[arg].pos = oldMapValue.pos;
+                            keysToDelete.push(idx + 1);
+                        }
+                    });
+                    // Filter out the value for the overriden key
+                    const newArgKeys = Object.keys(argsMap).filter(arg => !keysToDelete.includes(argsMap[arg].pos));
+                    // eslint-disable-next-line require-atomic-updates
+                    process.argv = newArgKeys;
+                    args = cmdArgs(core, { stopAtFirstUnknown: false, partial: true });
 
-                await cli.run(args, core);
-                process.stdout.write('\n');
-                process.cliLogger.warn('Duplicate flags found, defaulting to last set value');
-            } else {
-                process.cliLogger.error(err);
-                return;
+                    await cli.run(args, core);
+                    process.stdout.write('\n');
+                    process.cliLogger.warn('Duplicate flags found, defaulting to last set value');
+                    break;
+                }
+                default: {
+                    process.cliLogger.error(err);
+                }
             }
+            return;
         }
     }
 }


### PR DESCRIPTION
refactor to use enums and switch to execute correct error code

ISSUES CLOSED: #1138

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
refactor
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
NA

**If relevant, did you update the documentation?**
NA

**Summary**
Use enums rather than strict switch comparison to execute correct err code as per the switch.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
