### PR TITLE
fix: declare default commands as optional peer dependencies

### DIFF
--- a/packages/package-utils/package.json
+++ b/packages/package-utils/package.json
@@ -43,5 +43,16 @@
     "@webpack-cli/package-utils": "^1.0.1-alpha.4",
     "@types/cross-spawn": "6.0.1"
   },
+  "peerDependenciesMeta": {
+    "@webpack-cli/info": {
+      "optional": true
+    },
+    "@webpack-cli/init": {
+      "optional": true
+    },
+    "@webpack-cli/serve": {
+      "optional": true
+    }
+  },
   "gitHead": "fb50f766851f500ca12867a2aa9de81fa6e368f9"
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bug fix

**Did you add tests for your changes?**
N/A

**If relevant, did you update the documentation?**
N/A

**Summary**
This PR fixes the first issue of #1815 by declaring default command packages (included in `webpack-cli`) as optional peer dependencies of `@webpack-cli/package-utils` to enable it to resolve them.

**Does this PR introduce a breaking change?**
No