### PR TITLE
fix: remove unnecessary optional peer dependencies

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -35,15 +35,6 @@
     "@types/yeoman-generator": "^4.11.2"
   },
   "peerDependenciesMeta": {
-    "@webpack-cli/info": {
-      "optional": true
-    },
-    "@webpack-cli/init": {
-      "optional": true
-    },
-    "@webpack-cli/serve": {
-      "optional": true
-    },
     "prettier": {
       "optional": true
     }


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bugfix (this doesn't fix any bugs, but in terms of semver I think it should be a fix)

**Did you add tests for your changes?**
N/A

**If relevant, did you update the documentation?**
N/A

**Summary**
In #1816, default commands packages were added to peer dependencies of `@webpack-cli/package-utils`, as they were required by `packageExists` in order to fix #1815.

However, in #1822, `packageExists` was moved directly into `webpack-cli` not `@webpack-cli/utils`, so `@webpack-cli/utils` doesn't require them.

**Does this PR introduce a breaking change?**
No

**Other information**
Note #1815 has been fixed by #1822.
