### PR TITLE
tests(generator): enable init generator test

### DIFF
--- a/packages/generators/__tests__/init-generator.test.ts
+++ b/packages/generators/__tests__/init-generator.test.ts
@@ -2,7 +2,7 @@ import { join } from 'path';
 import { run } from 'yeoman-test';
 
 // fixme: unstable
-describe.skip('init generator', () => {
+describe('init generator', () => {
     it('generates a webpack project config', async () => {
         const outputDir = await run(join(__dirname, '../init-generator')).withPrompts({
             multiEntries: false,
@@ -17,5 +17,5 @@ describe.skip('init generator', () => {
         const config = (Object.entries(output)[0][1] as any).configuration.config.webpackOptions;
         expect(config.entry).toEqual("'./src/index2.js'");
         expect(config.output.path).toEqual("path.resolve(__dirname, 'dist2')");
-    });
+    }, 10000);
 });


### PR DESCRIPTION
enable init generator test

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
enable init gen test.

**Did you add tests for your changes?**
Yay

**If relevant, did you update the documentation?**
NA

**Summary**
Enables init generator test with more timeout so travis has enough time to execute the test.

**Does this PR introduce a breaking change?**
No

**Other information**
