### PR TITLE
feat: improve parsing of multiple same flags

### DIFF
--- a/packages/webpack-cli/__tests__/arg-parser.test.js
+++ b/packages/webpack-cli/__tests__/arg-parser.test.js
@@ -196,6 +196,16 @@ describe('arg-parser', () => {
         expect(warnMock.mock.calls.length).toEqual(0);
     });
 
+    it('handles multiple args with space separated values i.e, --multi-flag a.js b.js', () => {
+        const res = argParser(basicOptions, ['--multi-flag', 'a.js', 'b.js'], true);
+        expect(res.unknownArgs.length).toEqual(0);
+        expect(res.opts).toEqual({
+            multiFlag: ['a.js', 'b.js'],
+            stringFlagWithDefault: 'default-value',
+        });
+        expect(warnMock.mock.calls.length).toEqual(0);
+    });
+
     it('handles additional node args from argv', () => {
         const res = argParser(basicOptions, ['node', 'index.js', '--bool-flag', '--string-flag', 'val'], false);
         expect(res.unknownArgs.length).toEqual(0);

--- a/packages/webpack-cli/lib/utils/arg-parser.js
+++ b/packages/webpack-cli/lib/utils/arg-parser.js
@@ -61,13 +61,11 @@ function argParser(options, args, argsOnly = false, name = '', helpFunction = un
         const flags = option.alias ? `-${option.alias}, --${option.name}` : `--${option.name}`;
         let flagsWithType = option.type !== Boolean ? flags + ' <value>' : flags;
         if (option.type === Boolean || option.type === String) {
-            if (!option.multiple) {
-                // Prevent default behavior for standalone options
-                parserInstance.option(flagsWithType, option.description, option.defaultValue).action(() => {});
-            } else {
-                const multiArg = (value, previous = []) => previous.concat([value]);
-                parserInstance.option(flagsWithType, option.description, multiArg, option.defaultValue).action(() => {});
+            if (option.multiple) {
+                flagsWithType = flags + ' <value...>';
             }
+            // Prevent default behavior for standalone options
+            parserInstance.option(flagsWithType, option.description, option.defaultValue).action(() => {});
         } else if (option.type === Number) {
             parserInstance.option(flagsWithType, option.description, Number, option.defaultValue);
         } else {

--- a/test/entry/multiple-entries/multi-entries.test.js
+++ b/test/entry/multiple-entries/multi-entries.test.js
@@ -40,4 +40,22 @@ describe(' multiple entries', () => {
             done();
         });
     });
+
+    it('should allow multiple space separeted entries', (done) => {
+        const { stderr, stdout } = run(__dirname, ['--entry', 'src/a.js', 'src/b.js']);
+        expect(stderr).toBeFalsy();
+        expect(stdout).toBeTruthy();
+
+        stat(resolve(__dirname, './bin/main.js'), (err, stats) => {
+            expect(err).toBe(null);
+            expect(stats.isFile()).toBe(true);
+            done();
+        });
+        readFile(resolve(__dirname, './bin/main.js'), 'utf-8', (err, data) => {
+            expect(err).toBe(null);
+            expect(data).toContain('Hello from a.js');
+            expect(data).toContain('Hello from b.js');
+            done();
+        });
+    });
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Feature
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
Yes
**If relevant, did you update the documentation?**
no
**Summary**
Now we support multiple space-separated values for flags. i.e, `webpack --multiple value1 value2`, Old syntax is also valid i.e, `webpack --multiple value1 --multiple value2`
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
