### PR TITLE
chore: handle unknown args and improve test suite for info

### DIFF
--- a/packages/info/src/index.ts
+++ b/packages/info/src/index.ts
@@ -36,10 +36,10 @@ export default async function info(...args): Promise<string[]> {
     const infoArgs = parsedArgs.opts;
     const envinfoConfig = {};
 
-    const unknownArgs = parsedArgs.unknownArgs.filter((arg) => !['help', 'version'].includes(arg));
+    if (parsedArgs.unknownArgs.some((arg) => ['help', 'version', 'color'].includes(arg))) return;
 
-    if (unknownArgs.length > 0) {
-        process.stderr.write(`Unknown argument: ${chalk.red(unknownArgs)}\n`);
+    if (parsedArgs.unknownArgs.length > 0) {
+        process.stderr.write(`Unknown argument: ${chalk.red(parsedArgs.unknownArgs)}\n`);
     }
 
     if (infoArgs.output) {

--- a/packages/info/src/index.ts
+++ b/packages/info/src/index.ts
@@ -32,11 +32,12 @@ const DEFAULT_DETAILS: Information = {
 
 export default async function info(...args): Promise<string[]> {
     const cli = new WebpackCLI();
-    const infoArgs = cli.argParser(options, args, true).opts;
+    const parsedArgs = cli.argParser(options, args, true);
+    const infoArgs = parsedArgs.opts;
     const envinfoConfig = {};
 
-    if (infoArgs._unknown && infoArgs._unknown.length > 0) {
-        process.stderr.write(`Unknown option: ${chalk.red(infoArgs._unknown)}\n`);
+    if (parsedArgs.unknownArgs && parsedArgs.unknownArgs.length > 0) {
+        process.stderr.write(`Unknown argument: ${chalk.red(parsedArgs.unknownArgs)}\n`);
     }
 
     if (infoArgs.output) {

--- a/packages/info/src/index.ts
+++ b/packages/info/src/index.ts
@@ -36,8 +36,10 @@ export default async function info(...args): Promise<string[]> {
     const infoArgs = parsedArgs.opts;
     const envinfoConfig = {};
 
-    if (parsedArgs.unknownArgs && parsedArgs.unknownArgs.length > 0) {
-        process.stderr.write(`Unknown argument: ${chalk.red(parsedArgs.unknownArgs)}\n`);
+    const unknownArgs = parsedArgs.unknownArgs.filter((arg) => !['help', 'version'].includes(arg));
+
+    if (unknownArgs.length > 0) {
+        process.stderr.write(`Unknown argument: ${chalk.red(unknownArgs)}\n`);
     }
 
     if (infoArgs.output) {

--- a/test/info/info-help.test.js
+++ b/test/info/info-help.test.js
@@ -1,13 +1,8 @@
 'use strict';
 
 const chalk = require('chalk');
-const path = require('path');
-const { run } = require('../utils/test-utils');
+const { runInfo } = require('../utils/test-utils');
 const { commands } = require('../../packages/webpack-cli/lib/utils/cli-flags');
-
-const runInfo = (args) => {
-    return run(path.resolve(__dirname), args, false);
-};
 
 const infoFlags = commands.find((c) => c.name === 'info').flags;
 
@@ -15,22 +10,15 @@ const usageText = 'webpack i | info [options]';
 const descriptionText = 'Outputs information about your system and dependencies';
 
 describe('should print help for info command', () => {
-    it('help flag supplied after info', () => {
-        const { stdout, stderr } = runInfo(['info', 'help']);
-        expect(stdout).toContain(usageText);
-        expect(stdout).toContain(descriptionText);
-        expect(stderr).toHaveLength(0);
-    });
-
-    it('dashed help flag supplied before info', () => {
-        const { stdout, stderr } = runInfo(['--help', 'info']);
+    it('shows usage information on supplying help flag', () => {
+        const { stdout, stderr } = runInfo(['help'], __dirname);
         expect(stdout).toContain(usageText);
         expect(stdout).toContain(descriptionText);
         expect(stderr).toHaveLength(0);
     });
 
     it('should respect the --color=false flag', () => {
-        const { stdout, stderr } = runInfo(['info', 'help', '--color=false']);
+        const { stdout, stderr } = runInfo(['help', '--color=false'], __dirname);
         chalk.enabled = true;
         chalk.level = 3;
         const orange = chalk.keyword('orange');
@@ -40,7 +28,7 @@ describe('should print help for info command', () => {
     });
 
     it('should output all cli flags', () => {
-        const { stdout, stderr } = runInfo(['info', 'help']);
+        const { stdout, stderr } = runInfo(['help'], __dirname);
         infoFlags.forEach((flag) => expect(stdout).toContain(`--${flag.name}`));
         expect(stderr).toHaveLength(0);
     });

--- a/test/info/info-output.test.js
+++ b/test/info/info-output.test.js
@@ -1,16 +1,11 @@
 /* eslint-disable space-before-function-paren */
 'use strict';
 
-const path = require('path');
-const { run } = require('../utils/test-utils');
-
-const runInfo = (args) => {
-    return run(path.resolve(__dirname), ['info'].concat(args), false);
-};
+const { runInfo } = require('../utils/test-utils');
 
 describe('basic info usage', () => {
-    it('gets info without flags', async () => {
-        const { stdout, stderr } = await runInfo([]);
+    it('gets info without flags', () => {
+        const { stdout, stderr } = runInfo([], __dirname);
         // stdout should include many details which will be
         // unique for each computer
         expect(stdout).toContain('System:');
@@ -20,8 +15,8 @@ describe('basic info usage', () => {
         expect(stderr).toHaveLength(0);
     });
 
-    it('gets info as json', async () => {
-        const { stdout, stderr } = await runInfo(['--output="json"']);
+    it('gets info as json', () => {
+        const { stdout, stderr } = runInfo(['--output="json"'], __dirname);
         expect(stdout).toContain('"System":');
         expect(stderr).toHaveLength(0);
 
@@ -36,8 +31,8 @@ describe('basic info usage', () => {
         expect(parse).not.toThrow();
     });
 
-    it('gets info as markdown', async () => {
-        const { stdout, stderr } = await runInfo(['--output="markdown"']);
+    it('gets info as markdown', () => {
+        const { stdout, stderr } = runInfo(['--output="markdown"'], __dirname);
         expect(stdout).toContain('## System:');
         expect(stderr).toHaveLength(0);
     });

--- a/test/info/info-unknown.test.js
+++ b/test/info/info-unknown.test.js
@@ -1,0 +1,8 @@
+const { runInfo } = require('../utils/test-utils');
+
+describe('should handle unknown args', () => {
+    it('shows an appropriate warning on supplying unknown args', () => {
+        const { stderr } = runInfo(['--unknown'], __dirname);
+        expect(stderr).toContain('Unknown argument: --unknown');
+    });
+});

--- a/test/utils/test-utils.js
+++ b/test/utils/test-utils.js
@@ -248,6 +248,10 @@ const runServe = (args, testPath) => {
     });
 };
 
+const runInfo = (args, testPath) => {
+    return run(testPath, ['info'].concat(args), false);
+};
+
 module.exports = {
     run,
     runWatch,
@@ -258,4 +262,5 @@ module.exports = {
     copyFile,
     copyFileAsync,
     runInstall,
+    runInfo,
 };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
enhancement
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
Yes

**If relevant, did you update the documentation?**
N/A

**Summary**
- The existing strategy for handling unknown args with `webpack-cli info` didn't work as expected. Fixed it!
- A new helper method `runInfo()` to be consumed across test suites.
```bash
$ webpack-cli info --unknown

Unknown argument: --unknown

  System:
    OS: macOS 10.15.5
    CPU: (8) x64 Intel(R) Core(TM) i5-8279U CPU @ 2.40GHz
    Memory: 131.43 MB / 8.00 GB
  Binaries:
    Node: 13.11.0 - /usr/local/bin/node
    Yarn: 1.22.4 - /usr/local/bin/yarn
    npm: 6.14.6 - /usr/local/bin/npm
  Browsers:
    Brave Browser: 83.1.10.97
    Safari: 13.1.1
  Packages:
    webpack: ^4.43.0 => 4.43.0
  Global Packages:
    webpack-cli: 4.0.0-beta.8
```
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
Nope
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
N/A