### PR TITLE
[bugfix] webpack-cli init loader's test regex

### DIFF
--- a/packages/generators/src/utils/languageSupport.ts
+++ b/packages/generators/src/utils/languageSupport.ts
@@ -51,7 +51,7 @@ function getEntryFolders(self): string[] {
 export function getBabelLoader(includeFolders: string[]): Rule {
 	const include = includeFolders.map((folder: string): string => `path.resolve(__dirname, '${folder}')`);
 	return {
-		test: "/.(js|jsx)$/",
+		test: "/\\.(js|jsx)$/",
 		include,
 		loader: "'babel-loader'"
 	};
@@ -66,7 +66,7 @@ export function getBabelLoader(includeFolders: string[]): Rule {
 export function getTypescriptLoader(includeFolders: string[]): Rule {
 	const include = includeFolders.map((folder: string): string => `path.resolve(__dirname, '${folder}')`);
 	return {
-		test: "/.(ts|tsx)?$/",
+		test: "/\\.(ts|tsx)$/",
 		loader: "'ts-loader'",
 		include,
 		exclude: ["/node_modules/"]


### PR DESCRIPTION
**What kind of change does this PR introduce?**
bugfix

**Did you add tests for your changes?**
no

**If relevant, did you update the documentation?**
no

**Summary**

Fixed the `regular expression` of loader's `test` field in `webpack.config.js` generated by `webpack-cli init`

**Does this PR introduce a breaking change?**
no

**Other information**

the regex should be `\.jsx?$` or `\.(js|jsx)$`, the original string should be `"/\\.(js|jsx)$/"` instead of `/.(js|jsx)$/`

the same with `"/.(ts|tsx)?$/"` -> `"/\\.(ts|tsx)$/"`

```js
/.(ts|tsx)?$/.test("anystring") === true
/.(ts|tsx)$/.test("anystringts") === true
/\.(ts|tsx)$/.test("anystring.ts") === true
```