### PR TITLE
tests: add longer jest timeout to migrate test, set other timeouts to 20000

### DIFF
--- a/test/init/auto/init-auto.test.js
+++ b/test/init/auto/init-auto.test.js
@@ -8,7 +8,7 @@ const { run } = require('../../utils/test-utils');
 const firstPrompt = 'Will your application have multiple bundles?';
 const genPath = join(__dirname, 'test-assets');
 
-jest.setTimeout(200000);
+jest.setTimeout(20000);
 describe('init auto flag', () => {
     beforeAll(() => {
         rimraf.sync(genPath);

--- a/test/init/generator/init-inquirer.test.js
+++ b/test/init/generator/init-inquirer.test.js
@@ -9,7 +9,7 @@ const firstPrompt = 'Will your application have multiple bundles?';
 const ENTER = '\x0D';
 const genPath = path.join(__dirname, 'test-assets');
 
-jest.setTimeout(20000);
+jest.setTimeout(60000);
 
 describe('init', () => {
     beforeAll(() => {

--- a/test/init/generator/init-inquirer.test.js
+++ b/test/init/generator/init-inquirer.test.js
@@ -9,7 +9,7 @@ const firstPrompt = 'Will your application have multiple bundles?';
 const ENTER = '\x0D';
 const genPath = path.join(__dirname, 'test-assets');
 
-jest.setTimeout(200000);
+jest.setTimeout(20000);
 
 describe('init', () => {
     beforeAll(() => {

--- a/test/loader/loader.test.js
+++ b/test/loader/loader.test.js
@@ -12,7 +12,7 @@ const loaderName = 'test-loader';
 const loaderPath = join(__dirname, loaderName);
 
 // Since scaffolding is time consuming
-jest.setTimeout(200000);
+jest.setTimeout(20000);
 
 describe('loader command', () => {
     beforeAll(() => {

--- a/test/migrate/config/migrate-config.test.js
+++ b/test/migrate/config/migrate-config.test.js
@@ -11,7 +11,7 @@ const outputPath = path.join(__dirname, outputDir);
 const outputFile = `${outputDir}/updated-webpack.config.js`;
 const outputFilePath = path.join(__dirname, outputFile);
 
-jest.setTimeout(200000);
+jest.setTimeout(20000);
 
 describe('migrate command', () => {
     beforeEach(() => {

--- a/test/migrate/config/migrate-config.test.js
+++ b/test/migrate/config/migrate-config.test.js
@@ -11,6 +11,8 @@ const outputPath = path.join(__dirname, outputDir);
 const outputFile = `${outputDir}/updated-webpack.config.js`;
 const outputFilePath = path.join(__dirname, outputFile);
 
+jest.setTimeout(200000);
+
 describe('migrate command', () => {
     beforeEach(() => {
         rimraf.sync(outputPath);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

tests

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

Yes

**If relevant, did you update the documentation?**

No

**Summary**

The latest run of the migrate tests seems to have timed out: https://github.com/webpack/webpack-cli/runs/622211039

We should have a longer timeout

**Does this PR introduce a breaking change?**

No

**Other information**
