### PR TITLE
fix: show version information for plugin and loader subcommands

### DIFF
--- a/packages/webpack-cli/lib/groups/HelpGroup.js
+++ b/packages/webpack-cli/lib/groups/HelpGroup.js
@@ -1,5 +1,6 @@
 const chalk = require('chalk');
 const { core, commands } = require('../utils/cli-flags');
+const { defaultCommands } = require('../utils/commands');
 const commandLineUsage = require('command-line-usage');
 
 class HelpGroup {
@@ -49,7 +50,7 @@ class HelpGroup {
         if (externalPkg && commandsUsed.length === 1 && invalidArgs.length === 0) {
             try {
                 if (commandsUsed.includes(externalPkg.name)) {
-                    const { name, version } = require(`@webpack-cli/${externalPkg.name}/package.json`);
+                    const { name, version } = require(`@webpack-cli/${defaultCommands[externalPkg.name]}/package.json`);
                     process.stdout.write(`\n${name} ${version}`);
                 } else {
                     const { name, version } = require(`${externalPkg.name}/package.json`);

--- a/packages/webpack-cli/lib/utils/arg-parser.js
+++ b/packages/webpack-cli/lib/utils/arg-parser.js
@@ -1,14 +1,7 @@
 const commander = require('commander');
 const logger = require('./logger');
 
-const defaultCommands = {
-    init: 'init',
-    loader: 'generate-loader',
-    plugin: 'generate-plugin',
-    info: 'info',
-    migrate: 'migrate',
-    serve: 'serve',
-};
+const { defaultCommands } = require('./commands');
 
 /**
  *  Creates Argument parser corresponding to the supplied options

--- a/packages/webpack-cli/lib/utils/commands.js
+++ b/packages/webpack-cli/lib/utils/commands.js
@@ -1,5 +1,14 @@
 const { commands } = require('./cli-flags');
 
+const defaultCommands = {
+    init: 'init',
+    loader: 'generate-loader',
+    plugin: 'generate-plugin',
+    info: 'info',
+    migrate: 'migrate',
+    serve: 'serve',
+};
+
 // Contains an array of strings with commands and their aliases that the cli supports
 const names = commands
     .map(({ alias, name }) => {
@@ -10,4 +19,7 @@ const names = commands
     })
     .reduce((arr, val) => arr.concat(val), []);
 
-module.exports = { names };
+module.exports = {
+    defaultCommands,
+    names,
+};

--- a/test/version/version-external-packages.test.js
+++ b/test/version/version-external-packages.test.js
@@ -5,6 +5,8 @@ const initPkgJSON = require('../../packages/init/package.json');
 const servePkgJSON = require('../../packages/serve/package.json');
 const migratePkgJSON = require('../../packages/migrate/package.json');
 const infoPkgJSON = require('../../packages/info/package.json');
+const pluginPkgJSON = require('../../packages/generate-plugin/package.json');
+const loaderPkgJSON = require('../../packages/generate-loader/package.json');
 const cliPkgJSON = require('../../packages/webpack-cli/package.json');
 
 describe('version flag with external packages', () => {
@@ -32,6 +34,20 @@ describe('version flag with external packages', () => {
     it('outputs version with migrate', () => {
         const { stdout, stderr } = run(__dirname, ['migrate', '--version'], false);
         expect(stdout).toContain(migratePkgJSON.version);
+        expect(stdout).toContain(cliPkgJSON.version);
+        expect(stderr).toHaveLength(0);
+    });
+
+    it('outputs version with plugin', () => {
+        const { stdout, stderr } = run(__dirname, ['plugin', '--version'], false);
+        expect(stdout).toContain(pluginPkgJSON.version);
+        expect(stdout).toContain(cliPkgJSON.version);
+        expect(stderr).toHaveLength(0);
+    });
+
+    it('outputs version with loader', () => {
+        const { stdout, stderr } = run(__dirname, ['loader', '--version'], false);
+        expect(stdout).toContain(loaderPkgJSON.version);
         expect(stdout).toContain(cliPkgJSON.version);
         expect(stderr).toHaveLength(0);
     });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
bugfix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
yup

**If relevant, did you update the documentation?**
Nope

**Summary**
`webpack-cli plugin | loader --version` shows up the respective information.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
Nope
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
N/A