### PR TITLE
fix: consistent webpack plugin name throughout

### DIFF
--- a/packages/webpack-cli/lib/utils/Compiler.js
+++ b/packages/webpack-cli/lib/utils/Compiler.js
@@ -59,15 +59,15 @@ class Compiler {
                 return compilation.name ? compilation.name : '';
             };
             if (outputOptions.watch) {
-                compilation.hooks.watchRun.tap('WebpackInfo', (compilation) => {
+                compilation.hooks.watchRun.tap('WebpackCLI', (compilation) => {
                     logger.info(`Compilation ${resolveCompilationName(compilation)} starting…`);
                 });
             } else {
-                compilation.hooks.beforeRun.tap('WebpackInfo', (compilation) => {
+                compilation.hooks.beforeRun.tap('WebpackCLI', (compilation) => {
                     logger.info(`Compilation ${resolveCompilationName(compilation)} starting…`);
                 });
             }
-            compilation.hooks.done.tap('WebpackInfo', (compilation) => {
+            compilation.hooks.done.tap('WebpackCLI', (compilation) => {
                 logger.info(`Compilation ${resolveCompilationName(compilation)} finished`);
             });
         }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
This is a bugfix request. It aims to make the webpack Plugin name consistent throughout the codebase preventing any collision with webpack core plugin name.
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
Not yet, will add if needed
**If relevant, did you update the documentation?**
Not Yet
**Summary**
@evilebottnawi  requested to make the plugin name consistent throughout the code base. 
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
