### PR TITLE
chore: bump serve package

### DIFF
--- a/packages/serve/package.json
+++ b/packages/serve/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webpack-cli/serve",
-  "version": "1.0.1-alpha.5",
+  "version": "1.0.1-alpha.6",
   "description": "",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
Fixes https://github.com/webpack/webpack-cli/issues/1814

**What kind of change does this PR introduce?**

bump

**Did you add tests for your changes?**
No need

**If relevant, did you update the documentation?**
NA

**Summary**

Bump serve package for release, old release is not compatible with latest cli it seems

**Does this PR introduce a breaking change?**
No

**Other information**
