### PR TITLE
fix: 🐛 add git-cz as a dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,6 +149,7 @@
     "eslint-plugin-node": "^11.0.0",
     "eslint-plugin-prettier": "^3.1.2",
     "execa": "^3.2.0",
+    "git-cz": "^4.3.1",
     "husky": "^3.0.9",
     "jest": "^25.1.0",
     "jest-junit": "^10.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6015,6 +6015,11 @@ gh-got@^5.0.0:
     got "^6.2.0"
     is-plain-obj "^1.1.0"
 
+git-cz@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/git-cz/-/git-cz-4.3.1.tgz#1a1a462c2730c17c9fcbfa023beee98fd7659934"
+  integrity sha512-z+mbD76lbra8ml2nMoOoFkQPJ2OQvg6vpZa8d9VzNEvygEQNysgMkzGPBxqFKw1VIwZ/PHoQgAf70BPp9uElJw==
+
 git-raw-commits@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/git-raw-commits/-/git-raw-commits-2.0.0.tgz#d92addf74440c14bcc5c83ecce3fb7f8a79118b5"


### PR DESCRIPTION
Fix errors while running `$ yarn commit`. [reference](https://github.com/webpack/webpack-cli/blob/next/.github/CONTRIBUTING.md#commit-message)

BREAKING CHANGE: 🧨 No

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
bugfix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
N/A

**If relevant, did you update the documentation?**
N/A

**Summary**
`$ yarn commit` won't work as `$ npm run commit` would (for `npx` like execution).
Instead having git-cz as a dev dependency fixes the error.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
Nope.
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
