### PR TITLE
feat(cli): shows version details for sub packages

### DIFF
--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -49,7 +49,7 @@ async function runCLI(cli, commandIsUsed) {
         cli.runHelp(process.argv);
         return;
     } else if (versionFlagExists) {
-        cli.runVersion();
+        cli.runVersion(commandIsUsed);
         return;
     }
 

--- a/lib/groups/help.js
+++ b/lib/groups/help.js
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 const chalk = require('chalk');
 const commandLineUsage = require('command-line-usage');
+const path = require('path');
 
 class HelpGroup {
     outputHelp(command = null) {
@@ -27,7 +28,16 @@ class HelpGroup {
         process.stdout.write('\n                  Made with ♥️  by the webpack team \n');
     }
 
-    outputVersion() {
+    outputVersion(externalCommand) {
+        if (externalCommand && externalCommand.name)
+            try {
+                const pathForExternalPkg = path.resolve(process.cwd(), 'node_modules', '@webpack-cli', externalCommand.name);
+                const ExternalPkgJson = require(pathForExternalPkg + '/package.json');
+                const { name, version } = ExternalPkgJson;
+                process.stdout.write(`\n${name} ${version}`);
+            } catch (e) {
+                process.stderr.write('ERR_EXTERNAL_PACKAGE_NOT_FOUND', e);
+            }
         const pkgJSON = require('../../package.json');
         const webpack = require('webpack');
         process.stdout.write(`\nwebpack-cli ${pkgJSON.version}`);

--- a/lib/webpack-cli.js
+++ b/lib/webpack-cli.js
@@ -169,9 +169,9 @@ class WebpackCLI extends GroupHelper {
         return new HelpGroup().outputHelp(command);
     }
 
-    runVersion() {
+    runVersion(externalCommand) {
         const HelpGroup = require('./groups/help');
-        return new HelpGroup().outputVersion();
+        return new HelpGroup().outputVersion(externalCommand);
     }
 }
 


### PR DESCRIPTION

**What kind of change does this PR introduce?**
feature

**Did you add tests for your changes?**
No

**If relevant, did you update the documentation?**
Maybe

**Summary**
The current `--version` flag shows the version details for only `webpack` and `webpack-cli`. But it is not possible to get the version details of the sub-packages via the cli.

`webpack-cli info --version`

#### Current Behaviour

![Screenshot from 2019-12-08 13-51-36](https://user-images.githubusercontent.com/32242596/70386696-e59ee600-19c1-11ea-81ce-38fec8aacf03.png)

#### Suggested Changes via this.PR

![Screenshot from 2019-12-08 13-41-20](https://user-images.githubusercontent.com/32242596/70386707-f5b6c580-19c1-11ea-80de-900e117ec311.png)



