### PR TITLE
Log error stack traces to the console

### DIFF
--- a/packages/generators/src/addon-generator.ts
+++ b/packages/generators/src/addon-generator.ts
@@ -55,7 +55,8 @@ const addonGenerator = (
                 try {
                     mkdirp.sync(pathToProjectDir);
                 } catch (err) {
-                    logger.error('Failed to create directory', err);
+                    logger.error('Failed to create directory');
+                    logger.error(err);
                 }
                 this.destinationRoot(pathToProjectDir);
             }

--- a/packages/webpack-cli/lib/utils/logger.js
+++ b/packages/webpack-cli/lib/utils/logger.js
@@ -1,7 +1,13 @@
 const { red, cyan, yellow, green } = require('colorette');
 
 module.exports = {
-    error: (val) => console.error(`[webpack-cli] ${red(val)}`),
+    error: (val) => {
+        if (val && val.stack) {
+            val = val.stack;
+        }
+
+        console.error(`[webpack-cli] ${red(val)}`);
+    },
     warn: (val) => console.warn(`[webpack-cli] ${yellow(val)}`),
     info: (val) => console.info(`[webpack-cli] ${cyan(val)}`),
     success: (val) => console.log(`[webpack-cli] ${green(val)}`),


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Show stack traces for errors logged by webpack-cli.

**Did you add tests for your changes?**
No.

**If relevant, did you update the documentation?**
No.

**Summary**
An error occurring in a plugin (for example calling missing APIs or just throwing an error during `apply()`) results in a displayed error but no stack trace. This in turn makes it nearly impossible to track down the source of the problem and address it.

You may see an example of what I'm trying to address here: https://github.com/thecrypticace/webpack-cli-stack-traces

**Does this PR introduce a breaking change?**
No.

**Other information**
n/a