### PR TITLE
tests: add case to ensure entry and output resolve path same way

### DIFF
--- a/test/entry/flag-entry/entry-with-flag.test.js
+++ b/test/entry/flag-entry/entry-with-flag.test.js
@@ -22,6 +22,23 @@ describe('entry flag', () => {
         });
     });
 
+    it('should resolve path src/a.js to ./src/a.js', (done) => {
+        const { stderr, stdout } = run(__dirname, ['--entry', 'src/a.js']);
+        expect(stderr).toBeFalsy();
+        expect(stdout).toBeTruthy();
+
+        stat(resolve(__dirname, './bin/main.js'), (err, stats) => {
+            expect(err).toBe(null);
+            expect(stats.isFile()).toBe(true);
+            done();
+        });
+        readFile(resolve(__dirname, './bin/main.js'), 'utf-8', (err, data) => {
+            expect(err).toBe(null);
+            expect(data).toContain('Hello from a.js');
+            done();
+        });
+    });
+
     it('should throw error for invalid entry file', () => {
         const { stderr, stdout } = run(__dirname, ['--entry', './src/test.js']);
         expect(stderr).toBeFalsy();

--- a/test/entry/flag-entry/entry-with-flag.test.js
+++ b/test/entry/flag-entry/entry-with-flag.test.js
@@ -22,7 +22,7 @@ describe('entry flag', () => {
         });
     });
 
-    it('should resolve path src/a.js to ./src/a.js', (done) => {
+    it('should resolve the path to src/a.js as ./src/a.js', (done) => {
         const { stderr, stdout } = run(__dirname, ['--entry', 'src/a.js']);
         expect(stderr).toBeFalsy();
         expect(stdout).toBeTruthy();

--- a/test/output/named-bundles/output-named-bundles.test.js
+++ b/test/output/named-bundles/output-named-bundles.test.js
@@ -23,7 +23,7 @@ describe('output flag named bundles', () => {
         expect(stats.isFile()).toBe(true);
     });
 
-    it('should resolve the path binary/a.bundle.js as ./binary/a.bundle.js', () => {
+    it('should resolve the path to binary/a.bundle.js as ./binary/a.bundle.js', () => {
         const { stderr } = run(__dirname, ['-c', resolve(__dirname, 'webpack.config.js'), '--output', 'binary/a.bundle.js'], false);
         expect(stderr).toBeFalsy();
 

--- a/test/output/named-bundles/output-named-bundles.test.js
+++ b/test/output/named-bundles/output-named-bundles.test.js
@@ -23,6 +23,14 @@ describe('output flag named bundles', () => {
         expect(stats.isFile()).toBe(true);
     });
 
+    it('should resolve the path binary/a.bundle.js as ./binary/a.bundle.js', () => {
+        const { stderr } = run(__dirname, ['-c', resolve(__dirname, 'webpack.config.js'), '--output', 'binary/a.bundle.js'], false);
+        expect(stderr).toBeFalsy();
+
+        const stats = statSync(resolve(__dirname, './binary/a.bundle.js'));
+        expect(stats.isFile()).toBe(true);
+    });
+
     it('should create multiple bundles with an overriding flag', () => {
         const { stderr } = run(
             __dirname,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Tests.

Refers #899 
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
Yes

**If relevant, did you update the documentation?**
NA

**Summary**

this ensures `entry` and `output` resolve the path the same way

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

NO

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
