### PR TITLE
feat(webpack-cli): stats

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ install:
     - lerna bootstrap
     - yarn global add codecov
     - yarn global add eslint
+    - yarn prepsuite
 script:
     - yarn travis:lint
     - yarn test:ci

--- a/packages/webpack-cli/README.md
+++ b/packages/webpack-cli/README.md
@@ -50,6 +50,7 @@ Options
   -h, --hot                Enables Hot Module Replacement
   -s, --sourcemap string   Determine source maps to use
   --prefetch string        Prefetch this request
+  --pretty                 Prints a fancy output
   -j, --json               Prints result as JSON
   --standard               Prints standard output
   -d, --dev                Run development build
@@ -58,6 +59,8 @@ Options
   --no-mode                Sets mode="none" which disables any default behavior
   --version                Get current version
   --node-args string[]     NodeJS flags
+  --stats type             It instructs webpack on how to treat the stats
+  --verbose                It tells to webpack to output all the information
 ```
 
 ## Defaults

--- a/packages/webpack-cli/README.md
+++ b/packages/webpack-cli/README.md
@@ -60,7 +60,7 @@ Options
   --version                Get current version
   --node-args string[]     NodeJS flags
   --stats type             It instructs webpack on how to treat the stats
-  --verbose                It tells to webpack to output all the information
+  --verbose                It tells webpack to output all the information
 ```
 
 ## Defaults

--- a/packages/webpack-cli/__tests__/StatsGroup.test.js
+++ b/packages/webpack-cli/__tests__/StatsGroup.test.js
@@ -1,0 +1,18 @@
+const StatsGroup = require('../lib/groups/StatsGroup');
+
+describe('StatsGroup', function() {
+    {
+        StatsGroup.validOptions().map(option => {
+            it(`should handle ${option} option`, () => {
+                const statsGroup = new StatsGroup([
+                    {
+                        stats: option,
+                    },
+                ]);
+
+                const result = statsGroup.run();
+                expect(result.options.stats).toEqual(option);
+            });
+        });
+    }
+});

--- a/packages/webpack-cli/lib/groups/StatsGroup.js
+++ b/packages/webpack-cli/lib/groups/StatsGroup.js
@@ -1,21 +1,36 @@
 const GroupHelper = require('../utils/GroupHelper');
