### PR TITLE
fix: peer dependencies for `webpack serve`

### DIFF
--- a/packages/serve/package.json
+++ b/packages/serve/package.json
@@ -20,7 +20,8 @@
     "@types/cross-spawn": "6.0.0",
     "@types/inquirer": "6.5.0",
     "@types/node": "12.7.2",
-    "typescript": "3.5.3"
+    "typescript": "3.5.3",
+    "webpack-dev-server": "3.10.3"
   },
   "peerDependencies": {
     "webpack-cli": "4.x.x",

--- a/packages/serve/package.json
+++ b/packages/serve/package.json
@@ -13,8 +13,7 @@
   "dependencies": {
     "@webpack-cli/utils": "^1.0.1-alpha.5",
     "chalk": "3.0.0",
-    "cross-spawn": "6.0.5",
-    "inquirer": "6.5.1"
+    "cross-spawn": "6.0.5"
   },
   "devDependencies": {
     "@types/cross-spawn": "6.0.0",

--- a/packages/serve/package.json
+++ b/packages/serve/package.json
@@ -10,14 +10,7 @@
   },
   "author": "",
   "license": "MIT",
-  "dependencies": {
-    "@webpack-cli/utils": "^1.0.1-alpha.5",
-    "chalk": "3.0.0",
-    "cross-spawn": "6.0.5"
-  },
   "devDependencies": {
-    "@types/cross-spawn": "6.0.0",
-    "@types/inquirer": "6.5.0",
     "@types/node": "12.7.2",
     "typescript": "3.5.3",
     "webpack-dev-server": "3.10.3"

--- a/packages/serve/package.json
+++ b/packages/serve/package.json
@@ -14,9 +14,7 @@
     "@webpack-cli/utils": "^1.0.1-alpha.5",
     "chalk": "3.0.0",
     "cross-spawn": "6.0.5",
-    "inquirer": "6.5.1",
-    "webpack-cli": "^4.0.0-beta.8",
-    "webpack-dev-server": "^3.9.0"
+    "inquirer": "6.5.1"
   },
   "devDependencies": {
     "@types/cross-spawn": "6.0.0",
@@ -25,12 +23,8 @@
     "typescript": "3.5.3"
   },
   "peerDependencies": {
-    "webpack-dev-server": ">=3.0.0"
-  },
-  "peerDependenciesMeta": {
-    "webpack-dev-server": {
-      "optional": false
-    }
+    "webpack-cli": "4.x.x",
+    "webpack-dev-server": "3.x.x || 4.x.x"
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**

No need

**If relevant, did you update the documentation?**

No need

**Summary**

Allow developers to install any webpack-dev-server version (3 or next) + move webpack-cli to peer dependencies, because it is peer dependency

**Does this PR introduce a breaking change?**

Yes, you should add webpack-cli and webpack-dev-server to package.json and install them if you want to use `webpack serve`

**Other information**

No