### PR TITLE
feat: support command aliases with webpack-cli version

### DIFF
--- a/packages/webpack-cli/lib/groups/HelpGroup.js
+++ b/packages/webpack-cli/lib/groups/HelpGroup.js
@@ -49,7 +49,7 @@ class HelpGroup {
     outputVersion(externalPkg, commandsUsed, invalidArgs) {
         if (externalPkg && commandsUsed.length === 1 && invalidArgs.length === 0) {
             try {
-                if (commandsUsed.includes(externalPkg.name)) {
+                if ([externalPkg.alias, externalPkg.name].some((pkg) => commandsUsed.includes(pkg))) {
                     const { name, version } = require(`@webpack-cli/${defaultCommands[externalPkg.name]}/package.json`);
                     process.stdout.write(`\n${name} ${version}`);
                 } else {

--- a/test/version/version-external-packages.test.js
+++ b/test/version/version-external-packages.test.js
@@ -17,6 +17,13 @@ describe('version flag with external packages', () => {
         expect(stderr).toHaveLength(0);
     });
 
+    it('outputs version with the alias c for init', () => {
+        const { stdout, stderr } = run(__dirname, ['c', '--version'], false);
+        expect(stdout).toContain(initPkgJSON.version);
+        expect(stdout).toContain(cliPkgJSON.version);
+        expect(stderr).toHaveLength(0);
+    });
+
     it('outputs version with info', () => {
         const { stdout, stderr } = run(__dirname, ['info', '--version'], false);
         expect(stdout).toContain(infoPkgJSON.version);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
enhancement
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
Yup

**If relevant, did you update the documentation?**
N/A

**Summary**
Support command aliases with `webpack-cli version`

```bash
webpack-cli c version

@webpack-cli/init 1.0.1-alpha.5
webpack-cli 4.0.0-beta.8
webpack 4.43.0
```
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
Nope
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
N/A