### PR TITLE
docs: add commit message example

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -225,6 +225,15 @@ The **header** is mandatory.
 Any line of the commit message cannot be longer 100 characters. This allows the message to be easier
 to read on GitHub as well as in several git tools.
 
+#### Example commit message
+```
+docs(readme): update install instructions
+```
+
+```
+fix: refer to the `entrypoint` instead of the first `module`
+```
+
 For more information about what each part of the template mean, head up to the documentation in the
 [angular repo](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits)
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,7 +1,7 @@
 ## Code of Conduct
 
 At webpack and webpack/webpack-cli repository we follow the [JSFoundation Code of Conduct][1].
-Please adhere to the guidelines there and feel free to report any violation of them to the @webpack/core-team,
+Please adhere to the guidelines there and feel free to report any violation of them to the [@webpack/core-team](https://github.com/orgs/webpack/teams/core-team),
 [**@webpack/cli-team**](https://github.com/orgs/webpack/teams/cli-team), or <conduct@js.foundation>.
 
 [1]: https://js.foundation/community/code-of-conduct


### PR DESCRIPTION
add commit message example to help contributors/developers

What kind of change does this PR introduce?

docs(contributing): add commit message example to help contributors/developers

Did you add tests for your changes?
not required

If relevant, did you update the documentation?
not required

Summary

adding example for a commit message will save (possible)surfing to find an example of a commit message that the repo accepts

Does this PR introduce a breaking change?

no

Other information
resolves webpack#1340