### PR TITLE
fix: display verbose

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -185,8 +185,8 @@ For more information, see https://webpack.js.org/api/cli/.`);
 			});
 
 			if (!outputOptions.json) {
-				if (typeof outputOptions.cached === "undefined") outputOptions.cached = false;
-				if (typeof outputOptions.cachedAssets === "undefined") outputOptions.cachedAssets = false;
+				if (outputOptions.cached === undefined) outputOptions.cached = false;
+				if (outputOptions.cachedAssets === undefined) outputOptions.cachedAssets = false;
 
 				ifArg("display-chunks", function(bool) {
 					if (bool) {
@@ -240,7 +240,8 @@ For more information, see https://webpack.js.org/api/cli/.`);
 					if (bool) outputOptions.cachedAssets = true;
 				});
 
-				if (!outputOptions.exclude) outputOptions.exclude = ["node_modules", "bower_components", "components"];
+				if (outputOptions.exclude === undefined)
+					outputOptions.exclude = ["node_modules", "bower_components", "components"];
 
 				if (argv["display-modules"]) {
 					outputOptions.maxModules = Infinity;


### PR DESCRIPTION
closes #1167

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**

nope

**If relevant, did you update the documentation?**

nope

**Summary**

No `hidden modules` when display=verbose

Blocked by https://github.com/webpack/webpack/pull/10306

**Does this PR introduce a breaking change?**

nope