### PR TITLE
feat: show up cli flag aliases with webpack help <arg>

### DIFF
--- a/packages/webpack-cli/lib/groups/HelpGroup.js
+++ b/packages/webpack-cli/lib/groups/HelpGroup.js
@@ -16,7 +16,8 @@ class HelpGroup {
 
             const { bold, underline } = chalk.white;
             const header = (head) => bold(underline(head));
-            const usage = chalk.keyword('orange')('webpack ' + options.usage);
+            const flagAlias = options.alias ? (isCommand ? `${options.alias} |` : `-${options.alias},`) : '';
+            const usage = chalk.keyword('orange')(`webpack ${flagAlias} ${options.usage}`);
             const description = options.description;
             const link = options.link;
 

--- a/packages/webpack-cli/lib/groups/HelpGroup.js
+++ b/packages/webpack-cli/lib/groups/HelpGroup.js
@@ -16,8 +16,8 @@ class HelpGroup {
 
             const { bold, underline } = chalk.white;
             const header = (head) => bold(underline(head));
-            const flagAlias = options.alias ? (isCommand ? `${options.alias} |` : `-${options.alias},`) : '';
-            const usage = chalk.keyword('orange')(`webpack ${flagAlias} ${options.usage}`);
+            const flagAlias = options.alias ? (isCommand ? ` ${options.alias} |` : ` -${options.alias},`) : '';
+            const usage = chalk.keyword('orange')(`webpack${flagAlias} ${options.usage}`);
             const description = options.description;
             const link = options.link;
 

--- a/packages/webpack-cli/lib/utils/cli-flags.js
+++ b/packages/webpack-cli/lib/utils/cli-flags.js
@@ -21,7 +21,7 @@ module.exports = {
             name: 'init',
             alias: 'c',
             type: String,
-            usage: 'init | init <scaffold>',
+            usage: 'init [scaffold]',
             description: 'Initialize a new webpack configuration',
         },
         {

--- a/test/help/help-commands.test.js
+++ b/test/help/help-commands.test.js
@@ -17,7 +17,7 @@ describe('commands help', () => {
     it('gives precedence to earlier command in case of multiple commands', () => {
         const { stdout, stderr } = run(__dirname, ['--help', 'init', 'info'], false);
         expect(stdout).not.toContain(helpHeader);
-        expect(stdout).toContain('webpack init | init <scaffold>');
+        expect(stdout).toContain('webpack c | init [scaffold]');
         expect(stderr).toHaveLength(0);
     });
 });

--- a/test/help/help-flags.test.js
+++ b/test/help/help-flags.test.js
@@ -17,7 +17,7 @@ describe('commands help', () => {
     it('shows flag help with valid flag', () => {
         const { stdout, stderr } = run(__dirname, ['--help', '--merge'], false);
         expect(stdout).not.toContain(helpHeader);
-        expect(stdout).toContain('webpack --merge <path to configuration to be merged>');
+        expect(stdout).toContain('webpack -m, --merge <path to configuration to be merged>');
         expect(stderr).toHaveLength(0);
     });
 

--- a/test/help/help-multi-args.test.js
+++ b/test/help/help-multi-args.test.js
@@ -19,7 +19,7 @@ describe('help cmd with multiple arguments', () => {
     it('should output help for --version by taking precedence', () => {
         const { stdout, stderr } = run(__dirname, ['--help', '--version'], false);
         expect(stdout).not.toContain(helpHeader);
-        expect(stdout).toContain('webpack --version');
+        expect(stdout).toContain('webpack -v, --version');
         expect(stderr).toHaveLength(0);
     });
 });

--- a/test/info/info-help.test.js
+++ b/test/info/info-help.test.js
@@ -11,7 +11,7 @@ const runInfo = (args) => {
 
 const infoFlags = commands.find((c) => c.name === 'info').flags;
 
-const usageText = 'webpack info [options]';
+const usageText = 'webpack i | info [options]';
 const descriptionText = 'Outputs information about your system and dependencies';
 
 describe('should print help for info command', () => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
enhancement
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
Updated existing tests.

**If relevant, did you update the documentation?**
Nope

**Summary**
Help information for individual `cli-flags` shows up the corresponding alias if it exists.
<img width="601" alt="Screenshot 2020-06-24 at 1 43 28 PM" src="https://user-images.githubusercontent.com/25279263/85520564-b62f8e00-b620-11ea-81cf-ad6005b5a1e7.png">

<img width="884" alt="Screenshot 2020-06-24 at 1 45 01 PM" src="https://user-images.githubusercontent.com/25279263/85520722-ec6d0d80-b620-11ea-93c8-8564e9ddbb39.png">

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
Nope
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
N/A