### PR TITLE
chore: remove yo-rc on clean command

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   ],
   "scripts": {
     "bootstrap": "lerna bootstrap",
-    "clean": "del-cli \"*.tsbuildinfo\" \"packages/**/*.tsbuildinfo\" \"packages/!(webpack-cli)/lib/!(*.tpl)\"",
+    "clean": "del-cli \"*.tsbuildinfo\" \"packages/**/*.tsbuildinfo\" \"packages/!(webpack-cli)/lib/!(*.tpl)\" \"**/.yo-rc.json\"",
     "prebuild": "yarn clean",
     "build": "tsc --build",
     "watch": "tsc --build --watch",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

small chore

**Did you add tests for your changes?**

No

**If relevant, did you update the documentation?**

No

**Summary**

Prettier sometimes fails when it hits `.yo-rc.json` files, so it would be nice to clean them out

**Does this PR introduce a breaking change?**

No

**Other information**
