### PR TITLE
feat(webpack-cli): allow multiple types for --stats

### DIFF
--- a/packages/webpack-cli/__tests__/arg-parser.test.js
+++ b/packages/webpack-cli/__tests__/arg-parser.test.js
@@ -44,6 +44,12 @@ const basicOptions = [
         defaultValue: 'default-value',
     },
     {
+        name: 'multi-type',
+        usage: '--multi-type | --multi-type <value>',
+        type: [String, Boolean],
+        description: 'flag with multiple types',
+    },
+    {
         name: 'custom-type-flag',
         usage: '--custom-type-flag <value>',
         type: (val) => {
@@ -122,6 +128,26 @@ describe('arg-parser', () => {
         expect(res.unknownArgs.length).toEqual(0);
         expect(res.opts).toEqual({
             specificBool: false,
+            stringFlagWithDefault: 'default-value',
+        });
+        expect(warnMock.mock.calls.length).toEqual(0);
+    });
+
+    it('parses multi type flag as Boolean', () => {
+        const res = argParser(basicOptions, ['--multi-type'], true);
+        expect(res.unknownArgs.length).toEqual(0);
+        expect(res.opts).toEqual({
+            multiType: true,
+            stringFlagWithDefault: 'default-value',
+        });
+        expect(warnMock.mock.calls.length).toEqual(0);
+    });
+
+    it('parses multi type flag as String', () => {
+        const res = argParser(basicOptions, ['--multi-type', 'value'], true);
+        expect(res.unknownArgs.length).toEqual(0);
+        expect(res.opts).toEqual({
+            multiType: 'value',
             stringFlagWithDefault: 'default-value',
         });
         expect(warnMock.mock.calls.length).toEqual(0);
@@ -225,11 +251,12 @@ describe('arg-parser', () => {
     });
 
     it('parses webpack args', () => {
-        const res = argParser(core, ['--entry', 'test.js', '--hot', '-o', './dist/'], true);
+        const res = argParser(core, ['--entry', 'test.js', '--hot', '-o', './dist/', '--stats'], true);
         expect(res.unknownArgs.length).toEqual(0);
         expect(res.opts.entry).toEqual(['test.js']);
         expect(res.opts.hot).toBeTruthy();
         expect(res.opts.output).toEqual('./dist/');
+        expect(res.opts.stats).toEqual(true);
         expect(warnMock.mock.calls.length).toEqual(0);
     });
 });

--- a/packages/webpack-cli/lib/groups/HelpGroup.js
+++ b/packages/webpack-cli/lib/groups/HelpGroup.js
@@ -108,7 +108,10 @@ class HelpGroup {
             },
             {
                 header: 'Options',
-                optionList: options.core,
+                optionList: options.core.map((e) => {
+                    if (e.type.length > 1) e.type = e.type[0];
+                    return e;
+                }),
             },
         ]);
         return {

--- a/packages/webpack-cli/lib/groups/StatsGroup.js
+++ b/packages/webpack-cli/lib/groups/StatsGroup.js
@@ -5,7 +5,7 @@ const logger = require('../utils/logger');
  */
 class StatsGroup extends GroupHelper {
     static validOptions() {
-        return ['none', 'errors-only', 'minimal', 'normal', 'detailed', 'verbose', 'errors-warnings'];
+        return ['none', 'errors-only', 'minimal', 'normal', 'detailed', 'verbose', 'errors-warnings', true];
     }
 
     constructor(options) {

--- a/packages/webpack-cli/lib/utils/arg-parser.js
+++ b/packages/webpack-cli/lib/utils/arg-parser.js
@@ -37,7 +37,7 @@ function argParser(options, args, argsOnly = false, name = '', helpFunction = un
     // Register options on the parser
     options.reduce((parserInstance, option) => {
         const flags = option.alias ? `-${option.alias}, --${option.name}` : `--${option.name}`;
-        const flagsWithType = option.type !== Boolean ? flags + ' <value>' : flags;
+        let flagsWithType = option.type !== Boolean ? flags + ' <value>' : flags;
         if (option.type === Boolean || option.type === String) {
             if (!option.multiple) {
                 parserInstance.option(flagsWithType, option.description, option.defaultValue);
@@ -47,7 +47,12 @@ function argParser(options, args, argsOnly = false, name = '', helpFunction = un
             }
         } else {
             // in this case the type is a parsing function
-            parserInstance.option(flagsWithType, option.description, option.type, option.defaultValue);
+            if (option.type.length > 1) {
+                flagsWithType = flags + ' [value]';
+                parserInstance.option(flagsWithType, option.description, option.type[0], option.defaultValue);
+            } else {
+                parserInstance.option(flagsWithType, option.description, option.type, option.defaultValue);
+            }
         }
 
         return parserInstance;

--- a/packages/webpack-cli/lib/utils/cli-flags.js
+++ b/packages/webpack-cli/lib/utils/cli-flags.js
@@ -240,7 +240,7 @@ module.exports = {
         {
             name: 'stats',
             usage: '--stats <value>',
-            type: String,
+            type: [String, Boolean],
             group: DISPLAY_GROUP,
             description: 'It instructs webpack on how to treat the stats e.g. verbose',
             link: 'https://webpack.js.org/configuration/stats/#stats',

--- a/test/stats/stats.test.js
+++ b/test/stats/stats.test.js
@@ -1,48 +1,32 @@
 'use strict';
 // eslint-disable-next-line node/no-unpublished-require
 const { run } = require('../utils/test-utils');
+// eslint-disable-next-line node/no-extraneous-require
+const { version } = require('webpack');
+
+const presets = ['normal', 'detailed', 'errors-only', 'errors-warnings', 'minimal', 'verbose', 'none'];
 
 describe('stats flag', () => {
-    it('should accept stats "none"', () => {
-        const { stderr, stdout } = run(__dirname, ['--stats', 'none']);
-        expect(stderr).toBeFalsy();
-        expect(stdout).toBeFalsy();
-    });
+    for (const preset of presets) {
+        it(`should accept --stats "${preset}"`, () => {
+            const { stderr, stdout } = run(__dirname, ['--stats', `${preset}`]);
+            expect(stderr).toBeFalsy();
+            if (version.startsWith('5')) {
+                expect(stdout).toContain(`stats: { preset: '${preset}' }`);
+            } else {
+                expect(stdout).toContain(`stats: '${preset}'`);
+            }
+        });
+    }
 
-    it('should accept stats "errors-only"', () => {
-        const { stderr, stdout } = run(__dirname, ['--stats', 'errors-only']);
+    it('should accept stats as boolean', () => {
+        const { stderr, stdout } = run(__dirname, ['--stats']);
         expect(stderr).toBeFalsy();
-        expect(stdout).toBeFalsy();
-    });
-
-    it('should accept stats "errors-warnings"', () => {
-        const { stderr, stdout } = run(__dirname, ['--stats', 'errors-warnings']);
-        expect(stderr).toBeFalsy();
-        expect(stdout).toBeFalsy();
-    });
-
-    it('should accept stats "normal"', () => {
-        const { stderr, stdout } = run(__dirname, ['--stats', 'normal']);
-        expect(stderr).toBeFalsy();
-        expect(stdout).toBeTruthy();
-    });
-
-    it('should accept stats "verbose"', () => {
-        const { stderr, stdout } = run(__dirname, ['--stats', 'verbose']);
-        expect(stderr).toBeFalsy();
-        expect(stdout).toBeTruthy();
-    });
-
-    it('should accept stats "minimal"', () => {
-        const { stderr, stdout } = run(__dirname, ['--stats', 'minimal']);
-        expect(stderr).toBeFalsy();
-        expect(stdout).toBeTruthy();
-    });
-
-    it('should accept stats "detailed"', () => {
-        const { stderr, stdout } = run(__dirname, ['--stats', 'detailed']);
-        expect(stderr).toBeFalsy();
-        expect(stdout).toBeTruthy();
+        if (version.startsWith('5')) {
+            expect(stdout).toContain(`stats: {}`);
+        } else {
+            expect(stdout).toContain('stats: true');
+        }
     });
 
     it('should warn when --verbose & --stats are passed together', () => {

--- a/test/stats/webpack.config.js
+++ b/test/stats/webpack.config.js
@@ -1,4 +1,8 @@
+// eslint-disable-next-line node/no-unpublished-require
+const WebpackCLITestPlugin = require('../utils/webpack-cli-test-plugin');
+
 module.exports = {
     mode: 'development',
     entry: './index.js',
+    plugins: [new WebpackCLITestPlugin()],
 };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Feature.
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
WIP
**If relevant, did you update the documentation?**
WIP
**Summary**
Refers #717 

Allow multiple types for stats argument, i.e.
`webpack --stats (means stats: true)`,
`webpack --stats=verbose (means: stats: verbose)`

![Screenshot at 2020-06-10 09-18-27](https://user-images.githubusercontent.com/46647141/84225124-01fc1680-aafc-11ea-89ba-ea422536d125.png)

![Screenshot at 2020-06-10 09-18-52](https://user-images.githubusercontent.com/46647141/84225153-10e2c900-aafc-11ea-8ce7-f2eb1df719be.png)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
