### PR TITLE
chore: add network timeout in yarnrc

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+ network-timeout 600000


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Adds latency to yarnrc

**Did you add tests for your changes?**
N/A
**If relevant, did you update the documentation?**
N/A
**Summary**
https://github.com/webpack/webpack-cli/pull/1791 fails due latency

**Does this PR introduce a breaking change?**
No

**Other information**
