### PR TITLE
fix: test for output flag

### DIFF
--- a/test/output/defaults/output-defaults.test.js
+++ b/test/output/defaults/output-defaults.test.js
@@ -25,7 +25,7 @@ describe('output flag defaults', () => {
         const outputDir = 'defaults/dist';
 
         expect(summary['Output Directory']).toContain(outputDir);
-        stat(resolve(__dirname, './dist/bundle.js'), (err, stats) => {
+        stat(resolve(__dirname, './dist/main.js'), (err, stats) => {
             expect(err).toBe(null);
             expect(stats.isFile()).toBe(true);
             done();


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
- bugfix

**Did you add tests for your changes?**
- N/A

**If relevant, did you update the documentation?**
- N/A

**Summary**
if an empty output flag is passed, webpack(5.0.0-beta.11) falls back to `dist/main.js` file and not to `dist/bundle.js`.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
- Nope
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
