### PR TITLE
feat(webpack-cli): allow multiple entry files

### DIFF
--- a/packages/webpack-cli/README.md
+++ b/packages/webpack-cli/README.md
@@ -35,7 +35,7 @@ Available Commands
 
 Options
 
-  --entry string           The entry point of your application.
+  --entry string[]         The entry point(s) of your application.
   -c, --config string      Provide path to a webpack configuration file
   -m, --merge string       Merge a configuration file using webpack-merge
   --progress               Print compilation progress during build

--- a/packages/webpack-cli/lib/groups/BasicGroup.js
+++ b/packages/webpack-cli/lib/groups/BasicGroup.js
@@ -1,3 +1,4 @@
+const chalk = require('chalk');
 const GroupHelper = require('../utils/GroupHelper');
 const { core, groups } = require('../utils/cli-flags');
 
@@ -35,6 +36,9 @@ class BasicGroup extends GroupHelper {
             }
             if (arg === 'entry') {
                 options[arg] = this.resolveFilePath(args[arg], 'index.js');
+                if (options[arg].length === 0) {
+                    process.stdout.write(chalk.red('\nError: you provided an invalid entry point.\n'));
+                }
             }
         });
         if (outputOptions['dev']) {

--- a/packages/webpack-cli/lib/utils/cli-flags.js
+++ b/packages/webpack-cli/lib/utils/cli-flags.js
@@ -77,9 +77,10 @@ module.exports = {
             name: 'entry',
             usage: '--entry <path to entry file> e.g. ./src/main.js',
             type: String,
+            multiple: true,
             defaultOption: true,
             group: BASIC_GROUP,
-            description: 'The entry point of your application.',
+            description: 'The entry point(s) of your application.',
             link: 'https://webpack.js.org/concepts/#entry',
         },
         {

--- a/test/entry/flag-entry/entry-with-flag.test.js
+++ b/test/entry/flag-entry/entry-with-flag.test.js
@@ -22,9 +22,45 @@ describe('entry flag', () => {
         });
     });
 
+    it('should allow multiple entries with --entry <file1> <file2>', (done) => {
+        const { stderr, stdout } = run(__dirname, ['--entry', './src/a.js', './src/b.js']);
+        expect(stderr).toBeFalsy();
+        expect(stdout).toBeTruthy();
+
+        stat(resolve(__dirname, './bin/main.js'), (err, stats) => {
+            expect(err).toBe(null);
+            expect(stats.isFile()).toBe(true);
+            done();
+        });
+        readFile(resolve(__dirname, './bin/main.js'), 'utf-8', (err, data) => {
+            expect(err).toBe(null);
+            expect(data).toContain('Hello from a.js');
+            expect(data).toContain('Hello from b.js');
+            done();
+        });
+    });
+
+    it('should allow multiple entries with --entry <file1> --entry <file2>', (done) => {
+        const { stderr, stdout } = run(__dirname, ['--entry', './src/a.js', '--entry', './src/b.js']);
+        expect(stderr).toBeFalsy();
+        expect(stdout).toBeTruthy();
+
+        stat(resolve(__dirname, './bin/main.js'), (err, stats) => {
+            expect(err).toBe(null);
+            expect(stats.isFile()).toBe(true);
+            done();
+        });
+        readFile(resolve(__dirname, './bin/main.js'), 'utf-8', (err, data) => {
+            expect(err).toBe(null);
+            expect(data).toContain('Hello from a.js');
+            expect(data).toContain('Hello from b.js');
+            done();
+        });
+    });
+
     it('should throw error for invalid entry file', () => {
         const { stderr, stdout } = run(__dirname, ['--entry', './src/test.js']);
-        expect(stderr).toBeFalsy();
-        expect(stdout).toContain('not found');
+        expect(stderr).toBeTruthy();
+        expect(stdout).toContain('Error: you provided an invalid entry point.');
     });
 });

--- a/test/entry/flag-entry/src/b.js
+++ b/test/entry/flag-entry/src/b.js
@@ -1,0 +1,1 @@
+console.log('Hello from b.js');

--- a/test/target/node/node-test.test.js
+++ b/test/target/node/node-test.test.js
@@ -5,7 +5,7 @@ const { run } = require('../../utils/test-utils');
 
 describe('Node target', () => {
     it('should emit the correct code', (done) => {
-        const { stderr } = run(__dirname, [__dirname, '-c', './webpack.config.js']);
+        const { stderr } = run(__dirname, ['-c', './webpack.config.js']);
         expect(stderr).toBeFalsy();
         stat(resolve(__dirname, 'bin/main.js'), (err, stats) => {
             expect(err).toBe(null);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Feature

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

Yes.

**If relevant, did you update the documentation?**

Yes

**Summary**

Now multiple entry files are possible. `--entry ./src/a.js ./src/b.js` or `--entry ./src/a.js --entry ./src/b.js`

<img width="645" alt="entry2" src="https://user-images.githubusercontent.com/46647141/79113477-a08b2600-7d9e-11ea-9903-c24420ca6256.PNG">


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

Maybe

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**

Refers #717