### PR TITLE
Fix migrate command

### DIFF
--- a/packages/migrate/src/index.ts
+++ b/packages/migrate/src/index.ts
@@ -1,5 +1,5 @@
 import chalk from 'chalk';
-import diff from 'diff';
+import { Change, diffLines } from 'diff';
 import fs from 'fs';
 import inquirer from 'inquirer';
 import Listr from 'listr';
@@ -90,9 +90,9 @@ function runMigration(currentConfigPath: string, outputConfigPath: string): Prom
         .run()
         .then((ctx: Node): void | Promise<void> => {
             const result: string = ctx.ast.toSource(recastOptions);
-            const diffOutput: diff.Change[] = diff.diffLines(ctx.source, result);
+            const diffOutput: Change[] = diffLines(ctx.source, result);
 
-            diffOutput.forEach((diffLine: diff.Change): void => {
+            diffOutput.forEach((diffLine: Change): void => {
                 if (diffLine.added) {
                     process.stdout.write(chalk.green(`+ ${diffLine.value}`));
                 } else if (diffLine.removed) {

--- a/packages/migrate/src/index.ts
+++ b/packages/migrate/src/index.ts
@@ -194,7 +194,7 @@ export default function migrate(...args: string[]): void | Promise<void> {
             ])
             .then((ans: { confirmPath: boolean }): void | Promise<void> => {
                 if (!ans.confirmPath) {
-                    console.error(chalk.red('✖ ︎Migration aborted due no output path'));
+                    console.error(chalk.red('✖ ︎Migration aborted due to no output path'));
                     return;
                 }
                 outputConfigPath = path.resolve(process.cwd(), filePaths[0]);

--- a/packages/migrate/src/index.ts
+++ b/packages/migrate/src/index.ts
@@ -133,15 +133,11 @@ function runMigration(currentConfigPath: string, outputConfigPath: string): Prom
                             return;
                         }
 
-                        runPrettier(outputConfigPath, result, (err: object): void => {
-                            if (err) {
-                                throw err;
-                            }
-                        });
+                        runPrettier(outputConfigPath, result);
 
                         if (answer.confirmValidation) {
-                            const outputPath = await import(outputConfigPath);
-                            const webpackOptionsValidationErrors: string[] = validate(outputPath);
+                            const outputConfig = (await import(outputConfigPath)).default;
+                            const webpackOptionsValidationErrors: string[] = validate(outputConfig);
 
                             if (webpackOptionsValidationErrors.length) {
                                 console.error(chalk.red("\n✖ Your configuration validation wasn't successful \n"));

--- a/packages/utils/__tests__/run-prettier.test.ts
+++ b/packages/utils/__tests__/run-prettier.test.ts
@@ -1,0 +1,42 @@
+'use strict';
+
+import fs from 'fs';
+import path from 'path';
+//eslint-disable-next-line node/no-extraneous-import
+import rimraf from 'rimraf';
+import { runPrettier } from '../src/run-prettier';
+
+const outputPath = path.join(__dirname, 'test-assets');
+const outputFile = path.join(outputPath, 'test.js');
+const stdoutSpy = jest.spyOn(process.stdout, 'write');
+
+describe('runPrettier', () => {
+    beforeEach(() => {
+        rimraf.sync(outputPath);
+        fs.mkdirSync(outputPath);
+        stdoutSpy.mockClear();
+    });
+
+    afterAll(() => {
+        rimraf.sync(outputPath);
+    });
+
+    it('should run prettier on JS string and write file', () => {
+        runPrettier(outputFile, 'console.log("1");console.log("2");');
+        expect(fs.existsSync(outputFile)).toBeTruthy();
+        const data = fs.readFileSync(outputFile, 'utf8');
+        expect(data).toContain("console.log('1');\n");
+
+        expect(stdoutSpy.mock.calls.length).toEqual(0);
+    });
+
+    it('prettier should fail on invalid JS, with file still written', () => {
+        runPrettier(outputFile, '"');
+        expect(fs.existsSync(outputFile)).toBeTruthy();
+        const data = fs.readFileSync(outputFile, 'utf8');
+        expect(data).toContain('"');
+
+        expect(stdoutSpy.mock.calls.length).toEqual(1);
+        expect(stdoutSpy.mock.calls[0][0]).toContain('WARNING: Could not apply prettier');
+    });
+});

--- a/packages/utils/src/run-prettier.ts
+++ b/packages/utils/src/run-prettier.ts
@@ -8,35 +8,27 @@ import prettier from 'prettier';
  *
  * @param {String} outputPath - Path to write the config to
  * @param {Node} source - AST to write at the given path
- * @param {Function} cb - executes a callback after execution if supplied
- * @returns {Void} Writes a file at given location and prints messages accordingly
+ * @returns {Void} Writes a file at given location
  */
 
-export function runPrettier(outputPath: string, source: string, cb?: Function): void {
-    function validateConfig(): void | Function {
-        let prettySource: string;
-        let error: object;
-        try {
-            prettySource = prettier.format(source, {
-                filepath: outputPath,
-                parser: 'babel',
-                singleQuote: true,
-                tabWidth: 1,
-                useTabs: true,
-            });
-        } catch (err) {
-            process.stdout.write(
-                `\n${chalk.yellow(
-                    `WARNING: Could not apply prettier to ${outputPath}` + ' due validation error, but the file has been created\n',
-                )}`,
-            );
-            prettySource = source;
-            error = err;
-        }
-        if (cb) {
-            return cb(error);
-        }
-        return fs.writeFileSync(outputPath, prettySource, 'utf8');
+export function runPrettier(outputPath: string, source: string): void {
+    let prettySource: string = source;
+    try {
+        prettySource = prettier.format(source, {
+            filepath: outputPath,
+            parser: 'babel',
+            singleQuote: true,
+            tabWidth: 1,
+            useTabs: true,
+        });
+    } catch (err) {
+        process.stdout.write(
+            `\n${chalk.yellow(
+                `WARNING: Could not apply prettier to ${outputPath}` + ' due validation error, but the file has been created\n',
+            )}`,
+        );
+        prettySource = source;
     }
-    return fs.writeFile(outputPath, source, 'utf8', validateConfig);
+
+    return fs.writeFileSync(outputPath, prettySource, 'utf8');
 }

--- a/test/init/generator/init-inquirer.test.js
+++ b/test/init/generator/init-inquirer.test.js
@@ -22,7 +22,7 @@ describe('init', () => {
     });
 
     it('should scaffold when given answers', async () => {
-        const { stdout } = await runPromptWithAnswers(genPath, ['init'], ['N', ENTER, ENTER, ENTER, ENTER, ENTER, ENTER, ENTER]);
+        const { stdout } = await runPromptWithAnswers(genPath, ['init'], [`N${ENTER}`, ENTER, ENTER, ENTER, ENTER, ENTER, ENTER], true);
 
         expect(stdout).toBeTruthy();
         expect(stdout).toContain(firstPrompt);

--- a/test/init/generator/init-inquirer.test.js
+++ b/test/init/generator/init-inquirer.test.js
@@ -22,7 +22,7 @@ describe('init', () => {
     });
 
     it('should scaffold when given answers', async () => {
-        const { stdout } = await runPromptWithAnswers(genPath, ['init'], [`N${ENTER}`, ENTER, ENTER, ENTER, ENTER, ENTER, ENTER], true);
+        const { stdout } = await runPromptWithAnswers(genPath, ['init'], [`N${ENTER}`, ENTER, ENTER, ENTER, ENTER, ENTER, ENTER]);
 
         expect(stdout).toBeTruthy();
         expect(stdout).toContain(firstPrompt);

--- a/test/loader/loader.test.js
+++ b/test/loader/loader.test.js
@@ -31,7 +31,7 @@ describe('loader command', () => {
     });
 
     it('should scaffold loader template with a given name', async () => {
-        const { stdout } = await runPromptWithAnswers(__dirname, ['loader'], [`${loaderName}${ENTER}`], true);
+        const { stdout } = await runPromptWithAnswers(__dirname, ['loader'], [`${loaderName}${ENTER}`]);
 
         expect(stdout).toContain(firstPrompt);
 

--- a/test/loader/loader.test.js
+++ b/test/loader/loader.test.js
@@ -31,7 +31,7 @@ describe('loader command', () => {
     });
 
     it('should scaffold loader template with a given name', async () => {
-        const { stdout } = await runPromptWithAnswers(__dirname, ['loader'], [loaderName, ENTER]);
+        const { stdout } = await runPromptWithAnswers(__dirname, ['loader'], [`${loaderName}${ENTER}`], true);
 
         expect(stdout).toContain(firstPrompt);
 

--- a/test/migrate/config/bad-webpack.config.js
+++ b/test/migrate/config/bad-webpack.config.js
@@ -1,0 +1,7 @@
+/* eslint-disable */
+
+module.exports = {
+    output: {
+        badOption: true,
+    },
+};

--- a/test/migrate/config/migrate-config.test.js
+++ b/test/migrate/config/migrate-config.test.js
@@ -1,6 +1,8 @@
 'use strict';
 
-const { run, runAndGetWatchProc } = require('../../utils/test-utils');
+const { run, runAndGetWatchProc, runPromptWithAnswers } = require('../../utils/test-utils');
+
+const ENTER = '\x0D';
 
 describe('migrate command', () => {
     it('should warn if the source config file is not specified', () => {
@@ -20,6 +22,11 @@ describe('migrate command', () => {
 
     it('should prompt for config validation when an output path is provided', async () => {
         const { stdout } = await runAndGetWatchProc(__dirname, ['migrate', 'webpack.config.js', 'updated-webpack.config.js'], false, 'y');
+        expect(stdout).toContain('? Do you want to validate your configuration?');
+    });
+
+    it('should generate an updated config file when an output path is provided', async () => {
+        const stdout = await runPromptWithAnswers(__dirname, ['migrate', 'webpack.config.js', 'updated-webpack.config.js'], [ENTER, ENTER]);
         expect(stdout).toContain('? Do you want to validate your configuration?');
     });
 });

--- a/test/migrate/config/migrate-config.test.js
+++ b/test/migrate/config/migrate-config.test.js
@@ -1,10 +1,26 @@
 'use strict';
 
+const fs = require('fs');
+const path = require('path');
+const rimraf = require('rimraf');
 const { run, runAndGetWatchProc, runPromptWithAnswers } = require('../../utils/test-utils');
 
 const ENTER = '\x0D';
+const outputDir = 'test-assets';
+const outputPath = path.join(__dirname, outputDir);
+const outputFile = `${outputDir}/updated-webpack.config.js`;
+const outputFilePath = path.join(__dirname, outputFile);
 
 describe('migrate command', () => {
+    beforeEach(() => {
+        rimraf.sync(outputPath);
+        fs.mkdirSync(outputPath);
+    });
+
+    afterAll(() => {
+        rimraf.sync(outputPath);
+    });
+
     it('should warn if the source config file is not specified', () => {
         const { stderr } = run(__dirname, ['migrate'], false);
         expect(stderr).toContain('Please specify a path to your webpack config');
@@ -21,12 +37,23 @@ describe('migrate command', () => {
     });
 
     it('should prompt for config validation when an output path is provided', async () => {
-        const { stdout } = await runAndGetWatchProc(__dirname, ['migrate', 'webpack.config.js', 'updated-webpack.config.js'], false, 'y');
+        const { stdout } = await runAndGetWatchProc(__dirname, ['migrate', 'webpack.config.js', outputFile], false, 'y');
         expect(stdout).toContain('? Do you want to validate your configuration?');
     });
 
     it('should generate an updated config file when an output path is provided', async () => {
-        const stdout = await runPromptWithAnswers(__dirname, ['migrate', 'webpack.config.js', 'updated-webpack.config.js'], [ENTER, ENTER]);
+        const { stdout, stderr } = await runPromptWithAnswers(__dirname, ['migrate', 'webpack.config.js', outputFile], [ENTER, ENTER]);
         expect(stdout).toContain('? Do you want to validate your configuration?');
+        expect(stderr).toBeFalsy();
+
+        expect(fs.existsSync(outputFilePath)).toBeTruthy();
+    });
+
+    it('should generate an updated config file and warn of an invalid webpack config', async () => {
+        const { stdout, stderr } = await runPromptWithAnswers(__dirname, ['migrate', 'bad-webpack.config.js', outputFile], [ENTER, ENTER]);
+        expect(stdout).toContain('? Do you want to validate your configuration?');
+        expect(stderr).toContain("configuration.output has an unknown property 'badOption'");
+
+        expect(fs.existsSync(outputFilePath)).toBeTruthy();
     });
 });

--- a/test/migrate/config/migrate-config.test.js
+++ b/test/migrate/config/migrate-config.test.js
@@ -77,12 +77,7 @@ describe('migrate command', () => {
     });
 
     it('should generate an updated config file and warn of an invalid webpack config', async () => {
-        const { stdout, stderr } = await runPromptWithAnswers(
-            __dirname,
-            ['migrate', 'bad-webpack.config.js', outputFile],
-            [ENTER, ENTER],
-            true,
-        );
+        const { stdout, stderr } = await runPromptWithAnswers(__dirname, ['migrate', 'bad-webpack.config.js', outputFile], [ENTER, ENTER]);
         expect(stdout).toContain('? Do you want to validate your configuration?');
         expect(stderr).toContain("configuration.output has an unknown property 'badOption'");
 

--- a/test/migrate/config/migrate-config.test.js
+++ b/test/migrate/config/migrate-config.test.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const { run, runAndGetWatchProc } = require('../../utils/test-utils');
+
+describe('migrate command', () => {
+    it('should warn if the source config file is not specified', () => {
+        const { stderr } = run(__dirname, ['migrate'], false);
+        expect(stderr).toContain('Please specify a path to your webpack config');
+    });
+
+    it('should prompt accordingly if an output path is not specified', () => {
+        const { stdout } = run(__dirname, ['migrate', 'webpack.config.js'], false);
+        expect(stdout).toContain('? Migration output path not specified');
+    });
+
+    it('should throw an error if the user refused to overwrite the source file and no output path is provided', async () => {
+        const { stderr } = await runAndGetWatchProc(__dirname, ['migrate', 'webpack.config.js'], false, 'n');
+        expect(stderr).toBe('✖ ︎Migration aborted due no output path');
+    });
+
+    it('should prompt for config validation when an output path is provided', async () => {
+        const { stdout } = await runAndGetWatchProc(__dirname, ['migrate', 'webpack.config.js', 'updated-webpack.config.js'], false, 'y');
+        expect(stdout).toContain('? Do you want to validate your configuration?');
+    });
+});

--- a/test/migrate/config/migrate-config.test.js
+++ b/test/migrate/config/migrate-config.test.js
@@ -43,7 +43,7 @@ describe('migrate command', () => {
         expect(stdout).toContain('? Do you want to validate your configuration?');
     });
 
-    it.skip('should generate an updated config file when an output path is provided', async () => {
+    it('should generate an updated config file when an output path is provided', async () => {
         const { stdout, stderr } = await runPromptWithAnswers(__dirname, ['migrate', 'webpack.config.js', outputFile], [ENTER, ENTER]);
         expect(stdout).toContain('? Do you want to validate your configuration?');
         // should show the diff of the config file
@@ -71,7 +71,7 @@ describe('migrate command', () => {
         ]);
     });
 
-    it.skip('should generate an updated config file and warn of an invalid webpack config', async () => {
+    it('should generate an updated config file and warn of an invalid webpack config', async () => {
         const { stdout, stderr } = await runPromptWithAnswers(__dirname, ['migrate', 'bad-webpack.config.js', outputFile], [ENTER, ENTER]);
         expect(stdout).toContain('? Do you want to validate your configuration?');
         expect(stderr).toContain("configuration.output has an unknown property 'badOption'");

--- a/test/migrate/config/migrate-config.test.js
+++ b/test/migrate/config/migrate-config.test.js
@@ -33,7 +33,7 @@ describe('migrate command', () => {
 
     it('should throw an error if the user refused to overwrite the source file and no output path is provided', async () => {
         const { stderr } = await runAndGetWatchProc(__dirname, ['migrate', 'webpack.config.js'], false, 'n');
-        expect(stderr).toBe('✖ ︎Migration aborted due no output path');
+        expect(stderr).toBe('✖ ︎Migration aborted due to no output path');
     });
 
     it('should prompt for config validation when an output path is provided', async () => {
@@ -43,7 +43,7 @@ describe('migrate command', () => {
         expect(stdout).toContain('? Do you want to validate your configuration?');
     });
 
-    it('should generate an updated config file when an output path is provided', async () => {
+    it.skip('should generate an updated config file when an output path is provided', async () => {
         const { stdout, stderr } = await runPromptWithAnswers(__dirname, ['migrate', 'webpack.config.js', outputFile], [ENTER, ENTER]);
         expect(stdout).toContain('? Do you want to validate your configuration?');
         // should show the diff of the config file
@@ -71,7 +71,7 @@ describe('migrate command', () => {
         ]);
     });
 
-    it('should generate an updated config file and warn of an invalid webpack config', async () => {
+    it.skip('should generate an updated config file and warn of an invalid webpack config', async () => {
         const { stdout, stderr } = await runPromptWithAnswers(__dirname, ['migrate', 'bad-webpack.config.js', outputFile], [ENTER, ENTER]);
         expect(stdout).toContain('? Do you want to validate your configuration?');
         expect(stderr).toContain("configuration.output has an unknown property 'badOption'");

--- a/test/migrate/config/migrate-config.test.js
+++ b/test/migrate/config/migrate-config.test.js
@@ -44,7 +44,12 @@ describe('migrate command', () => {
     });
 
     it('should generate an updated config file when an output path is provided', async () => {
-        const { stdout, stderr } = await runPromptWithAnswers(__dirname, ['migrate', 'webpack.config.js', outputFile], [ENTER, ENTER]);
+        const { stdout, stderr } = await runPromptWithAnswers(
+            __dirname,
+            ['migrate', 'webpack.config.js', outputFile],
+            [ENTER, ENTER],
+            true,
+        );
         expect(stdout).toContain('? Do you want to validate your configuration?');
         // should show the diff of the config file
         expect(stdout).toContain('rules: [');
@@ -72,7 +77,12 @@ describe('migrate command', () => {
     });
 
     it('should generate an updated config file and warn of an invalid webpack config', async () => {
-        const { stdout, stderr } = await runPromptWithAnswers(__dirname, ['migrate', 'bad-webpack.config.js', outputFile], [ENTER, ENTER]);
+        const { stdout, stderr } = await runPromptWithAnswers(
+            __dirname,
+            ['migrate', 'bad-webpack.config.js', outputFile],
+            [ENTER, ENTER],
+            true,
+        );
         expect(stdout).toContain('? Do you want to validate your configuration?');
         expect(stderr).toContain("configuration.output has an unknown property 'badOption'");
 

--- a/test/migrate/config/migrate-config.test.js
+++ b/test/migrate/config/migrate-config.test.js
@@ -38,15 +38,37 @@ describe('migrate command', () => {
 
     it('should prompt for config validation when an output path is provided', async () => {
         const { stdout } = await runAndGetWatchProc(__dirname, ['migrate', 'webpack.config.js', outputFile], false, 'y');
+        // should show the diff of the config file
+        expect(stdout).toContain('rules: [');
         expect(stdout).toContain('? Do you want to validate your configuration?');
     });
 
     it('should generate an updated config file when an output path is provided', async () => {
         const { stdout, stderr } = await runPromptWithAnswers(__dirname, ['migrate', 'webpack.config.js', outputFile], [ENTER, ENTER]);
         expect(stdout).toContain('? Do you want to validate your configuration?');
+        // should show the diff of the config file
+        expect(stdout).toContain('rules: [');
         expect(stderr).toBeFalsy();
 
         expect(fs.existsSync(outputFilePath)).toBeTruthy();
+        // the output file should be a valid config file
+        const config = require(outputFilePath);
+        expect(config.module.rules).toEqual([
+            {
+                test: /\.js$/,
+                exclude: /node_modules/,
+
+                use: [
+                    {
+                        loader: 'babel-loader',
+
+                        options: {
+                            presets: ['@babel/preset-env'],
+                        },
+                    },
+                ],
+            },
+        ]);
     });
 
     it('should generate an updated config file and warn of an invalid webpack config', async () => {

--- a/test/migrate/config/webpack.config.js
+++ b/test/migrate/config/webpack.config.js
@@ -1,0 +1,62 @@
+/* eslint-disable */
+const ExtractTextPlugin = require('extract-text-webpack-plugin');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+const path = require('path');
+const webpack = require('webpack');
+
+module.exports = {
+    entry: {
+        index: './src/index.js',
+        vendor: './src/vendor.js',
+    },
+
+    output: {
+        filename: '[name].[chunkhash].js',
+        chunkFilename: '[name].[chunkhash].js',
+        path: path.resolve(__dirname, 'dist'),
+    },
+
+    module: {
+        rules: [
+            {
+                test: /\.js$/,
+                exclude: /node_modules/,
+
+                use: [{
+                    loader: 'babel-loader',
+
+                    options: {
+                        presets: ['@babel/preset-env'],
+                    }
+                }]
+            },
+            {
+                test: /\.(scss|css)$/,
+                use: ExtractTextPlugin.extract({
+                    fallback: 'style',
+                    use: 'css!sass'
+                }),
+            },
+        ],
+    },
+
+    plugins: [new ExtractTextPlugin('styles-[contentHash].css'), new HtmlWebpackPlugin()],
+
+    optimization: {
+        minimize: true
+    },
+
+    optimizations: {
+        splitChunks: {
+            cacheGroups: {
+                common: {
+                    name: 'common',
+                    chunks: 'initial',
+                    enforce: true,
+                    minChunks: 2,
+                    filename: 'common-[hash].min.js'
+                }
+            }
+        }
+    }
+};

--- a/test/migrate/config/webpack.config.js
+++ b/test/migrate/config/webpack.config.js
@@ -16,4 +16,17 @@ module.exports = {
     optimization: {
         minimize: true
     },
+
+    module: {
+        loaders: [
+            {
+                test: /\.js$/,
+                exclude: /node_modules/,
+                loader: 'babel',
+                query: {
+                    presets: ['@babel/preset-env'],
+                },
+            },
+        ],
+    },
 };

--- a/test/migrate/config/webpack.config.js
+++ b/test/migrate/config/webpack.config.js
@@ -1,8 +1,5 @@
 /* eslint-disable */
-const ExtractTextPlugin = require('extract-text-webpack-plugin');
-const HtmlWebpackPlugin = require('html-webpack-plugin');
 const path = require('path');
-const webpack = require('webpack');
 
 module.exports = {
     entry: {
@@ -16,47 +13,7 @@ module.exports = {
         path: path.resolve(__dirname, 'dist'),
     },
 
-    module: {
-        rules: [
-            {
-                test: /\.js$/,
-                exclude: /node_modules/,
-
-                use: [{
-                    loader: 'babel-loader',
-
-                    options: {
-                        presets: ['@babel/preset-env'],
-                    }
-                }]
-            },
-            {
-                test: /\.(scss|css)$/,
-                use: ExtractTextPlugin.extract({
-                    fallback: 'style',
-                    use: 'css!sass'
-                }),
-            },
-        ],
-    },
-
-    plugins: [new ExtractTextPlugin('styles-[contentHash].css'), new HtmlWebpackPlugin()],
-
     optimization: {
         minimize: true
     },
-
-    optimizations: {
-        splitChunks: {
-            cacheGroups: {
-                common: {
-                    name: 'common',
-                    chunks: 'initial',
-                    enforce: true,
-                    minChunks: 2,
-                    filename: 'common-[hash].min.js'
-                }
-            }
-        }
-    }
 };

--- a/test/output/named-bundles/output-named-bundles.test.js
+++ b/test/output/named-bundles/output-named-bundles.test.js
@@ -1,59 +1,81 @@
 'use strict';
-const { stat } = require('fs');
-const { resolve } = require('path');
+const { statSync } = require('fs');
+const { join, resolve } = require('path');
+const rimraf = require('rimraf');
 const { run } = require('../../utils/test-utils');
 
 describe('output flag named bundles', () => {
-    it('should output file given as flag instead of in configuration', (done) => {
-        run(__dirname, ['-c', resolve(__dirname, 'webpack.config.js'), '--output', './binary/a.bundle.js'], false);
-        stat(resolve(__dirname, './binary/a.bundle.js'), (err, stats) => {
-            expect(err).toBe(null);
-            expect(stats.isFile()).toBe(true);
-            done();
-        });
+    const clean = () => {
+        rimraf.sync(join(__dirname, 'bin'));
+        rimraf.sync(join(__dirname, 'dist'));
+        rimraf.sync(join(__dirname, 'binary'));
+    };
+
+    beforeEach(clean);
+
+    afterAll(clean);
+
+    it('should output file given as flag instead of in configuration', () => {
+        const { stderr } = run(__dirname, ['-c', resolve(__dirname, 'webpack.config.js'), '--output', './binary/a.bundle.js'], false);
+        expect(stderr).toBeFalsy();
+
+        const stats = statSync(resolve(__dirname, './binary/a.bundle.js'));
+        expect(stats.isFile()).toBe(true);
     });
 
-    it('should create multiple bundles with an overriding flag', (done) => {
-        run(__dirname, ['-c', resolve(__dirname, 'webpack.single.config.js'), '--output', './bin/[name].bundle.js'], false);
+    it('should create multiple bundles with an overriding flag', () => {
+        const { stderr } = run(
+            __dirname,
+            ['-c', resolve(__dirname, 'webpack.single.config.js'), '--output', './bin/[name].bundle.js'],
+            false,
+        );
+        expect(stderr).toBeFalsy();
 
-        stat(resolve(__dirname, './bin/b.bundle.js'), (err, stats) => {
-            expect(err).toBe(null);
-            expect(stats.isFile()).toBe(true);
-        });
-        stat(resolve(__dirname, './bin/c.bundle.js'), (err, stats) => {
-            expect(err).toBe(null);
-            expect(stats.isFile()).toBe(true);
-        });
-        done();
+        let stats = statSync(resolve(__dirname, './bin/b.bundle.js'));
+        expect(stats.isFile()).toBe(true);
+        stats = statSync(resolve(__dirname, './bin/c.bundle.js'));
+        expect(stats.isFile()).toBe(true);
     });
 
-    it('should not throw error on same bundle name for multiple entries with defaults', (done) => {
+    it('should not throw error on same bundle name for multiple entries with defaults', () => {
         const { stderr } = run(__dirname, ['-c', resolve(__dirname, 'webpack.defaults.config.js'), '--defaults'], false);
+        expect(stderr).toBeFalsy();
 
-        expect(stderr).toBe('');
-
-        stat(resolve(__dirname, './dist/b.main.js'), (err, stats) => {
-            expect(err).toBe(null);
-            expect(stats.isFile()).toBe(true);
-        });
-        stat(resolve(__dirname, './dist/c.main.js'), (err, stats) => {
-            expect(err).toBe(null);
-            expect(stats.isFile()).toBe(true);
-        });
-        done();
+        let stats = statSync(resolve(__dirname, './dist/b.main.js'));
+        expect(stats.isFile()).toBe(true);
+        stats = statSync(resolve(__dirname, './dist/c.main.js'));
+        expect(stats.isFile()).toBe(true);
     });
 
-    it('should successfully compile multiple entries', (done) => {
-        run(__dirname, ['-c', resolve(__dirname, 'webpack.multiple.config.js')], false);
+    it('should successfully compile multiple entries', () => {
+        const { stderr } = run(__dirname, ['-c', resolve(__dirname, 'webpack.multiple.config.js')], false);
+        expect(stderr).toBeFalsy();
 
-        stat(resolve(__dirname, './bin/b.bundle.js'), (err, stats) => {
-            expect(err).toBe(null);
-            expect(stats.isFile()).toBe(true);
-        });
-        stat(resolve(__dirname, './bin/c.bundle.js'), (err, stats) => {
-            expect(err).toBe(null);
-            expect(stats.isFile()).toBe(true);
-        });
-        done();
+        let stats = statSync(resolve(__dirname, './bin/b.bundle.js'));
+        expect(stats.isFile()).toBe(true);
+        stats = statSync(resolve(__dirname, './bin/c.bundle.js'));
+        expect(stats.isFile()).toBe(true);
+    });
+
+    it('should output file in bin directory using default webpack config with warning for empty output value', () => {
+        const { stderr } = run(__dirname, ['--output='], false);
+        expect(stderr).toContain(
+            "You provided an empty output value. Falling back to the output value of your webpack config file, or './dist/' if none was provided",
+        );
+
+        const stats = statSync(resolve(__dirname, './bin/bundle.js'));
+        expect(stats.isFile()).toBe(true);
+    });
+
+    it('should output file in dist directory using default value with warning for empty output value', () => {
+        const { stderr } = run(__dirname, ['-c', resolve(__dirname, 'webpack.defaults.config.js'), '--defaults', '--output='], false);
+        expect(stderr).toContain(
+            "You provided an empty output value. Falling back to the output value of your webpack config file, or './dist/' if none was provided",
+        );
+
+        let stats = statSync(resolve(__dirname, './dist/b.main.js'));
+        expect(stats.isFile()).toBe(true);
+        stats = statSync(resolve(__dirname, './dist/c.main.js'));
+        expect(stats.isFile()).toBe(true);
     });
 });

--- a/test/output/named-bundles/output-named-bundles.test.js
+++ b/test/output/named-bundles/output-named-bundles.test.js
@@ -56,26 +56,4 @@ describe('output flag named bundles', () => {
         stats = statSync(resolve(__dirname, './bin/c.bundle.js'));
         expect(stats.isFile()).toBe(true);
     });
-
-    it('should output file in bin directory using default webpack config with warning for empty output value', () => {
-        const { stderr } = run(__dirname, ['--output='], false);
-        expect(stderr).toContain(
-            "You provided an empty output value. Falling back to the output value of your webpack config file, or './dist/' if none was provided",
-        );
-
-        const stats = statSync(resolve(__dirname, './bin/bundle.js'));
-        expect(stats.isFile()).toBe(true);
-    });
-
-    it('should output file in dist directory using default value with warning for empty output value', () => {
-        const { stderr } = run(__dirname, ['-c', resolve(__dirname, 'webpack.defaults.config.js'), '--defaults', '--output='], false);
-        expect(stderr).toContain(
-            "You provided an empty output value. Falling back to the output value of your webpack config file, or './dist/' if none was provided",
-        );
-
-        let stats = statSync(resolve(__dirname, './dist/b.main.js'));
-        expect(stats.isFile()).toBe(true);
-        stats = statSync(resolve(__dirname, './dist/c.main.js'));
-        expect(stats.isFile()).toBe(true);
-    });
 });

--- a/test/output/named-bundles/output-named-bundles.test.js
+++ b/test/output/named-bundles/output-named-bundles.test.js
@@ -1,59 +1,59 @@
 'use strict';
-const { statSync } = require('fs');
-const { join, resolve } = require('path');
-const rimraf = require('rimraf');
+const { stat } = require('fs');
+const { resolve } = require('path');
 const { run } = require('../../utils/test-utils');
 
 describe('output flag named bundles', () => {
-    const clean = () => {
-        rimraf.sync(join(__dirname, 'bin'));
-        rimraf.sync(join(__dirname, 'dist'));
-        rimraf.sync(join(__dirname, 'binary'));
-    };
-
-    beforeEach(clean);
-
-    afterAll(clean);
-
-    it('should output file given as flag instead of in configuration', () => {
-        const { stderr } = run(__dirname, ['-c', resolve(__dirname, 'webpack.config.js'), '--output', './binary/a.bundle.js'], false);
-        expect(stderr).toBeFalsy();
-
-        const stats = statSync(resolve(__dirname, './binary/a.bundle.js'));
-        expect(stats.isFile()).toBe(true);
+    it('should output file given as flag instead of in configuration', (done) => {
+        run(__dirname, ['-c', resolve(__dirname, 'webpack.config.js'), '--output', './binary/a.bundle.js'], false);
+        stat(resolve(__dirname, './binary/a.bundle.js'), (err, stats) => {
+            expect(err).toBe(null);
+            expect(stats.isFile()).toBe(true);
+            done();
+        });
     });
 
-    it('should create multiple bundles with an overriding flag', () => {
-        const { stderr } = run(
-            __dirname,
-            ['-c', resolve(__dirname, 'webpack.single.config.js'), '--output', './bin/[name].bundle.js'],
-            false,
-        );
-        expect(stderr).toBeFalsy();
+    it('should create multiple bundles with an overriding flag', (done) => {
+        run(__dirname, ['-c', resolve(__dirname, 'webpack.single.config.js'), '--output', './bin/[name].bundle.js'], false);
 
-        let stats = statSync(resolve(__dirname, './bin/b.bundle.js'));
-        expect(stats.isFile()).toBe(true);
-        stats = statSync(resolve(__dirname, './bin/c.bundle.js'));
-        expect(stats.isFile()).toBe(true);
+        stat(resolve(__dirname, './bin/b.bundle.js'), (err, stats) => {
+            expect(err).toBe(null);
+            expect(stats.isFile()).toBe(true);
+        });
+        stat(resolve(__dirname, './bin/c.bundle.js'), (err, stats) => {
+            expect(err).toBe(null);
+            expect(stats.isFile()).toBe(true);
+        });
+        done();
     });
 
-    it('should not throw error on same bundle name for multiple entries with defaults', () => {
+    it('should not throw error on same bundle name for multiple entries with defaults', (done) => {
         const { stderr } = run(__dirname, ['-c', resolve(__dirname, 'webpack.defaults.config.js'), '--defaults'], false);
-        expect(stderr).toBeFalsy();
 
-        let stats = statSync(resolve(__dirname, './dist/b.main.js'));
-        expect(stats.isFile()).toBe(true);
-        stats = statSync(resolve(__dirname, './dist/c.main.js'));
-        expect(stats.isFile()).toBe(true);
+        expect(stderr).toBe('');
+
+        stat(resolve(__dirname, './dist/b.main.js'), (err, stats) => {
+            expect(err).toBe(null);
+            expect(stats.isFile()).toBe(true);
+        });
+        stat(resolve(__dirname, './dist/c.main.js'), (err, stats) => {
+            expect(err).toBe(null);
+            expect(stats.isFile()).toBe(true);
+        });
+        done();
     });
 
-    it('should successfully compile multiple entries', () => {
-        const { stderr } = run(__dirname, ['-c', resolve(__dirname, 'webpack.multiple.config.js')], false);
-        expect(stderr).toBeFalsy();
+    it('should successfully compile multiple entries', (done) => {
+        run(__dirname, ['-c', resolve(__dirname, 'webpack.multiple.config.js')], false);
 
-        let stats = statSync(resolve(__dirname, './bin/b.bundle.js'));
-        expect(stats.isFile()).toBe(true);
-        stats = statSync(resolve(__dirname, './bin/c.bundle.js'));
-        expect(stats.isFile()).toBe(true);
+        stat(resolve(__dirname, './bin/b.bundle.js'), (err, stats) => {
+            expect(err).toBe(null);
+            expect(stats.isFile()).toBe(true);
+        });
+        stat(resolve(__dirname, './bin/c.bundle.js'), (err, stats) => {
+            expect(err).toBe(null);
+            expect(stats.isFile()).toBe(true);
+        });
+        done();
     });
 });

--- a/test/utils/test-utils.js
+++ b/test/utils/test-utils.js
@@ -91,7 +91,9 @@ function runAndGetWatchProc(testCase, args = [], setOutput = true, input = '', f
 /**
  * runInitWithAnswers
  * @param {string} location location of current working directory
+ * @param {string[]} args CLI args to pass in
  * @param {string[]} answers answers to be passed to stdout for inquirer question
+ * @param {boolean} waitForOutput whether to wait for stdout before writing the next answer
  */
 const runPromptWithAnswers = (location, args, answers, waitForOutput = false) => {
     const runner = runAndGetWatchProc(location, args, false, '', true);

--- a/test/utils/test-utils.js
+++ b/test/utils/test-utils.js
@@ -75,7 +75,6 @@ function runAndGetWatchProc(testCase, args = [], setOutput = true, input = '', f
 
     const options = {
         cwd,
-        input,
         reject: false,
         stdio: ENABLE_LOG_COMPILATION && !forcePipe ? 'inherit' : 'pipe',
     };

--- a/test/utils/test-utils.js
+++ b/test/utils/test-utils.js
@@ -41,7 +41,7 @@ function runWatch({ testCase, args = [], setOutput = true, outputKillStr = 'Time
         const watchPromise = execa(WEBPACK_PATH, argsWithOutput, {
             cwd,
             reject: false,
-            stdio: ENABLE_LOG_COMPILATION ? 'inherit' : 'pipe',
+            stdio: 'pipe',
         });
 
         watchPromise.stdout.pipe(
@@ -95,7 +95,7 @@ function runAndGetWatchProc(testCase, args = [], setOutput = true, input = '', f
  * @param {string[]} answers answers to be passed to stdout for inquirer question
  * @param {boolean} waitForOutput whether to wait for stdout before writing the next answer
  */
-const runPromptWithAnswers = (location, args, answers, waitForOutput = false) => {
+const runPromptWithAnswers = (location, args, answers, waitForOutput = true) => {
     const runner = runAndGetWatchProc(location, args, false, '', true);
     runner.stdin.setDefaultEncoding('utf-8');
 
@@ -128,7 +128,7 @@ const runPromptWithAnswers = (location, args, answers, waitForOutput = false) =>
             }),
         );
     } else {
-        // Simulate answers by sending the answers after waiting for 2s
+        // Simulate answers by sending the answers every 2s
         answers.reduce((prevAnswer, answer) => {
             return prevAnswer.then(() => {
                 return new Promise((resolvePromise) => {

--- a/test/utils/test-utils.js
+++ b/test/utils/test-utils.js
@@ -118,6 +118,8 @@ const runPromptWithAnswers = (location, args, answers, waitForOutput = false) =>
                         if (outputTimeout) {
                             clearTimeout(outputTimeout);
                         }
+                        // we must receive new stdout, then have 2 seconds
+                        // without any stdout before writing the next answer
                         outputTimeout = setTimeout(writeAnswer, delay);
                     }
 

--- a/test/utils/test-utils.js
+++ b/test/utils/test-utils.js
@@ -75,6 +75,7 @@ function runAndGetWatchProc(testCase, args = [], setOutput = true, input = '', f
 
     const options = {
         cwd,
+        input,
         reject: false,
         stdio: ENABLE_LOG_COMPILATION && !forcePipe ? 'inherit' : 'pipe',
     };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

fix/tests

**Did you add tests for your changes?**

Yes (still need to add tests for runPrettier)

I'm not exactly sure how the migrate command is supposed to work. Could someone give an example of a webpack config that it should make modifications to?

**If relevant, did you update the documentation?**

No

**Summary**

@jamesgeorge007 Sorry for taking over, just couldn't debug `runPromptWithAnswers` without using your changes. It seems that execa does not like an empty `input` string option.

- Fixes `runPromptWithAnswers`
- Fixes migrate
- Fixes issues with `runPrettier`

**Does this PR introduce a breaking change?**

Slightly with how `runPrettier` works

**Other information**
