### PR TITLE
docs: remove reference to package-utils (deprecated)

### DIFF
--- a/packages/README.md
+++ b/packages/README.md
@@ -19,11 +19,10 @@ This folder is the collection of those packages.
 4. [info](https://github.com/webpack/webpack-cli/tree/master/packages/info)
 5. [init](https://github.com/webpack/webpack-cli/tree/master/packages/init)
 6. [migrate](https://github.com/webpack/webpack-cli/tree/master/packages/migrate)
-7. [package-utils](https://github.com/webpack/webpack-cli/tree/master/packages/package-utils)
-8. [serve](https://github.com/webpack/webpack-cli/tree/master/packages/serve)
-9. [utils](https://github.com/webpack/webpack-cli/tree/master/packages/utils)
-10. [webpack-cli](https://github.com/webpack/webpack-cli/tree/master/packages/webpack-cli)
-11. [webpack-scaffold](https://github.com/webpack/webpack-cli/tree/master/packages/webpack-scaffold)
+7. [serve](https://github.com/webpack/webpack-cli/tree/master/packages/serve)
+8. [utils](https://github.com/webpack/webpack-cli/tree/master/packages/utils)
+9. [webpack-cli](https://github.com/webpack/webpack-cli/tree/master/packages/webpack-cli)
+10. [webpack-scaffold](https://github.com/webpack/webpack-cli/tree/master/packages/webpack-scaffold)
 
 ## Generic Installation
 

--- a/packages/webpack-cli/README.md
+++ b/packages/webpack-cli/README.md
@@ -25,12 +25,12 @@ yarn add webpack-cli --dev
 ### Available Commands
 
 ```
-  init      Initialize a new webpack configuration
-  migrate   Migrate a configuration to a new version
-  loader    Scaffold a loader repository
-  plugin    Scaffold a plugin repository
-  info      Outputs information about your system and dependencies
-  serve     Run the webpack Dev Server
+  init | c      Initialize a new webpack configuration
+  migrate | m   Migrate a configuration to a new version
+  loader | l    Scaffold a loader repository
+  plugin | p    Scaffold a plugin repository
+  info | i      Outputs information about your system and dependencies
+  serve | s     Run the webpack Dev Server
 ```
 
 ### webpack 4


### PR DESCRIPTION
**What kind of change does this PR introduce?**

docs

**Did you add tests for your changes?**
Yes

**If relevant, did you update the documentation?**
Yes

**Summary**

Removes ref to `package-utils` which is a deprecated package.

**Does this PR introduce a breaking change?**
No

**Other information**
