### PR TITLE
feat(webpack-cli): allow multiple entry files

### DIFF
--- a/packages/webpack-cli/README.md
+++ b/packages/webpack-cli/README.md
@@ -35,7 +35,7 @@ Available Commands
 
 Options
 
-  --entry string           The entry point of your application.
+  --entry string[]         The entry point(s) of your application.
   -c, --config string      Provide path to a webpack configuration file
   -m, --merge string       Merge a configuration file using webpack-merge
   --progress               Print compilation progress during build

--- a/packages/webpack-cli/__tests__/arg-parser.test.js
+++ b/packages/webpack-cli/__tests__/arg-parser.test.js
@@ -51,6 +51,13 @@ const basicOptions = [
         },
         description: 'custom type flag',
     },
+    {
+        name: 'multi-flag',
+        usage: '--multi-flag <value>',
+        type: String,
+        multiple: true,
+        description: 'multi flag',
+    },
 ];
 
 const helpAndVersionOptions = basicOptions.slice(0);
@@ -163,6 +170,16 @@ describe('arg-parser', () => {
         expect(warnMock.mock.calls.length).toEqual(0);
     });
 
+    it('handles multiple same args', () => {
+        const res = argParser(basicOptions, ['--multi-flag', 'a.js', '--multi-flag', 'b.js'], true);
+        expect(res.unknownArgs.length).toEqual(0);
+        expect(res.opts).toEqual({
+            multiFlag: ['a.js', 'b.js'],
+            stringFlagWithDefault: 'default-value',
+        });
+        expect(warnMock.mock.calls.length).toEqual(0);
+    });
+
     it('handles additional node args from argv', () => {
         const res = argParser(basicOptions, ['node', 'index.js', '--bool-flag', '--string-flag', 'val'], false);
         expect(res.unknownArgs.length).toEqual(0);
@@ -210,7 +227,7 @@ describe('arg-parser', () => {
     it('parses webpack args', () => {
         const res = argParser(core, ['--entry', 'test.js', '--hot', '-o', './dist/'], true);
         expect(res.unknownArgs.length).toEqual(0);
-        expect(res.opts.entry).toEqual('test.js');
+        expect(res.opts.entry).toEqual(['test.js']);
         expect(res.opts.hot).toBeTruthy();
         expect(res.opts.output).toEqual('./dist/');
         expect(warnMock.mock.calls.length).toEqual(0);

--- a/packages/webpack-cli/lib/bootstrap.js
+++ b/packages/webpack-cli/lib/bootstrap.js
@@ -49,14 +49,21 @@ async function runCLI(cli, commandIsUsed) {
             // if the unknown arg starts with a '-', it will be considered
             // an unknown flag rather than an entry
             let entry;
-            if (parsedArgs.unknownArgs.length === 1 && !parsedArgs.unknownArgs[0].startsWith('-')) {
-                entry = parsedArgs.unknownArgs[0];
-            } else if (parsedArgs.unknownArgs.length > 0) {
-                parsedArgs.unknownArgs
-                    .filter((e) => e)
-                    .forEach((unknown) => {
-                        logger.warn('Unknown argument:', unknown);
+            if (parsedArgs.unknownArgs.length > 0 && !parsedArgs.unknownArgs[0].startsWith('-')) {
+                if (parsedArgs.unknownArgs.length === 1) {
+                    entry = parsedArgs.unknownArgs[0];
+                } else {
+                    entry = [];
+                    parsedArgs.unknownArgs.forEach((unknown) => {
+                        if (!unknown.startsWith('-')) {
+                            entry.push(unknown);
+                        }
                     });
+                }
+            } else if (parsedArgs.unknownArgs.length > 0) {
+                parsedArgs.unknownArgs.forEach((unknown) => {
+                    logger.warn('Unknown argument:', unknown);
+                });
                 cliExecuter();
                 return;
             }

--- a/packages/webpack-cli/lib/groups/BasicGroup.js
+++ b/packages/webpack-cli/lib/groups/BasicGroup.js
@@ -1,4 +1,5 @@
 const GroupHelper = require('../utils/GroupHelper');
+const chalk = require('chalk');
 const { core, groups } = require('../utils/cli-flags');
 
 class BasicGroup extends GroupHelper {
@@ -35,6 +36,9 @@ class BasicGroup extends GroupHelper {
             }
             if (arg === 'entry') {
                 options[arg] = this.resolveFilePath(args[arg], 'index.js');
+                if (options[arg].length === 0) {
+                    process.stdout.write(chalk.red('\nError: you provided an invalid entry point.\n'));
+                }
             }
         });
         if (outputOptions['dev']) {

--- a/packages/webpack-cli/lib/groups/BasicGroup.js
+++ b/packages/webpack-cli/lib/groups/BasicGroup.js
@@ -44,6 +44,7 @@ class BasicGroup extends GroupHelper {
 
     run() {
         this.resolveFlags();
+        console.log(this);
         return this.opts;
     }
 }

--- a/packages/webpack-cli/lib/groups/BasicGroup.js
+++ b/packages/webpack-cli/lib/groups/BasicGroup.js
@@ -48,7 +48,6 @@ class BasicGroup extends GroupHelper {
 
     run() {
         this.resolveFlags();
-        console.log(this);
         return this.opts;
     }
 }

--- a/packages/webpack-cli/lib/utils/arg-parser.js
+++ b/packages/webpack-cli/lib/utils/arg-parser.js
@@ -39,7 +39,12 @@ function argParser(options, args, argsOnly = false, name = '', helpFunction = un
         const flags = option.alias ? `-${option.alias}, --${option.name}` : `--${option.name}`;
         const flagsWithType = option.type !== Boolean ? flags + ' <value>' : flags;
         if (option.type === Boolean || option.type === String) {
-            parserInstance.option(flagsWithType, option.description, option.defaultValue);
+            if (option.multiple) {
+                parserInstance.option(flagsWithType, option.description, option.defaultValue);
+            } else {
+                const multiArg = (value, previous = []) => previous.concat([value]);
+                parserInstance.option(flagsWithType, option.description, multiArg, option.defaultValue);
+            }
         } else {
             // in this case the type is a parsing function
             parserInstance.option(flagsWithType, option.description, option.type, option.defaultValue);

--- a/packages/webpack-cli/lib/utils/arg-parser.js
+++ b/packages/webpack-cli/lib/utils/arg-parser.js
@@ -39,7 +39,7 @@ function argParser(options, args, argsOnly = false, name = '', helpFunction = un
         const flags = option.alias ? `-${option.alias}, --${option.name}` : `--${option.name}`;
         const flagsWithType = option.type !== Boolean ? flags + ' <value>' : flags;
         if (option.type === Boolean || option.type === String) {
-            if (option.multiple) {
+            if (!option.multiple) {
                 parserInstance.option(flagsWithType, option.description, option.defaultValue);
             } else {
                 const multiArg = (value, previous = []) => previous.concat([value]);

--- a/packages/webpack-cli/lib/utils/cli-flags.js
+++ b/packages/webpack-cli/lib/utils/cli-flags.js
@@ -72,12 +72,12 @@ module.exports = {
     core: [
         {
             name: 'entry',
-            usage: '--entry <path to entry file>',
+            usage: '--entry <path to entry file> | --entry <path> --entry <path>',
             type: String,
             multiple: true,
             defaultOption: true,
             group: BASIC_GROUP,
-            description: 'The entry point of your application e.g. ./src/main.js',
+            description: 'The entry point(s) of your application e.g. ./src/main.js',
             link: 'https://webpack.js.org/concepts/#entry',
         },
         {

--- a/packages/webpack-cli/lib/utils/cli-flags.js
+++ b/packages/webpack-cli/lib/utils/cli-flags.js
@@ -74,6 +74,7 @@ module.exports = {
             name: 'entry',
             usage: '--entry <path to entry file>',
             type: String,
+            multiple: true,
             defaultOption: true,
             group: BASIC_GROUP,
             description: 'The entry point of your application e.g. ./src/main.js',

--- a/test/entry/flag-entry/entry-with-flag.test.js
+++ b/test/entry/flag-entry/entry-with-flag.test.js
@@ -41,7 +41,7 @@ describe('entry flag', () => {
 
     it('should throw error for invalid entry file', () => {
         const { stderr, stdout } = run(__dirname, ['--entry', './src/test.js']);
-        expect(stderr).toBeFalsy();
+        expect(stderr).toBeTruthy();
         expect(stdout).toContain('Error: you provided an invalid entry point.');
     });
 });

--- a/test/entry/flag-entry/entry-with-flag.test.js
+++ b/test/entry/flag-entry/entry-with-flag.test.js
@@ -42,6 +42,6 @@ describe('entry flag', () => {
     it('should throw error for invalid entry file', () => {
         const { stderr, stdout } = run(__dirname, ['--entry', './src/test.js']);
         expect(stderr).toBeFalsy();
-        expect(stdout).toContain('not found');
+        expect(stdout).toContain('Error: you provided an invalid entry point.');
     });
 });

--- a/test/entry/multiple-entries/multi-entries.test.js
+++ b/test/entry/multiple-entries/multi-entries.test.js
@@ -4,9 +4,9 @@ const { run } = require('../../utils/test-utils');
 const { stat, readFile } = require('fs');
 const { resolve } = require('path');
 
-describe('entry flag', () => {
+describe(' multiple entries', () => {
     it('should allow multiple entry files', (done) => {
-        const { stderr, stdout } = run(__dirname, ['src/a.js', 'src/b.js', 'src/c.js']);
+        const { stderr, stdout } = run(__dirname, ['./src/a.js', './src/b.js', './src/c.js']);
         expect(stderr).toBeFalsy();
         expect(stdout).toBeTruthy();
 
@@ -20,6 +20,24 @@ describe('entry flag', () => {
             expect(data).toContain('Hello from a.js');
             expect(data).toContain('Hello from b.js');
             expect(data).toContain('Hello from c.js');
+            done();
+        });
+    });
+
+    it('should allow multiple entry flags', (done) => {
+        const { stderr, stdout } = run(__dirname, ['--entry', 'src/a.js', '--entry', 'src/b.js']);
+        expect(stderr).toBeFalsy();
+        expect(stdout).toBeTruthy();
+
+        stat(resolve(__dirname, './bin/main.js'), (err, stats) => {
+            expect(err).toBe(null);
+            expect(stats.isFile()).toBe(true);
+            done();
+        });
+        readFile(resolve(__dirname, './bin/main.js'), 'utf-8', (err, data) => {
+            expect(err).toBe(null);
+            expect(data).toContain('Hello from a.js');
+            expect(data).toContain('Hello from b.js');
             done();
         });
     });

--- a/test/entry/multiple-entries/multi-entries.test.js
+++ b/test/entry/multiple-entries/multi-entries.test.js
@@ -6,7 +6,7 @@ const { resolve } = require('path');
 
 describe(' multiple entries', () => {
     it('should allow multiple entry files', (done) => {
-        const { stderr, stdout } = run(__dirname, ['./src/a.js', './src/b.js', './src/c.js']);
+        const { stderr, stdout } = run(__dirname, ['./src/a.js', './src/b.js']);
         expect(stderr).toBeFalsy();
         expect(stdout).toBeTruthy();
 
@@ -19,7 +19,6 @@ describe(' multiple entries', () => {
             expect(err).toBe(null);
             expect(data).toContain('Hello from a.js');
             expect(data).toContain('Hello from b.js');
-            expect(data).toContain('Hello from c.js');
             done();
         });
     });

--- a/test/entry/multiple-entries/multi-entries.test.js
+++ b/test/entry/multiple-entries/multi-entries.test.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const { run } = require('../../utils/test-utils');
+const { stat, readFile } = require('fs');
+const { resolve } = require('path');
+
+describe('entry flag', () => {
+    it('should allow multiple entry files', (done) => {
+        const { stderr, stdout } = run(__dirname, ['src/a.js', 'src/b.js', 'src/c.js']);
+        expect(stderr).toBeFalsy();
+        expect(stdout).toBeTruthy();
+
+        stat(resolve(__dirname, './bin/main.js'), (err, stats) => {
+            expect(err).toBe(null);
+            expect(stats.isFile()).toBe(true);
+            done();
+        });
+        readFile(resolve(__dirname, './bin/main.js'), 'utf-8', (err, data) => {
+            expect(err).toBe(null);
+            expect(data).toContain('Hello from a.js');
+            expect(data).toContain('Hello from b.js');
+            expect(data).toContain('Hello from c.js');
+            done();
+        });
+    });
+});

--- a/test/entry/multiple-entries/src/a.js
+++ b/test/entry/multiple-entries/src/a.js
@@ -1,0 +1,1 @@
+console.log('Hello from a.js');

--- a/test/entry/multiple-entries/src/b.js
+++ b/test/entry/multiple-entries/src/b.js
@@ -1,0 +1,1 @@
+console.log('Hello from b.js');

--- a/test/entry/multiple-entries/src/c.js
+++ b/test/entry/multiple-entries/src/c.js
@@ -1,0 +1,1 @@
+console.log('Hello from c.js');

--- a/test/init/auto/init-auto.test.js
+++ b/test/init/auto/init-auto.test.js
@@ -8,7 +8,6 @@ const { run } = require('../../utils/test-utils');
 const firstPrompt = 'Will your application have multiple bundles?';
 const genPath = join(__dirname, 'test-assets');
 
-jest.setTimeout(60000);
 describe('init auto flag', () => {
     beforeAll(() => {
         rimraf.sync(genPath);

--- a/test/init/force/init-force.test.js
+++ b/test/init/force/init-force.test.js
@@ -9,8 +9,6 @@ const firstPrompt = 'Will your application have multiple bundles?';
 const ENTER = '\x0D';
 const genPath = join(__dirname, 'test-assets');
 
-jest.setTimeout(100000);
-
 describe('init force flag', () => {
     beforeAll(() => {
         rimraf.sync(genPath);

--- a/test/init/generator/init-inquirer.test.js
+++ b/test/init/generator/init-inquirer.test.js
@@ -9,8 +9,6 @@ const firstPrompt = 'Will your application have multiple bundles?';
 const ENTER = '\x0D';
 const genPath = join(__dirname, 'test-assets');
 
-jest.setTimeout(100000);
-
 describe('init', () => {
     beforeAll(() => {
         rimraf.sync(genPath);

--- a/test/init/multipleEntries/init-multipleEntries.test.js
+++ b/test/init/multipleEntries/init-multipleEntries.test.js
@@ -9,8 +9,6 @@ const firstPrompt = 'Will your application have multiple bundles?';
 const ENTER = '\x0D';
 const genPath = path.join(__dirname, 'test-assets');
 
-jest.setTimeout(100000);
-
 describe('init with multiple entries', () => {
     beforeAll(() => {
         rimraf.sync(genPath);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Feature
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
YES
**If relevant, did you update the documentation?**
YES
**Summary**
Now we can provide multiple entry files via CLI using  -
- `webpack --entry=a.js --entry=b.js` 
- `webpack ./a.js ./b.js`

Refers #717
Fixes #1454 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
