### PR TITLE
chore: bump interpret for .mjs support

### DIFF
--- a/packages/webpack-cli/package.json
+++ b/packages/webpack-cli/package.json
@@ -23,10 +23,10 @@
     "web"
   ],
   "dependencies": {
-    "@webpack-cli/package-utils": "^1.0.1-alpha.4",
     "@webpack-cli/info": "^1.0.1-alpha.4",
     "@webpack-cli/init": "^1.0.1-alpha.5",
     "@webpack-cli/serve": "^1.0.1-alpha.5",
+    "@webpack-cli/package-utils": "^1.0.1-alpha.4",
     "ansi-escapes": "^4.3.1",
     "colorette": "^1.2.1",
     "command-line-usage": "^6.1.0",
@@ -34,7 +34,7 @@
     "enquirer": "^2.3.4",
     "execa": "^4.0.0",
     "import-local": "^3.0.2",
-    "interpret": "^2.0.0",
+    "interpret": "^2.2.0",
     "rechoir": "^0.7.0",
     "v8-compile-cache": "^2.1.0",
     "webpack-merge": "^4.2.2"

--- a/test/config-format/mjs/main.js
+++ b/test/config-format/mjs/main.js
@@ -1,0 +1,1 @@
+console.log('Hoshiumi');

--- a/test/config-format/mjs/mjs-config.test.js
+++ b/test/config-format/mjs/mjs-config.test.js
@@ -1,0 +1,13 @@
+const { run } = require('../../utils/test-utils');
+const { existsSync } = require('fs');
+const { resolve } = require('path');
+
+describe('webpack cli', () => {
+    it('should support mjs file', () => {
+        const { stderr, stdout } = run(__dirname, ['-c', 'webpack.config.mjs'], false);
+        expect(stderr).toBeFalsy();
+        expect(stdout).toBeTruthy();
+        console.log({ stderr, stdout });
+        expect(existsSync(resolve(__dirname, 'dist/foo.bundle.js'))).toBeTruthy();
+    });
+});

--- a/test/config-format/mjs/webpack.config.mjs
+++ b/test/config-format/mjs/webpack.config.mjs
@@ -1,0 +1,15 @@
+// import { dirname, resolve } from 'path';
+// import { fileURLToPath } from 'url';
+
+// const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const config = {
+    mode: 'production',
+    entry: './main.js',
+    output: {
+        path: './dist',
+        filename: 'foo.bundle.js',
+    },
+};
+
+export default config;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6849,7 +6849,7 @@ interpret@^1.0.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.2.0.tgz#d5061a6224be58e8083985f5014d844359576296"
   integrity sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==
 
-interpret@^2.0.0:
+interpret@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-2.2.0.tgz#1a78a0b5965c40a5416d007ad6f50ad27c417df9"
   integrity sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==


### PR DESCRIPTION
**What kind of change does this PR introduce?**

chore

**Did you add tests for your changes?**
Yes

**If relevant, did you update the documentation?**
NA

**Summary**
Interpret has added .mjs support in latest version so bumping it then will be working on mjs support + tests

**Does this PR introduce a breaking change?**
No

**Other information**
