### PR TITLE
feat(webpack-cli): add mode argument validation

### DIFF
--- a/packages/webpack-cli/lib/utils/cli-flags.js
+++ b/packages/webpack-cli/lib/utils/cli-flags.js
@@ -1,3 +1,4 @@
+const { logger } = require('@webpack-cli/logger');
 const HELP_GROUP = 'help';
 const CONFIG_GROUP = 'config';
 const BASIC_GROUP = 'basic';
@@ -286,11 +287,17 @@ module.exports = {
         {
             name: 'mode',
             usage: '--mode <development | production>',
-            type: String,
+            type: (value) => {
+                if (value === 'development' || value === 'production' || value === 'none') {
+                    return value ;
+                } else {
+                    logger.warn('You provided an invalid value for "mode" option.');
+                    return 'production' ;
+                }
+            },
             group: ZERO_CONFIG_GROUP,
             description: 'Defines the mode to pass to webpack',
-            link: 'https://webpack.js.org/concepts/#mode',
-            acceptedValues: ["development", "production"]
+            link: 'https://webpack.js.org/concepts/#mode'
         },
         {
             name: 'no-mode',

--- a/test/mode/prod/prod.test.js
+++ b/test/mode/prod/prod.test.js
@@ -1,6 +1,6 @@
 'use strict';
 const { run } = require('../../utils/test-utils');
-const { stat } = require('fs');
+const { stat, readFile } = require('fs');
 const { resolve } = require('path');
 describe('mode flags', () => {
     it('should load a production config when --prod is passed', done => {
@@ -21,6 +21,22 @@ describe('mode flags', () => {
         stat(resolve(__dirname, './bin/main.js'), (err, stats) => {
             expect(err).toBe(null);
             expect(stats.isFile()).toBe(true);
+            done();
+        });
+    });
+
+    it('should load a production config when --mode=abcd is passed', done => {
+        const { stderr, stdout } = run(__dirname, ['--mode', 'abcd']);
+        expect(stderr).toContain('invalid value for "mode"');
+        expect(stdout).toBeTruthy();
+        stat(resolve(__dirname, './bin/main.js'), (err, stats) => {
+            expect(err).toBe(null);
+            expect(stats.isFile()).toBe(true);
+            done();
+        });
+        readFile(resolve(__dirname, './bin/main.js'), 'utf-8', (err, data) => {
+            expect(err).toBe(null);
+            expect(data).toContain('production');
             done();
         });
     });

--- a/test/mode/prod/src/index.js
+++ b/test/mode/prod/src/index.js
@@ -1,1 +1,5 @@
 console.log('default');
+
+if (process.env.NODE_ENV === "production") {
+    console.log('production');
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
Fixes #1282  

**Did you add tests for your changes?**
Yes.

**If relevant, did you update the documentation?**
Yes

**Summary**
Added validation for `mode` argument , now can only accept `development , production or none`
 will promt a warning if set to any other value.

![Screenshot from 2020-03-04 19-06-48](https://user-images.githubusercontent.com/46647141/75884876-8d09a880-5e4b-11ea-8947-8a24b29bd9e5.png)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
NO.
