### PR TITLE
chore: update code of conduct and fix links

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,7 +1,7 @@
 ## Code of Conduct
 
 At webpack and webpack/webpack-cli repository we follow the [JSFoundation Code of Conduct][1].
-Please adhere to the guidelines there and feel free to report any violation of them to the [@webpack/core-team](https://github.com/orgs/webpack/teams/core-team),
-[**@webpack/cli-team**](https://github.com/orgs/webpack/teams/cli-team), or <conduct@js.foundation>.
+Please adhere to the guidelines there and feel free to report any violation of them to the @webpack/core-team,
+**@webpack/cli-team**, or <conduct@js.foundation>.
 
-[1]: https://js.foundation/community/code-of-conduct
+[1]: https://github.com/openjs-foundation/code-and-learn/blob/master/CODE_OF_CONDUCT.md


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Doc change

**Summary**
Removed the team links as they're only visible to members of the webpack org, and fixed the code of conduct link
