### PR TITLE
tests: ensure progress plugin is applied only once

### DIFF
--- a/test/progress/index.js
+++ b/test/progress/index.js
@@ -1,0 +1,1 @@
+console.log("Jotaro Kujo")

--- a/test/progress/progress-flag.test.js
+++ b/test/progress/progress-flag.test.js
@@ -9,4 +9,13 @@ describe('progress flag', () => {
         expect(stderr).toContain('[webpack.Progress] 100%');
         expect(stdout).toContain('main.js');
     });
+
+    it('should not add duplicate plugins', () => {
+        const { stderr, stdout, exitCode } = run(__dirname, ['-c', 'webpack.progress.config.js', '--progress']);
+        // Only 1 progress plugin should be applied to the compiler
+        expect(stdout.match(/ProgressPlugin/g)).toHaveLength(1);
+        expect(stderr).toContain('[webpack.Progress] 100%');
+        expect(stdout).toContain('main.js');
+        expect(exitCode).toEqual(0);
+    });
 });

--- a/test/progress/src/index.js
+++ b/test/progress/src/index.js
@@ -1,1 +1,0 @@
-console.log('progress flag test');

--- a/test/progress/webpack.progress.config.js
+++ b/test/progress/webpack.progress.config.js
@@ -1,0 +1,6 @@
+const { ProgressPlugin } = require('webpack');
+const WebpackCLITestPlugin = require('../utils/webpack-cli-test-plugin');
+
+module.exports = {
+    plugins: [new ProgressPlugin({}), new WebpackCLITestPlugin()],
+};


### PR DESCRIPTION
**What kind of change does this PR introduce?**

tests

**Did you add tests for your changes?**
yes

**If relevant, did you update the documentation?**
no need

**Summary**
- Add tests to ensure we're only applying progress plugin once

**Does this PR introduce a breaking change?**

no

**Other information**
Fixes https://github.com/webpack/webpack-cli/issues/1497