### PR TITLE
chore: add peer dependencies for yarn pnp

### DIFF
--- a/packages/webpack-cli/package.json
+++ b/packages/webpack-cli/package.json
@@ -57,6 +57,9 @@
     },
     "webpack-bundle-analyzer": {
       "optional": true
+    },
+    "webpack-dev-server": {
+      "optional": true
     }
   },
   "gitHead": "fb50f766851f500ca12867a2aa9de81fa6e368f9"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

bugfix: fix `peerDependencies` for Yarn PnP.<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

no.

**If relevant, did you update the documentation?**

no.

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

Support Yarn PnP.

1. `@webpack-cli/serve` require `webpack-dev-server`(a peer dependency);
2. `webpack-cli` require `@webpack-cli/serve`;
3. so, `webpack-cli` would add `webpack-dev-server` into `peerDependencies`.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

no.

**Other information**

Repo for reproducing bug: https://github.com/aicest/webpack-v5-demo

![image](https://user-images.githubusercontent.com/4016742/95949642-ad5c0580-0e25-11eb-998b-a15ea2e15883.png)
