### PR TITLE
feat: allow passing strings in env flag

### DIFF
--- a/packages/webpack-cli/lib/groups/ConfigGroup.js
+++ b/packages/webpack-cli/lib/groups/ConfigGroup.js
@@ -167,17 +167,7 @@ const finalize = async (moduleObj, args) => {
             // `Promise` may return `Function`
             if (typeof rawConfig === 'function') {
                 // when config is a function, pass the env from args to the config function
-                let envs;
-
-                if (Array.isArray(env)) {
-                    envs = env.reduce((envObject, envOption) => {
-                        envObject[envOption] = true;
-
-                        return envObject;
-                    }, {});
-                }
-
-                rawConfig = await rawConfig(envs, args);
+                rawConfig = await rawConfig(env, args);
             }
 
             return rawConfig;

--- a/packages/webpack-cli/lib/utils/arg-parser.js
+++ b/packages/webpack-cli/lib/utils/arg-parser.js
@@ -97,8 +97,20 @@ const argParser = (options, args, argsOnly = false, name = '') => {
                 // so you can do `--env platform=staging --env production`
                 // { platform: "staging", production: true }
                 const multiArg = (value, previous = {}) => {
-                    const [key, val] = value.split('=');
-                    return { ...previous, [key]: val || true };
+                    const [allKeys, val] = value.split('=');
+                    const splitKeys = allKeys.split('.');
+                    let prevRef = previous;
+                    splitKeys.forEach((someKey, index) => {
+                        if (!prevRef[someKey]) prevRef[someKey] = {};
+                        if (index === splitKeys.length - 1) {
+                            prevRef[someKey] = val || true;
+                        } else {
+                            prevRef[someKey] = typeof prevRef[someKey] === 'string' ? {} : { ...prevRef[someKey] };
+                        }
+                        console.log({ prevRef, previous, someKey });
+                        prevRef = prevRef[someKey];
+                    });
+                    return previous;
                 };
                 parserInstance.option(flagsWithType, option.description, multiArg, option.defaultValue).action(() => {});
             } else {

--- a/packages/webpack-cli/lib/utils/arg-parser.js
+++ b/packages/webpack-cli/lib/utils/arg-parser.js
@@ -92,6 +92,15 @@ const argParser = (options, args, argsOnly = false, name = '') => {
                 // a multiple argument parsing function
                 const multiArg = (value, previous = []) => previous.concat([value]);
                 parserInstance.option(flagsWithType, option.description, multiArg, option.defaultValue).action(() => {});
+            } else if (option.multipleType) {
+                // for options which accept multiple types like env
+                // so you can do `--env platform=staging --env production`
+                // { platform: "staging", production: true }
+                const multiArg = (value, previous = {}) => {
+                    const [key, val] = value.split('=');
+                    return { ...previous, [key]: val || true };
+                };
+                parserInstance.option(flagsWithType, option.description, multiArg, option.defaultValue).action(() => {});
             } else {
                 // Prevent default behavior for standalone options
                 parserInstance.option(flagsWithType, option.description, option.defaultValue).action(() => {});

--- a/packages/webpack-cli/lib/utils/arg-parser.js
+++ b/packages/webpack-cli/lib/utils/arg-parser.js
@@ -97,17 +97,18 @@ const argParser = (options, args, argsOnly = false, name = '') => {
                 // so you can do `--env platform=staging --env production`
                 // { platform: "staging", production: true }
                 const multiArg = (value, previous = {}) => {
-                    const [allKeys, val] = value.split('=');
+                    // this ensures we're only splitting by the first `=`
+                    const [allKeys, val] = value.split(/=(.+)/, 2);
                     const splitKeys = allKeys.split('.');
                     let prevRef = previous;
                     splitKeys.forEach((someKey, index) => {
                         if (!prevRef[someKey]) prevRef[someKey] = {};
+                        if ('string' === typeof prevRef[someKey]) {
+                            prevRef[someKey] = {};
+                        }
                         if (index === splitKeys.length - 1) {
                             prevRef[someKey] = val || true;
-                        } else {
-                            prevRef[someKey] = typeof prevRef[someKey] === 'string' ? {} : { ...prevRef[someKey] };
                         }
-                        console.log({ prevRef, previous, someKey });
                         prevRef = prevRef[someKey];
                     });
                     return previous;

--- a/packages/webpack-cli/lib/utils/arg-parser.js
+++ b/packages/webpack-cli/lib/utils/arg-parser.js
@@ -99,7 +99,7 @@ const argParser = (options, args, argsOnly = false, name = '') => {
                 const multiArg = (value, previous = {}) => {
                     // this ensures we're only splitting by the first `=`
                     const [allKeys, val] = value.split(/=(.+)/, 2);
-                    const splitKeys = allKeys.split('.');
+                    const splitKeys = allKeys.split(/\.(?!$)/);
                     let prevRef = previous;
                     splitKeys.forEach((someKey, index) => {
                         if (!prevRef[someKey]) prevRef[someKey] = {};

--- a/packages/webpack-cli/lib/utils/cli-flags.js
+++ b/packages/webpack-cli/lib/utils/cli-flags.js
@@ -205,7 +205,7 @@ const core = [
         name: 'env',
         usage: '--env',
         type: String,
-        multiple: true,
+        multipleType: true,
         description: 'Environment passed to the configuration when it is a function',
     },
     {

--- a/test/config/type/function-with-env/function-with-env.test.js
+++ b/test/config/type/function-with-env/function-with-env.test.js
@@ -19,11 +19,18 @@ describe('function configuration', () => {
         expect(existsSync(resolve(__dirname, './bin/dev.js'))).toBeTruthy();
     });
     it('Supports passing string in env', () => {
-        const { stderr, stdout } = run(__dirname, ['--env', 'environment=production', '-c', 'webpack.env.config.js']);
+        const { stderr, stdout } = run(__dirname, [
+            '--env',
+            'environment=production',
+            '--env',
+            'app.title=Luffy',
+            '-c',
+            'webpack.env.config.js',
+        ]);
         expect(stderr).toBeFalsy();
         expect(stdout).toBeTruthy();
         // Should generate the appropriate files
-        expect(existsSync(resolve(__dirname, './bin/prod.js'))).toBeTruthy();
+        expect(existsSync(resolve(__dirname, './bin/Luffy.js'))).toBeTruthy();
     });
     it('is able to understand multiple env flags', (done) => {
         const { stderr, stdout } = run(__dirname, ['--env', 'isDev', '--env', 'verboseStats', '--env', 'envMessage']);

--- a/test/config/type/function-with-env/function-with-env.test.js
+++ b/test/config/type/function-with-env/function-with-env.test.js
@@ -18,6 +18,13 @@ describe('function configuration', () => {
         // Should generate the appropriate files
         expect(existsSync(resolve(__dirname, './bin/dev.js'))).toBeTruthy();
     });
+    it('Supports passing string in env', () => {
+        const { stderr, stdout } = run(__dirname, ['--env', 'environment=production', '-c', 'webpack.env.config.js']);
+        expect(stderr).toBeFalsy();
+        expect(stdout).toBeTruthy();
+        // Should generate the appropriate files
+        expect(existsSync(resolve(__dirname, './bin/prod.js'))).toBeTruthy();
+    });
     it('is able to understand multiple env flags', (done) => {
         const { stderr, stdout } = run(__dirname, ['--env', 'isDev', '--env', 'verboseStats', '--env', 'envMessage']);
         expect(stderr).toBeFalsy();

--- a/test/config/type/function-with-env/function-with-env.test.js
+++ b/test/config/type/function-with-env/function-with-env.test.js
@@ -4,6 +4,13 @@ const { resolve } = require('path');
 const { run } = require('../../../utils/test-utils');
 
 describe('function configuration', () => {
+    it('should throw when env is not supplied', () => {
+        const { stderr, stdout, exitCode } = run(__dirname, ['--env'], false);
+        expect(stdout).toBeFalsy();
+        expect(stderr).toBeTruthy();
+        expect(stderr).toContain(`option '--env <value>' argument missing`);
+        expect(exitCode).toEqual(1);
+    });
     it('is able to understand a configuration file as a function', () => {
         const { stderr, stdout } = run(__dirname, ['--env', 'isProd']);
         expect(stderr).toBeFalsy();
@@ -31,6 +38,20 @@ describe('function configuration', () => {
         expect(stdout).toBeTruthy();
         // Should generate the appropriate files
         expect(existsSync(resolve(__dirname, './bin/Luffy.js'))).toBeTruthy();
+    });
+    it('Supports long nested values in env', () => {
+        const { stderr, stdout } = run(__dirname, [
+            '--env',
+            'file.name.is.this=Atsumu',
+            '--env',
+            'environment=production',
+            '-c',
+            'webpack.env.config.js',
+        ]);
+        expect(stderr).toBeFalsy();
+        expect(stdout).toBeTruthy();
+        // Should generate the appropriate files
+        expect(existsSync(resolve(__dirname, './bin/Atsumu.js'))).toBeTruthy();
     });
     it('is able to understand multiple env flags', (done) => {
         const { stderr, stdout } = run(__dirname, ['--env', 'isDev', '--env', 'verboseStats', '--env', 'envMessage']);

--- a/test/config/type/function-with-env/function-with-env.test.js
+++ b/test/config/type/function-with-env/function-with-env.test.js
@@ -53,6 +53,34 @@ describe('function configuration', () => {
         // Should generate the appropriate files
         expect(existsSync(resolve(__dirname, './bin/Atsumu.js'))).toBeTruthy();
     });
+    it('Supports multiple equal in a string', () => {
+        const { stderr, stdout } = run(__dirname, [
+            '--env',
+            'file=name=is=Eren',
+            '--env',
+            'environment=multipleq',
+            '-c',
+            'webpack.env.config.js',
+        ]);
+        expect(stderr).toBeFalsy();
+        expect(stdout).toBeTruthy();
+        // Should generate the appropriate files
+        expect(existsSync(resolve(__dirname, './bin/name=is=Eren.js'))).toBeTruthy();
+    });
+    it('Supports dot at the end', () => {
+        const { stderr, stdout } = run(__dirname, ['--env', 'name.=Hisoka', '--env', 'environment=dot', '-c', 'webpack.env.config.js']);
+        expect(stderr).toBeFalsy();
+        expect(stdout).toBeTruthy();
+        // Should generate the appropriate files
+        expect(existsSync(resolve(__dirname, './bin/Hisoka.js'))).toBeTruthy();
+    });
+    it('Supports dot at the end', () => {
+        const { stderr, stdout } = run(__dirname, ['--env', 'name.', '--env', 'environment=dot', '-c', 'webpack.env.config.js']);
+        expect(stderr).toBeFalsy();
+        expect(stdout).toBeTruthy();
+        // Should generate the appropriate files
+        expect(existsSync(resolve(__dirname, './bin/true.js'))).toBeTruthy();
+    });
     it('is able to understand multiple env flags', (done) => {
         const { stderr, stdout } = run(__dirname, ['--env', 'isDev', '--env', 'verboseStats', '--env', 'envMessage']);
         expect(stderr).toBeFalsy();

--- a/test/config/type/function-with-env/webpack.env.config.js
+++ b/test/config/type/function-with-env/webpack.env.config.js
@@ -1,0 +1,12 @@
+module.exports = (env) => {
+    const { environment } = env;
+    if (environment === 'production') {
+        return {
+            entry: './a.js',
+            output: {
+                filename: 'prod.js',
+            },
+        };
+    }
+    return {};
+};

--- a/test/config/type/function-with-env/webpack.env.config.js
+++ b/test/config/type/function-with-env/webpack.env.config.js
@@ -1,10 +1,13 @@
 module.exports = (env) => {
-    const { environment } = env;
+    const {
+        environment,
+        app: { title },
+    } = env;
     if (environment === 'production') {
         return {
             entry: './a.js',
             output: {
-                filename: 'prod.js',
+                filename: `${title}.js`,
             },
         };
     }

--- a/test/config/type/function-with-env/webpack.env.config.js
+++ b/test/config/type/function-with-env/webpack.env.config.js
@@ -2,12 +2,29 @@ module.exports = (env) => {
     const { environment, app, file } = env;
     const customName = file && file.name && file.name.is && file.name.is.this;
     const appTitle = app && app.title;
-    console.log(env);
     if (environment === 'production') {
         return {
             entry: './a.js',
             output: {
                 filename: `${customName ? customName : appTitle}.js`,
+            },
+        };
+    }
+    if (environment === 'multipleq') {
+        const { file } = env;
+        return {
+            entry: './a.js',
+            output: {
+                filename: `${file}.js`,
+            },
+        };
+    }
+    if (environment === 'dot') {
+        const file = env['name.'];
+        return {
+            entry: './a.js',
+            output: {
+                filename: `${file}.js`,
             },
         };
     }

--- a/test/config/type/function-with-env/webpack.env.config.js
+++ b/test/config/type/function-with-env/webpack.env.config.js
@@ -1,13 +1,13 @@
 module.exports = (env) => {
-    const {
-        environment,
-        app: { title },
-    } = env;
+    const { environment, app, file } = env;
+    const customName = file && file.name && file.name.is && file.name.is.this;
+    const appTitle = app && app.title;
+    console.log(env);
     if (environment === 'production') {
         return {
             entry: './a.js',
             output: {
-                filename: `${title}.js`,
+                filename: `${customName ? customName : appTitle}.js`,
             },
         };
     }

--- a/test/config/type/promise-function/promise-function.test.js
+++ b/test/config/type/promise-function/promise-function.test.js
@@ -6,8 +6,6 @@ const { run } = require('../../../utils/test-utils');
 describe('promise function', () => {
     it('is able to understand a configuration file as a promise', (done) => {
         const { stdout, stderr } = run(__dirname, ['-c', './webpack.config.js'], false);
-        console.log(stdout);
-        console.log(stderr);
         expect(stdout).toBeTruthy();
         expect(stderr).toBeFalsy();
         stat(resolve(__dirname, './binary/promise.js'), (err, stats) => {


### PR DESCRIPTION
**What kind of change does this PR introduce?**
feat/fix

**Did you add tests for your changes?**
Yes

**If relevant, did you update the documentation?**
Need to reflect in docs

**Summary**
- Allow passing strings to env flag which is passed to config
- You can now do - 

`webpack --env platform=app --env production`

which will pass `{ platform: "app", production: true }` to the config

**Does this PR introduce a breaking change?**

Nope

**Other information**

Fixes https://github.com/webpack/webpack-cli/issues/1932