### PR TITLE
fix(init): fixed package template to include name param

### DIFF
--- a/packages/generators/templates/package.json.js
+++ b/packages/generators/templates/package.json.js
@@ -9,6 +9,7 @@ module.exports = usingDefaults => {
 	return {
 		version: "1.0.0",
 		description: "My webpack project",
+		name: "my-webpack-project",
 		scripts
 	};
 };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
fix

**Did you add tests for your changes?**
No

**If relevant, did you update the documentation?**
N/A

**Summary**

Begins to fix: https://github.com/webpack/webpack-cli/issues/901

As explained here: https://github.com/forcedotcom/salesforcedx-vscode/issues/253, it seems that having a `name` field in the `package.json` when you run `webpack-cli create` prevents an error from being thrown. Thus, we can allow for `webpack-cli create` being run repeatedly by adding a `name` property to the generated `package.json`.

However, we should still either provide a more specific error or prompt the user to delete the `package.json` if the `name` parameter is missing, so this does not entirely close the previously mentioned issue. I will work on this other stuff soon.

**Does this PR introduce a breaking change?**
No

**Other information**
