### PR TITLE
chore: upgrades typescript to the latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "readable-stream": "^3.6.0",
     "rimraf": "^3.0.2",
     "ts-jest": "^25.3.0",
-    "typescript": "^3.8.3",
+    "typescript": "^3.9.5",
     "webpack": "^4.42.0",
     "yeoman-test": "^2.3.0"
   }

--- a/packages/utils/src/modify-config-helper.ts
+++ b/packages/utils/src/modify-config-helper.ts
@@ -133,13 +133,13 @@ export function modifyHelperUtil(
                 process.exitCode = -1;
             }
 
-            const transformConfig: TransformConfig = Object.assign(
+            const transformConfig = Object.assign(
                 {
                     configFile: !configPath ? null : fs.readFileSync(configPath, 'utf8'),
                     configPath,
                 },
                 finalConfig,
-            );
+            ) as TransformConfig;
             if (finalConfig.usingDefaults && finalConfig.usingDefaults === true) {
                 const runCommand = getPackageManager() === 'yarn' ? 'yarn build' : 'npm run build';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11506,10 +11506,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
+typescript@^3.9.5:
+  version "3.9.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.5.tgz#586f0dba300cde8be52dd1ac4f7e1009c1b13f36"
+  integrity sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==
 
 typical@^5.0.0, typical@^5.2.0:
   version "5.2.0"


### PR DESCRIPTION
With this PR I aim to upgrade typescript to the latest. 

Testing notes:
- All linters passed ✅
- All builds passed ✅
- Unit tests 9 failed, but believe this to be a windows issue. 
![image](https://user-images.githubusercontent.com/599459/84835242-83145a00-b076-11ea-8579-6e5af826e85d.png)
- There was only 1 code change required, and was due to a fundamental type mismatch. I've noted that in the [line-comment](https://github.com/webpack/webpack-cli/pull/1636/files#r441183817). 


fixes #1617