-
+const { logger } = require('@webpack-cli/logger');
 /**
  * StatsGroup gathers information about the stats options
  */
 class StatsGroup extends GroupHelper {
+    static validOptions() {
+        return ['minimal', 'none', 'normal', 'verbose', 'errors-warnings', 'errors-only'];
+    }
+
     constructor(options) {
         super(options);
     }
 
     resolveOptions() {
-        Object.keys(this.args).forEach(arg => {
-            if (['quiet', 'verbose', 'json', 'silent', 'standard'].includes(arg)) {
-                this.opts.outputOptions[arg] = this.args[arg];
+        if (this.args.verbose && this.args.stats) {
+            logger.warn('Conflict between "verbose" and "stats" options. Using verbose.');
+            this.opts.option.stats = {
+                verbose: true,
+            };
+        } else {
+            if (this.args.verbose) {
+                this.opts.option.stats = {
+                    verbose: true,
+                };
             } else {
-                this.opts.options[arg] = this.args[arg];
+                this.opts.options.stats = this.args.stats;
             }
-        });
+        }
+
+        if (this.args.pretty) {
+            this.opts.outputOptions.pretty = true;
+        }
     }
 
     run() {

--- a/packages/webpack-cli/lib/utils/Compiler.js
+++ b/packages/webpack-cli/lib/utils/Compiler.js
@@ -78,9 +78,7 @@ class Compiler {
     }
 
     generateOutput(outputOptions, stats, statsErrors, processingMessageBuffer) {
-        if (outputOptions.standard) {
-            this.output.generateRawOutput(stats);
-        } else {
+        if (outputOptions.pretty) {
             const statsObj = stats.toJson(outputOptions);
             if (statsObj.children && Array.isArray(statsObj.children) && this.compilerOptions && Array.isArray(this.compilerOptions)) {
                 statsObj.children.forEach(child => {
@@ -89,6 +87,8 @@ class Compiler {
                 return;
             }
             this.output.generateFancyOutput(statsObj, statsErrors, processingMessageBuffer);
+        } else {
+            this.output.generateRawOutput(stats, this.compilerOptions);
         }
         process.stdout.write('\n');
         if (outputOptions.watch) {

--- a/packages/webpack-cli/lib/utils/CompilerOutput.js
+++ b/packages/webpack-cli/lib/utils/CompilerOutput.js
@@ -110,8 +110,8 @@ class CompilerOutput {
         return statsObj;
     }
 
-    generateRawOutput(stats) {
-        process.stdout.write(stats.toString());
+    generateRawOutput(stats, options) {
+        process.stdout.write(stats.toString(options.stats));
     }
 
     generateJsonOutput() {}

--- a/packages/webpack-cli/lib/utils/cli-flags.js
+++ b/packages/webpack-cli/lib/utils/cli-flags.js
@@ -1,4 +1,6 @@
 const { logger } = require('@webpack-cli/logger');
+const StatsGroup = require('../groups/StatsGroup');
+
 const HELP_GROUP = 'help';
 const CONFIG_GROUP = 'config';
 const BASIC_GROUP = 'basic';
@@ -243,7 +245,7 @@ module.exports = {
         },
         {
             name: 'prefetch',
-            usage: '--prefetch <request>',
+            usage: 'webpack --prefetch <request>',
             type: String,
             group: ADVANCED_GROUP,
             description: 'Prefetch this request',
@@ -251,17 +253,17 @@ module.exports = {
         },
         {
             name: 'json',
-            usage: '--json',
+            usage: 'webpack --json',
             type: Boolean,
             alias: 'j',
             description: 'Prints result as JSON',
             group: DISPLAY_GROUP,
         },
         {
-            name: 'standard',
-            usage: '--standard',
+            name: 'pretty',
+            usage: 'webpack --pretty',
             type: Boolean,
-            description: 'Prints standard output',
+            description: 'Prints a fancy output',
             group: DISPLAY_GROUP,
         },
         {
@@ -321,6 +323,27 @@ module.exports = {
             multiple: true,
             group: BASIC_GROUP,
             description: 'NodeJS flags',
+        },
+        {
+            name: 'stats',
+            usage: 'webpack --stats verbose',
+            type: value => {
+                if (StatsGroup.validOptions().includes(value)) {
+                    return value;
+                }
+                logger.warn('No value recognised for "stats" option');
+                return 'normal';
+            },
+            group: DISPLAY_GROUP,
+            description: 'It instructs webpack on how to treat the stats',
+            link: 'https://webpack.js.org/configuration/stats/#stats',
+        },
+        {
+            name: 'verbose',
+            usage: 'webpack --verbose',
+            type: Boolean,
+            group: DISPLAY_GROUP,
+            description: 'It tells to webpack to output all the information',
         },
         /* 		{
 			name: "analyze",

--- a/packages/webpack-cli/lib/utils/cli-flags.js
+++ b/packages/webpack-cli/lib/utils/cli-flags.js
@@ -343,7 +343,7 @@ module.exports = {
             usage: 'webpack --verbose',
             type: Boolean,
             group: DISPLAY_GROUP,
-            description: 'It tells to webpack to output all the information',
+            description: 'It tells webpack to output all the information',
         },
         /* 		{
 			name: "analyze",

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,0 +1,10 @@
+{
+    "extends": ["eslint:recommended", "plugin:node/recommended", "plugin:prettier/recommended"],
+    "env": {
+        "node": true,
+        "es6": true,
+        "jest": true
+    },
+    "plugins": ["node", "prettier"],
+    "parserOptions": { "ecmaVersion": 2020, "sourceType": "module" }
+}

--- a/test/config-lookup/dotfolder-array/dotfolder-array.test.js
+++ b/test/config-lookup/dotfolder-array/dotfolder-array.test.js
@@ -1,7 +1,7 @@
 'use strict';
 const { stat } = require('fs');
-const { resolve, sep } = require('path');
-const { run, extractSummary } = require('../../utils/test-utils');
+const { resolve } = require('path');
+const { run } = require('../../utils/test-utils');
 
 describe('dotfolder array config lookup', () => {
     it('should find a webpack array configuration in a dotfolder', done => {
@@ -9,13 +9,6 @@ describe('dotfolder array config lookup', () => {
         expect(stderr).not.toBeUndefined();
         expect(stdout).not.toBeUndefined();
 
-        const summary = extractSummary(stdout);
-        const outputDir = 'config-lookup/dotfolder-array/dist';
-        const outDirectoryFromCompiler = summary['Output Directory'].split(sep);
-        const outDirToMatch = outDirectoryFromCompiler
-            .slice(outDirectoryFromCompiler.length - 3, outDirectoryFromCompiler.length)
-            .join('/');
-        expect(outDirToMatch).toContain(outputDir);
         stat(resolve(__dirname, './dist/dist-commonjs.js'), (err, stats) => {
             expect(err).toBe(null);
             expect(stats.isFile()).toBe(true);

--- a/test/config-lookup/dotfolder-single/dotfolder-single.test.js
+++ b/test/config-lookup/dotfolder-single/dotfolder-single.test.js
@@ -3,7 +3,7 @@
 const { stat } = require('fs');
 const { resolve } = require('path');
 
-const { run, extractSummary } = require('../../utils/test-utils');
+const { run } = require('../../utils/test-utils');
 
 describe('dotfolder single config lookup', () => {
     it('should find a webpack configuration in a dotfolder', done => {
@@ -11,11 +11,7 @@ describe('dotfolder single config lookup', () => {
         expect(stderr).not.toBeUndefined();
         expect(stdout).not.toBeUndefined();
 
-        const summary = extractSummary(stdout);
-        const outputDir = 'config-lookup/dotfolder-single/dist';
-
-        expect(summary['Output Directory']).toContain(outputDir);
-        expect(stderr).not.toContain('Module not found');
+        expect(stdout).not.toContain('Module not found');
         stat(resolve(__dirname, './dist/main.js'), (err, stats) => {
             expect(err).toBe(null);
             expect(stats.isFile()).toBe(true);

--- a/test/config/basic/basic-config.test.js
+++ b/test/config/basic/basic-config.test.js
@@ -1,20 +1,13 @@
 'use strict';
 const { stat } = require('fs');
-const { resolve, sep } = require('path');
-const { run, extractSummary } = require('../../utils/test-utils');
+const { resolve } = require('path');
+const { run } = require('../../utils/test-utils');
 
 describe('basic config file', () => {
     it('is able to understand and parse a very basic configuration file', done => {
         const { stdout, stderr } = run(__dirname, ['-c', resolve(__dirname, 'webpack.config.js'), '--output', './binary/a.bundle.js']);
         expect(stderr).toContain('Duplicate flags found, defaulting to last set value');
         expect(stdout).not.toBe(undefined);
-        const summary = extractSummary(stdout);
-        const outputDir = 'basic/binary';
-        const outDirectoryFromCompiler = summary['Output Directory'].split(sep);
-        const outDirToMatch = outDirectoryFromCompiler
-            .slice(outDirectoryFromCompiler.length - 2, outDirectoryFromCompiler.length)
-            .join('/');
-        expect(outDirToMatch).toContain(outputDir);
         stat(resolve(__dirname, './binary/a.bundle.js'), (err, stats) => {
             expect(err).toBe(null);
             expect(stats.isFile()).toBe(true);

--- a/test/config/empty/empty-config.test.js
+++ b/test/config/empty/empty-config.test.js
@@ -1,17 +1,11 @@
 'use strict';
-const { resolve, sep } = require('path');
-const { run, extractSummary } = require('../../utils/test-utils');
+const { resolve } = require('path');
+const { run } = require('../../utils/test-utils');
 
 describe('config flag with empty config file', () => {
     it('should throw error with no configuration or index file', () => {
         const { stdout, stderr } = run(__dirname, ['-c', resolve(__dirname, 'webpack.config.js')]);
-        const summary = extractSummary(stdout);
-        const outputDir = 'empty/bin';
-        const outDirectoryFromCompiler = summary['Output Directory'].split(sep);
-        const outDirToMatch = outDirectoryFromCompiler
-            .slice(outDirectoryFromCompiler.length - 2, outDirectoryFromCompiler.length)
-            .join('/');
-        expect(outDirToMatch).toContain(outputDir);
-        expect(stderr).toBeTruthy();
+        expect(stderr).toBeFalsy();
+        expect(stdout).toBeTruthy();
     });
 });

--- a/test/config/type/array/array-config.test.js
+++ b/test/config/type/array/array-config.test.js
@@ -1,18 +1,11 @@
 'use strict';
 const { stat } = require('fs');
-const { resolve, sep } = require('path');
-const { run, extractSummary } = require('../../../utils/test-utils');
+const { resolve } = require('path');
+const { run } = require('../../../utils/test-utils');
 
 describe('array configuration', () => {
     it('is able to understand a configuration file in array format', done => {
-        const { stdout } = run(__dirname, ['-c', resolve(__dirname, 'webpack.config.js')], false);
-        const summary = extractSummary(stdout);
-        const outputDir = 'type/array/dist';
-        const outDirectoryFromCompiler = summary['Output Directory'].split(sep);
-        const outDirToMatch = outDirectoryFromCompiler
-            .slice(outDirectoryFromCompiler.length - 3, outDirectoryFromCompiler.length)
-            .join('/');
-        expect(outDirToMatch).toContain(outputDir);
+        run(__dirname, ['-c', resolve(__dirname, 'webpack.config.js')], false);
         stat(resolve(__dirname, './dist/dist-commonjs.js'), (err, stats) => {
             expect(err).toBe(null);
             expect(stats.isFile()).toBe(true);

--- a/test/config/type/function/function-config.test.js
+++ b/test/config/type/function/function-config.test.js
@@ -1,18 +1,11 @@
 'use strict';
 const { stat } = require('fs');
-const { resolve, sep } = require('path');
-const { run, extractSummary } = require('../../../utils/test-utils');
+const { resolve } = require('path');
+const { run } = require('../../../utils/test-utils');
 
 describe('function configuration', () => {
     it('is able to understand a configuration file as a function', done => {
-        const { stdout } = run(__dirname, ['-c', resolve(__dirname, 'webpack.config.js')], false);
-        const summary = extractSummary(stdout);
-        const outputDir = 'type/function/binary';
-        const outDirectoryFromCompiler = summary['Output Directory'].split(sep);
-        const outDirToMatch = outDirectoryFromCompiler
-            .slice(outDirectoryFromCompiler.length - 3, outDirectoryFromCompiler.length)
-            .join('/');
-        expect(outDirToMatch).toContain(outputDir);
+        run(__dirname, ['-c', resolve(__dirname, 'webpack.config.js')], false);
         stat(resolve(__dirname, './binary/functor.js'), (err, stats) => {
             expect(err).toBe(null);
             expect(stats.isFile()).toBe(true);

--- a/test/defaults/output-defaults.test.js
+++ b/test/defaults/output-defaults.test.js
@@ -1,15 +1,11 @@
 'use strict';
 const { stat } = require('fs');
 const { resolve } = require('path');
-const { run, extractSummary } = require('../utils/test-utils');
+const { run } = require('../utils/test-utils');
 
 describe('output flag defaults', () => {
     it('should create default file for a given directory', done => {
-        const { stdout } = run(__dirname, ['--entry', './a.js', '--output', './binary'], false);
-        const summary = extractSummary(stdout);
-        const outputDir = 'defaults/binary';
-
-        expect(summary['Output Directory']).toContain(outputDir);
+        run(__dirname, ['--entry', './a.js', '--output', './binary'], false);
 
         stat(resolve(__dirname, './binary/main.js'), (err, stats) => {
             expect(err).toBe(null);
@@ -18,14 +14,10 @@ describe('output flag defaults', () => {
         });
     });
     it('set default output directory on empty flag', done => {
-        const { stdout, stderr } = run(__dirname, ['--entry', './a.js', '--output'], false);
+        const { stdout } = run(__dirname, ['--entry', './a.js', '--output'], false);
         // Should print a warning about config fallback since we did not supply --defaults
-        expect(stderr).toContain('option has not been set, webpack will fallback to');
-        const summary = extractSummary(stdout);
+        expect(stdout).toContain('option has not been set, webpack will fallback to');
 
-        const outputDir = 'defaults/dist';
-
-        expect(summary['Output Directory']).toContain(outputDir);
         stat(resolve(__dirname, './dist/main.js'), (err, stats) => {
             expect(err).toBe(null);
             expect(stats.isFile()).toBe(true);
@@ -33,12 +25,9 @@ describe('output flag defaults', () => {
         });
     });
     it('should not throw when --defaults flag is passed', done => {
-        const { stdout, stderr } = run(__dirname, ['--defaults'], false);
-        const summary = extractSummary(stdout);
-        const outputDir = 'defaults/dist';
+        const { stderr } = run(__dirname, ['--defaults'], false);
         // When using --defaults it should not print warnings about config fallback
         expect(stderr).toBeFalsy();
-        expect(summary['Output Directory']).toContain(outputDir);
         stat(resolve(__dirname, './dist/main.js'), (err, stats) => {
             expect(err).toBe(null);
             expect(stats.isFile()).toBe(true);

--- a/test/defaults/without-config-and-entry/default-without-config.test.js
+++ b/test/defaults/without-config-and-entry/default-without-config.test.js
@@ -1,16 +1,13 @@
 'use strict';
 const { stat } = require('fs');
 const { resolve } = require('path');
-const { run, extractSummary } = require('../../utils/test-utils');
+const { run } = require('../../utils/test-utils');
 
 describe('output flag defaults without config', () => {
     it('should throw if the entry file is not present', done => {
-        const { stdout, stderr } = run(__dirname, ['--defaults'], false);
-        const summary = extractSummary(stdout);
-        const outputDir = 'without-config-and-entry/dist';
-        // eslint-disable-next-line quotes
-        expect(stderr).toContain("Error: Can't resolve './index.js' in");
-        expect(summary['Output Directory']).toContain(outputDir);
+        const { stdout } = run(__dirname, ['--defaults'], false);
+
+        expect(stdout).toContain("Error: Can't resolve './index.js' in");
         stat(resolve(__dirname, './dist/main.js'), (err, stats) => {
             expect(err).toBeTruthy();
             expect(stats).toBe(undefined);

--- a/test/entry/defaults-empty/entry-single-arg.test.js
+++ b/test/entry/defaults-empty/entry-single-arg.test.js
@@ -1,18 +1,11 @@
 'use strict';
 
-const { sep } = require('path');
-const { run, extractSummary } = require('../../utils/test-utils');
+const { run } = require('../../utils/test-utils');
 
 describe('single entry flag empty project', () => {
     it('sets default entry, compiles but throw missing module error', () => {
         const { stdout, stderr } = run(__dirname);
-        const summary = extractSummary(stdout);
-        const outputDir = 'defaults-empty/bin';
-        const outDirectoryFromCompiler = summary['Output Directory'].split(sep);
-        const outDirToMatch = outDirectoryFromCompiler
-            .slice(outDirectoryFromCompiler.length - 2, outDirectoryFromCompiler.length)
-            .join('/');
-        expect(outDirToMatch).toContain(outputDir);
-        expect(stderr).toBeTruthy();
+        expect(stderr).toBeFalsy();
+        expect(stdout).toBeTruthy();
     });
 });

--- a/test/entry/defaults-index/entry-multi-args.test.js
+++ b/test/entry/defaults-index/entry-multi-args.test.js
@@ -3,15 +3,12 @@
 const { stat } = require('fs');
 const { resolve } = require('path');
 
-const { run, extractSummary } = require('../../utils/test-utils');
+const { run } = require('../../utils/test-utils');
 
 describe('single entry flag index present', () => {
     it('finds default index file and compiles successfully', done => {
-        const { stdout, stderr } = run(__dirname);
-        const summary = extractSummary(stdout);
-        const outputDir = 'entry/defaults-index/bin';
+        const { stderr } = run(__dirname);
 
-        expect(summary['Output Directory']).toContain(outputDir);
         expect(stderr).not.toContain('Module not found');
         stat(resolve(__dirname, './bin/main.js'), (err, stats) => {
             expect(err).toBe(null);
@@ -21,13 +18,9 @@ describe('single entry flag index present', () => {
     });
 
     it('finds default index file, compiles and overrides with flags successfully', done => {
-        const { stdout, stderr } = run(__dirname, ['--output', 'bin/main.js']);
+        const { stderr } = run(__dirname, ['--output', 'bin/main.js']);
         expect(stderr).toContain('Duplicate flags found, defaulting to last set value');
-        const summary = extractSummary(stdout);
-        const outputDir = 'entry/defaults-index/bin';
 
-        expect(summary['Output Directory']).toContain(outputDir);
-        expect(stderr).not.toContain('Module not found');
         stat(resolve(__dirname, './bin/main.js'), (err, stats) => {
             expect(err).toBe(null);
             expect(stats.isFile()).toBe(true);

--- a/test/global/global.test.js
+++ b/test/global/global.test.js
@@ -18,24 +18,24 @@ describe('global flag', () => {
     });
 
     it('is able to inject one variable to global scope', () => {
-        const { stderr } = run(__dirname, ['--global', 'myVar', './global1.js']);
-        expect(stderr).toContain('option has not been set, webpack will fallback to');
+        const { stdout } = run(__dirname, ['--global', 'myVar', './global1.js']);
+        expect(stdout).toContain('option has not been set, webpack will fallback to');
         const executable = path.join(__dirname, './bin/main.js');
         const bundledScript = spawnSync('node', [executable]);
         expect(bundledScript.stdout).toEqual('myVar ./global1.js');
     });
 
     it('is able to inject multiple variables to global scope', () => {
-        const { stderr } = run(__dirname, ['--global', 'myVar', './global1.js', '--global', 'myVar2', './global2.js']);
-        expect(stderr).toContain('option has not been set, webpack will fallback to');
+        const { stdout } = run(__dirname, ['--global', 'myVar', './global1.js', '--global', 'myVar2', './global2.js']);
+        expect(stdout).toContain('option has not been set, webpack will fallback to');
         const executable = path.join(__dirname, './bin/main.js');
         const bundledScript = spawnSync('node', [executable]);
         expect(bundledScript.stdout).toEqual('myVar ./global1.js\nmyVar ./global2.js');
     });
 
     it('understands = syntax', () => {
-        const { stderr } = run(__dirname, ['--global', 'myVar', './global1.js', '--global', 'myVar2=./global2.js']);
-        expect(stderr).toContain('option has not been set, webpack will fallback to');
+        const { stdout } = run(__dirname, ['--global', 'myVar', './global1.js', '--global', 'myVar2=./global2.js']);
+        expect(stdout).toContain('option has not been set, webpack will fallback to');
         const executable = path.join(__dirname, './bin/main.js');
         const bundledScript = spawnSync('node', [executable]);
         expect(bundledScript.stdout).toEqual('myVar ./global1.js\nmyVar ./global2.js');

--- a/test/merge/config/merge-config.test.js
+++ b/test/merge/config/merge-config.test.js
@@ -7,8 +7,8 @@ const { run } = require('../../utils/test-utils');
 
 describe('merge flag configuration', () => {
     it('merges two configurations together', done => {
-        const { stderr } = run(__dirname, ['--config', './1.js', '--merge', './2.js'], false);
-        expect(stderr).toContain('option has not been set, webpack will fallback to');
+        const { stdout } = run(__dirname, ['--config', './1.js', '--merge', './2.js'], false);
+        expect(stdout).toContain('option has not been set, webpack will fallback to');
         stat(resolve(__dirname, './dist/merged.js'), (err, stats) => {
             expect(err).toBe(null);
             expect(stats.isFile()).toBe(true);

--- a/test/merge/defaults/merge-defaults.test.js
+++ b/test/merge/defaults/merge-defaults.test.js
@@ -7,8 +7,8 @@ const { run } = require('../../utils/test-utils');
 
 describe('merge flag defaults', () => {
     it('merges a default webpack.base.config with default config lookup', done => {
-        const { stderr } = run(__dirname, ['-m', './'], false);
-        expect(stderr).toContain('option has not been set, webpack will fallback to');
+        const { stdout } = run(__dirname, ['-m', './'], false);
+        expect(stdout).toContain('option has not been set, webpack will fallback to');
         stat(resolve(__dirname, './dist/default.js'), (err, stats) => {
             expect(err).toBe(null);
             expect(stats.isFile()).toBe(true);
@@ -16,8 +16,8 @@ describe('merge flag defaults', () => {
         });
     });
     it('merges a configuration file with default base config', done => {
-        const { stderr } = run(__dirname, ['-c', './1.js'], false);
-        expect(stderr).toContain('option has not been set, webpack will fallback to');
+        const { stdout } = run(__dirname, ['-c', './1.js'], false);
+        expect(stdout).toContain('option has not been set, webpack will fallback to');
         stat(resolve(__dirname, './dist/default.js'), (err, stats) => {
             expect(err).toBe(null);
             expect(stats.isFile()).toBe(true);

--- a/test/node/node.test.js
+++ b/test/node/node.test.js
@@ -1,7 +1,7 @@
 'use strict';
 const { stat } = require('fs');
-const { resolve, sep } = require('path');
-const { run, extractSummary } = require('../utils/test-utils');
+const { resolve } = require('path');
+const { run } = require('../utils/test-utils');
 const parseArgs = require('../../packages/webpack-cli/lib/utils/parse-args');
 
 describe('node flags', () => {
@@ -53,13 +53,6 @@ describe('node flags', () => {
         );
         expect(stdout).toContain('---from bootstrap.js---');
         expect(stdout).toContain('---from bootstrap2.js---');
-        const summary = extractSummary(stdout);
-        const outputDir = 'node/bin';
-        const outDirectoryFromCompiler = summary['Output Directory'].split(sep);
-        const outDirToMatch = outDirectoryFromCompiler
-            .slice(outDirectoryFromCompiler.length - 2, outDirectoryFromCompiler.length)
-            .join('/');
-        expect(outDirToMatch).toContain(outputDir);
         stat(resolve(__dirname, './bin/main.bundle.js'), (err, stats) => {
             expect(err).toBe(null);
             expect(stats.isFile()).toBe(true);

--- a/test/output/named-bundles/output-named-bundles.test.js
+++ b/test/output/named-bundles/output-named-bundles.test.js
@@ -1,14 +1,11 @@
 'use strict';
 const { stat } = require('fs');
 const { resolve } = require('path');
-const { run, extractSummary } = require('../../utils/test-utils');
+const { run } = require('../../utils/test-utils');
 
 describe('output flag named bundles', () => {
     it('should output file given as flag instead of in configuration', done => {
-        const { stdout } = run(__dirname, ['-c', resolve(__dirname, 'webpack.config.js'), '--output', './binary/a.bundle.js'], false);
-        const summary = extractSummary(stdout);
-        const outputDir = 'named-bundles/binary';
-        expect(summary['Output Directory']).toContain(outputDir);
+        run(__dirname, ['-c', resolve(__dirname, 'webpack.config.js'), '--output', './binary/a.bundle.js'], false);
         stat(resolve(__dirname, './binary/a.bundle.js'), (err, stats) => {
             expect(err).toBe(null);
             expect(stats.isFile()).toBe(true);
@@ -17,14 +14,7 @@ describe('output flag named bundles', () => {
     });
 
     it('should create multiple bundles with an overriding flag', done => {
-        const { stdout } = run(
-            __dirname,
-            ['-c', resolve(__dirname, 'webpack.single.config.js'), '--output', './bin/[name].bundle.js'],
-            false,
-        );
-        const summary = extractSummary(stdout);
-        const outputDir = 'named-bundles/bin';
-        expect(summary['Output Directory']).toContain(outputDir);
+        run(__dirname, ['-c', resolve(__dirname, 'webpack.single.config.js'), '--output', './bin/[name].bundle.js'], false);
 
         stat(resolve(__dirname, './bin/b.bundle.js'), (err, stats) => {
             expect(err).toBe(null);
@@ -45,13 +35,9 @@ describe('output flag named bundles', () => {
     });
 
     it('should not throw error on same bundle name for multiple entries with defaults', done => {
-        const { stdout, stderr } = run(__dirname, ['-c', resolve(__dirname, 'webpack.defaults.config.js'), '--defaults'], false);
-        const summary = extractSummary(stdout);
-        const outputDir = 'named-bundles/dist';
+        const { stderr } = run(__dirname, ['-c', resolve(__dirname, 'webpack.defaults.config.js'), '--defaults'], false);
 
         expect(stderr).toBe('');
-
-        expect(summary['Output Directory']).toContain(outputDir);
 
         stat(resolve(__dirname, './dist/b.main.js'), (err, stats) => {
             expect(err).toBe(null);
@@ -64,11 +50,8 @@ describe('output flag named bundles', () => {
         done();
     });
 
-    it('should sucessfully compile multiple entries', done => {
-        const { stdout } = run(__dirname, ['-c', resolve(__dirname, 'webpack.multiple.config.js')], false);
-        const summary = extractSummary(stdout);
-        const outputDir = 'named-bundles/bin';
-        expect(summary['Output Directory']).toContain(outputDir);
+    it('should successfully compile multiple entries', done => {
+        run(__dirname, ['-c', resolve(__dirname, 'webpack.multiple.config.js')], false);
 
         stat(resolve(__dirname, './bin/b.bundle.js'), (err, stats) => {
             expect(err).toBe(null);

--- a/test/output/named-bundles/output-named-bundles.test.js
+++ b/test/output/named-bundles/output-named-bundles.test.js
@@ -27,13 +27,6 @@ describe('output flag named bundles', () => {
         done();
     });
 
-    it('should throw error on same bundle name for multiple entries', done => {
-        const { stderr } = run(__dirname, ['-c', resolve(__dirname, 'webpack.single.config.js')], false);
-        const errMsg = 'Multiple chunks emit assets to the same filename bundle.js';
-        expect(stderr).toContain(errMsg);
-        done();
-    });
-
     it('should not throw error on same bundle name for multiple entries with defaults', done => {
         const { stderr } = run(__dirname, ['-c', resolve(__dirname, 'webpack.defaults.config.js'), '--defaults'], false);
 

--- a/test/output/pretty/pretty.test.js
+++ b/test/output/pretty/pretty.test.js
@@ -2,7 +2,7 @@ const { run } = require('../../utils/test-utils');
 
 describe('pretty output', () => {
     it('should output file given as flag instead of in configuration', () => {
-        const { stdout } = run(__dirname);
+        const { stdout } = run(__dirname, ['--pretty']);
         expect(stdout).toBeTruthy();
         expect(stdout).toContain('Entrypoint');
         expect(stdout).toContain('Bundle');

--- a/test/standard/standard.test.js
+++ b/test/standard/standard.test.js
@@ -1,8 +1,8 @@
 const { run } = require('../utils/test-utils');
 
-describe('standard flag', () => {
+describe('standard output', () => {
     it('should print standard output', () => {
-        const { stdout, stderr } = run(__dirname, ['--standard']);
+        const { stdout, stderr } = run(__dirname);
         expect(stdout).toBeTruthy();
         expect(stdout).toContain('Hash');
         expect(stdout).toContain('Version');

--- a/test/stats/.gitignore
+++ b/test/stats/.gitignore
@@ -1,0 +1,3 @@
+yarn.lock
+package-lock.json
+node_modules/

--- a/test/stats/index.js
+++ b/test/stats/index.js
@@ -1,0 +1,4 @@
+require('react');
+require('react-dom');
+require('redux');
+require('react-redux');

--- a/test/stats/package.json
+++ b/test/stats/package.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "react": "^16.13.0",
+    "react-dom": "^16.13.0",
+    "redux": "^4.0.5",
+    "react-redux": "^7.2.0"
+  }
+}

--- a/test/stats/stats.test.js
+++ b/test/stats/stats.test.js
@@ -1,0 +1,50 @@
+'use strict';
+// eslint-disable-next-line node/no-unpublished-require
+const { run } = require('../utils/test-utils');
+
+describe('stats flag', () => {
+    // {
+    //     StatsGroup.validOptions().map(option => {
+    it('should accept stats "none"', () => {
+        const { stderr, stdout } = run(__dirname, ['--stats', 'none']);
+        expect(stderr).toBeFalsy();
+        expect(stdout).toBeFalsy();
+    });
+
+    it('should accept stats "errors-only"', () => {
+        const { stderr, stdout } = run(__dirname, ['--stats', 'errors-only']);
+        expect(stderr).toBeFalsy();
+        expect(stdout).toBeFalsy();
+    });
+
+    it('should accept stats "errors-warnings"', () => {
+        const { stderr, stdout } = run(__dirname, ['--stats', 'errors-warnings']);
+        expect(stderr).toBeFalsy();
+        expect(stdout).toBeFalsy();
+    });
+
+    it('should accept stats "normal"', () => {
+        const { stderr, stdout } = run(__dirname, ['--stats', 'normal']);
+        expect(stderr).toBeFalsy();
+        expect(stdout).toBeTruthy();
+    });
+
+    it('should accept stats "verbose"', () => {
+        const { stderr, stdout } = run(__dirname, ['--stats', 'verbose']);
+        expect(stderr).toBeFalsy();
+        expect(stdout).toBeTruthy();
+    });
+
+    it('should accept stats "minimal"', () => {
+        const { stderr, stdout } = run(__dirname, ['--stats', 'minimal']);
+        expect(stderr).toBeFalsy();
+        expect(stdout).toBeTruthy();
+    });
+
+    it('should warn when an unknown flag stats value is passed', () => {
+        const { stderr, stdout } = run(__dirname, ['--stats', 'foo']);
+        expect(stderr).toBeTruthy();
+        expect(stderr).toContain('No value recognised for "stats" option');
+        expect(stdout).toBeTruthy();
+    });
+});

--- a/test/stats/webpack.config.js
+++ b/test/stats/webpack.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+    mode: 'development',
+    entry: './index.js',
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
It implements the `stats` option for webpack via CLI.
Closes #1298

**Did you add tests for your changes?**
Yes

**If relevant, did you update the documentation?**
Yes

**Summary**
These options https://webpack.js.org/configuration/stats/#stats are now passed to the compiler via CLI.

I also removed the "fancy" output with the table. I had a discussion with the core maintainers about the library. The CLI should not alter the output of the compiler. I left `--pretty` as option, so we can still use but it is experimental.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
Kind of because it removed `--standard` flag.

**Other information**
