### PR TITLE
chore: cleanup version invocation, argParser

### DIFF
--- a/packages/info/src/options.ts
+++ b/packages/info/src/options.ts
@@ -5,4 +5,10 @@ export default [
         type: String,
         description: 'To get the output in specified format (accept json or markdown)',
     },
+    {
+        name: 'version',
+        usage: '--version',
+        type: Boolean,
+        description: 'Display the version of the package',
+    },
 ];

--- a/packages/webpack-cli/__tests__/arg-parser.test.js
+++ b/packages/webpack-cli/__tests__/arg-parser.test.js
@@ -357,12 +357,6 @@ describe('arg-parser', () => {
         expect(helpCb.mock.calls[0][0]).toEqual(['--help']);
     });
 
-    it('calls version callback on --version', () => {
-        const versionCb = jest.fn();
-        argParser(helpAndVersionOptions, ['--version'], true, '', () => {}, versionCb);
-        expect(versionCb.mock.calls.length).toEqual(1);
-    });
-
     it('parses webpack args', () => {
         const res = argParser(core, ['--entry', 'test.js', '--hot', '-o', './dist/', '--stats'], true);
         expect(res.unknownArgs.length).toEqual(0);

--- a/packages/webpack-cli/lib/bootstrap.js
+++ b/packages/webpack-cli/lib/bootstrap.js
@@ -16,14 +16,15 @@ async function runCLI(cliArgs) {
     let args;
 
     const commandIsUsed = isCommandUsed(cliArgs);
-    options.enabled = !cliArgs.includes('--no-color');
     const parsedArgs = argParser(core, cliArgs, true, process.title, cli.runHelp);
     if (parsedArgs.unknownArgs.includes('help') || parsedArgs.opts.help) {
+        options.enabled = !cliArgs.includes('--no-color');
         cli.runHelp(cliArgs);
         process.exit(0);
     }
 
     if (parsedArgs.unknownArgs.includes('version') || parsedArgs.opts.version) {
+        options.enabled = !cliArgs.includes('--no-color');
         versionRunner(cliArgs, commandIsUsed);
         process.exit(0);
     }

--- a/packages/webpack-cli/lib/bootstrap.js
+++ b/packages/webpack-cli/lib/bootstrap.js
@@ -1,7 +1,9 @@
 const { options } = require('colorette');
 const WebpackCLI = require('./webpack-cli');
-const { core, commands } = require('./utils/cli-flags');
+const { core } = require('./utils/cli-flags');
+const versionRunner = require('./groups/runVersion');
 const logger = require('./utils/logger');
+const { isCommandUsed } = require('./utils/arg-utils');
 const cliExecuter = require('./utils/cli-executer');
 const argParser = require('./utils/arg-parser');
 require('./utils/process-log');
@@ -10,27 +12,19 @@ process.title = 'webpack-cli';
 // Create a new instance of the CLI object
 const cli = new WebpackCLI();
 
-const isCommandUsed = (args) =>
-    commands.find((cmd) => {
-        return args.includes(cmd.name) || args.includes(cmd.alias);
-    });
-
 async function runCLI(cliArgs) {
     let args;
 
     const commandIsUsed = isCommandUsed(cliArgs);
-    const runVersion = () => {
-        cli.runVersion(cliArgs, commandIsUsed);
-    };
-    const parsedArgs = argParser(core, cliArgs, true, process.title, cli.runHelp, runVersion, commands);
-
-    if (parsedArgs.unknownArgs.includes('help')) {
+    options.enabled = !cliArgs.includes('--no-color');
+    const parsedArgs = argParser(core, cliArgs, true, process.title, cli.runHelp);
+    if (parsedArgs.unknownArgs.includes('help') || parsedArgs.opts.help) {
         cli.runHelp(cliArgs);
         process.exit(0);
     }
 
-    if (parsedArgs.unknownArgs.includes('version')) {
-        runVersion();
+    if (parsedArgs.unknownArgs.includes('version') || parsedArgs.opts.version) {
+        versionRunner(cliArgs, commandIsUsed);
         process.exit(0);
     }
 

--- a/packages/webpack-cli/lib/groups/HelpGroup.js
+++ b/packages/webpack-cli/lib/groups/HelpGroup.js
@@ -1,6 +1,5 @@
 const { yellow, bold, underline } = require('colorette');
 const { core, commands } = require('../utils/cli-flags');
-const { defaultCommands } = require('../utils/commands');
 const logger = require('../utils/logger');
 const commandLineUsage = require('command-line-usage');
 
@@ -44,40 +43,6 @@ class HelpGroup {
             logger.raw(this.run().outputOptions.help);
         }
         logger.raw('\n                  Made with ♥️  by the webpack team');
-    }
-
-    outputVersion(externalPkg, commandsUsed, invalidArgs) {
-        if (externalPkg && commandsUsed.length === 1 && invalidArgs.length === 0) {
-            try {
-                if ([externalPkg.alias, externalPkg.name].some((pkg) => commandsUsed.includes(pkg))) {
-                    const { name, version } = require(`@webpack-cli/${defaultCommands[externalPkg.name]}/package.json`);
-                    logger.raw(`\n${name} ${version}`);
-                } else {
-                    const { name, version } = require(`${externalPkg.name}/package.json`);
-                    logger.raw(`\n${name} ${version}`);
-                }
-            } catch (e) {
-                logger.error('Error: External package not found.');
-                process.exit(2);
-            }
-        }
-
-        if (commandsUsed.length > 1) {
-            logger.error('You provided multiple commands. Please use only one command at a time.\n');
-            process.exit(2);
-        }
-
-        if (invalidArgs.length > 0) {
-            const argType = invalidArgs[0].startsWith('-') ? 'option' : 'command';
-            logger.error(`Error: Invalid ${argType} '${invalidArgs[0]}'.`);
-            logger.info('Run webpack --help to see available commands and arguments.\n');
-            process.exit(2);
-        }
-
-        const pkgJSON = require('../../package.json');
-        const webpack = require('webpack');
-        logger.raw(`\nwebpack-cli ${pkgJSON.version}`);
-        logger.raw(`\nwebpack ${webpack.version}\n`);
     }
 
     run() {

--- a/packages/webpack-cli/lib/groups/runVersion.js
+++ b/packages/webpack-cli/lib/groups/runVersion.js
@@ -1,0 +1,46 @@
+const logger = require('../utils/logger');
+const { defaultCommands } = require('../utils/commands');
+const { isCommandUsed } = require('../utils/arg-utils');
+const { commands, allNames, hasUnknownArgs } = require('../utils/unknown-args');
+
+const outputVersion = (args) => {
+    // This is used to throw err when there are multiple command along with version
+    const commandsUsed = args.filter((val) => commands.includes(val));
+
+    // The command with which version is invoked
+    const commandUsed = isCommandUsed(args);
+    const invalidArgs = hasUnknownArgs(args, ...allNames);
+    if (commandsUsed && commandsUsed.length === 1 && invalidArgs.length === 0) {
+        try {
+            if ([commandUsed.alias, commandUsed.name].some((pkg) => commandsUsed.includes(pkg))) {
+                const { name, version } = require(`@webpack-cli/${defaultCommands[commandUsed.name]}/package.json`);
+                logger.raw(`\n${name} ${version}`);
+            } else {
+                const { name, version } = require(`${commandUsed.name}/package.json`);
+                logger.raw(`\n${name} ${version}`);
+            }
+        } catch (e) {
+            logger.error('Error: External package not found.');
+            process.exit(2);
+        }
+    }
+
+    if (commandsUsed.length > 1) {
+        logger.error('You provided multiple commands. Please use only one command at a time.\n');
+        process.exit(2);
+    }
+
+    if (invalidArgs.length > 0) {
+        const argType = invalidArgs[0].startsWith('-') ? 'option' : 'command';
+        logger.error(`Error: Invalid ${argType} '${invalidArgs[0]}'.`);
+        logger.info('Run webpack --help to see available commands and arguments.\n');
+        process.exit(2);
+    }
+
+    const pkgJSON = require('../../package.json');
+    const webpack = require('webpack');
+    logger.raw(`\nwebpack-cli ${pkgJSON.version}`);
+    logger.raw(`\nwebpack ${webpack.version}\n`);
+};
+
+module.exports = outputVersion;

--- a/packages/webpack-cli/lib/utils/arg-parser.js
+++ b/packages/webpack-cli/lib/utils/arg-parser.js
@@ -1,6 +1,6 @@
 const commander = require('commander');
 const logger = require('./logger');
-
+const { commands } = require('./cli-flags');
 const { defaultCommands } = require('./commands');
 
 /**
@@ -12,38 +12,28 @@ const { defaultCommands } = require('./commands');
  * @param {boolean} argsOnly false if all of process.argv has been provided, true if
  * args is only a subset of process.argv that removes the first couple elements
  */
-function argParser(options, args, argsOnly = false, name = '', helpFunction = undefined, versionFunction = undefined, commands) {
+function argParser(options, args, argsOnly = false, name = '', helpFunction) {
     const parser = new commander.Command();
     // Set parser name
     parser.name(name);
     parser.storeOptionsAsProperties(false);
 
-    if (commands) {
-        commands.reduce((parserInstance, cmd) => {
-            parser
-                .command(cmd.name)
-                .alias(cmd.alias)
-                .description(cmd.description)
-                .usage(cmd.usage)
-                .allowUnknownOption(true)
-                .action(async () => {
-                    const cliArgs = args.slice(args.indexOf(cmd.name) + 1 || args.indexOf(cmd.alias) + 1);
-                    return await require('../commands/ExternalCommand').run(defaultCommands[cmd.name], ...cliArgs);
-                });
-            return parser;
-        }, parser);
+    commands.reduce((parserInstance, cmd) => {
+        parser
+            .command(cmd.name)
+            .alias(cmd.alias)
+            .description(cmd.description)
+            .usage(cmd.usage)
+            .allowUnknownOption(true)
+            .action(async () => {
+                const cliArgs = args.slice(args.indexOf(cmd.name) + 1 || args.indexOf(cmd.alias) + 1);
+                return await require('../commands/ExternalCommand').run(defaultCommands[cmd.name], ...cliArgs);
+            });
+        return parser;
+    }, parser);
 
-        // Prevent default behavior
-        parser.on('command:*', () => {});
-    }
-
-    // Use customized version output if available
-    if (versionFunction) {
-        parser.on('option:version', () => {
-            versionFunction();
-            process.exit(0);
-        });
-    }
+    // Prevent default behavior
+    parser.on('command:*', () => {});
 
     // Use customized help output if available
     if (helpFunction) {

--- a/packages/webpack-cli/lib/utils/arg-utils.js
+++ b/packages/webpack-cli/lib/utils/arg-utils.js
@@ -1,3 +1,5 @@
+const { commands } = require('./cli-flags');
+
 function hyphenToUpperCase(name) {
     if (!name) {
         return name;
@@ -18,6 +20,12 @@ function arrayToObject(arr) {
     }, {});
 }
 
+const isCommandUsed = (args) =>
+    commands.find((cmd) => {
+        return args.includes(cmd.name) || args.includes(cmd.alias);
+    });
+
 module.exports = {
     arrayToObject,
+    isCommandUsed,
 };

--- a/packages/webpack-cli/lib/utils/cli-flags.js
+++ b/packages/webpack-cli/lib/utils/cli-flags.js
@@ -56,7 +56,7 @@ const commands = [
             {
                 name: 'version',
                 type: Boolean,
-                description: 'Print version information if info package',
+                description: 'Print version information of info package',
             },
         ],
     },

--- a/packages/webpack-cli/lib/utils/cli-flags.js
+++ b/packages/webpack-cli/lib/utils/cli-flags.js
@@ -47,13 +47,6 @@ const commands = [
         type: String,
         usage: 'info [options]',
         description: 'Outputs information about your system and dependencies',
-        flags: [
-            {
-                name: 'output',
-                type: String,
-                description: 'To get the output in specified format ( accept json or markdown )',
-            },
-        ],
     },
     {
         name: 'serve',

--- a/packages/webpack-cli/lib/utils/cli-flags.js
+++ b/packages/webpack-cli/lib/utils/cli-flags.js
@@ -47,6 +47,18 @@ const commands = [
         type: String,
         usage: 'info [options]',
         description: 'Outputs information about your system and dependencies',
+        flags: [
+            {
+                name: 'output',
+                type: String,
+                description: 'To get the output in specified format ( accept json or markdown )',
+            },
+            {
+                name: 'version',
+                type: Boolean,
+                description: 'Print version information if info package',
+            },
+        ],
     },
     {
         name: 'serve',

--- a/packages/webpack-cli/lib/webpack-cli.js
+++ b/packages/webpack-cli/lib/webpack-cli.js
@@ -235,15 +235,6 @@ class WebpackCLI extends GroupHelper {
         options.enabled = !args.includes('--no-color');
         return new HelpGroup().outputHelp(isCommand, subject, invalidArgs);
     }
-
-    runVersion(args, externalPkg) {
-        const HelpGroup = require('./groups/HelpGroup');
-        const { commands, allNames, hasUnknownArgs } = require('./utils/unknown-args');
-        const commandsUsed = args.filter((val) => commands.includes(val));
-        const invalidArgs = hasUnknownArgs(args, ...allNames);
-        options.enabled = !args.includes('--no-color');
-        return new HelpGroup().outputVersion(externalPkg, commandsUsed, invalidArgs);
-    }
 }
 
 module.exports = WebpackCLI;


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Refactor

**Did you add tests for your changes?**
Yes

**If relevant, did you update the documentation?**

**Summary**
- Changes version to a simple fn and takes a single param and move out of help group, remove instance from `webpack-cli`
- Cleaned up redundant args in arg parser
- Only invoke once in bootstrap.js, instead of multiple places


**Does this PR introduce a breaking change?**
No

**Other information**
