### PR TITLE
fix: allow unknown files to use default require as fallback

### DIFF
--- a/packages/webpack-cli/lib/groups/ConfigGroup.js
+++ b/packages/webpack-cli/lib/groups/ConfigGroup.js
@@ -42,25 +42,16 @@ const getDefaultConfigFiles = () => {
 };
 
 const getConfigInfoFromFileName = (filename) => {
-    const fileMetaData = parse(filename);
-    // .cjs is not available on interpret side, handle it manually for now
-    if (filename.endsWith('.cjs')) {
-        return [
-            {
-                path: resolve(filename),
-                ext: '.cjs',
-                module: null,
-            },
-        ];
-    }
-    return Object.keys(extensions)
-        .filter((ext) => ext.includes(fileMetaData.ext))
-        .filter((ext) => fileMetaData.base.substr(fileMetaData.base.length - ext.length) === ext)
-        .map((ext) => {
+    const { ext } = parse(filename);
+    // since we support only one config for now
+    const allFiles = [filename];
+    // return all the file metadata
+    return allFiles
+        .map((file) => {
             return {
-                path: resolve(filename),
+                path: resolve(file),
                 ext: ext,
-                module: extensions[ext],
+                module: extensions[ext] || null,
             };
         })
         .filter((e) => existsSync(e.path));

--- a/packages/webpack-cli/lib/groups/ConfigGroup.js
+++ b/packages/webpack-cli/lib/groups/ConfigGroup.js
@@ -1,5 +1,5 @@
 const { existsSync } = require('fs');
-const { resolve, sep, dirname, parse } = require('path');
+const { resolve, sep, dirname, extname } = require('path');
 const webpackMerge = require('webpack-merge');
 const { extensions, jsVariants } = require('interpret');
 const GroupHelper = require('../utils/GroupHelper');
@@ -42,7 +42,7 @@ const getDefaultConfigFiles = () => {
 };
 
 const getConfigInfoFromFileName = (filename) => {
-    const { ext } = parse(filename);
+    const ext = extname(filename);
     // since we support only one config for now
     const allFiles = [filename];
     // return all the file metadata


### PR DESCRIPTION
**What kind of change does this PR introduce?**
fix

**Did you add tests for your changes?**
Yes

**If relevant, did you update the documentation?**
No need

**Summary**
- Remove unnecessary filtering
- We filter all the config based on the available extensions in interpret which is not right and files should fallback to the default node require when they don't have a module needed.

**Does this PR introduce a breaking change?**
No

**Other information**
Question -> when we pass some file which doesn't exist ex `-c webpack.testconfig.js` we fallback to default config `webpack.config.js`, should we allow that considering the user already passed a config they want to use or should we throw err that config not found?