### PR TITLE
chore: display running webpack version during tests

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -83,7 +83,6 @@ jobs:
           yarn bootstrap
 
       - name: Install webpack ${{ matrix.webpack-version }}
-        if: steps.cache.outputs.cache-hit != 'true'
         run: yarn add -W webpack@${{ matrix.webpack-version }}
 
       - name: Build

--- a/jest.config.js
+++ b/jest.config.js
@@ -17,5 +17,6 @@ module.exports = {
     watchPlugins: ['jest-watch-typeahead/filename', 'jest-watch-typeahead/testname'],
     setupFilesAfterEnv: ['<rootDir>/setupTest.js'],
     globalTeardown: '<rootDir>/scripts/cleanupTest.js',
+    globalSetup: '<rootDir>/scripts/globalSetup.js',
     modulePathIgnorePatterns: ['<rootDir>/test/loader/test-loader', '<rootDir>/test/plugin/test-plugin'],
 };

--- a/scripts/globalSetup.js
+++ b/scripts/globalSetup.js
@@ -1,3 +1,3 @@
 const { version } = require('webpack');
 
-module.exports = () => console.log(`Running tests for webpack @${version}`);
+module.exports = () => console.log(`\n Running tests for webpack @${version} \n`);

--- a/scripts/globalSetup.js
+++ b/scripts/globalSetup.js
@@ -1,0 +1,3 @@
+const { version } = require('webpack');
+
+module.exports = () => console.log(`Running tests for webpack @${version}`);

--- a/test/progress/progress-flag.test.js
+++ b/test/progress/progress-flag.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { run } = require('../utils/test-utils');
+const { run, isWebpack5 } = require('../utils/test-utils');
 
 describe('progress flag', () => {
     it('should show progress', () => {
@@ -16,7 +16,9 @@ describe('progress flag', () => {
         const { stderr, stdout, exitCode } = run(__dirname, ['--progress=profile']);
 
         expect(exitCode).toBe(0);
-        expect(stderr).toMatch(/\[webpack\.Progress] \d+ ms setup/);
+        if (isWebpack5) {
+            expect(stderr).toMatch(/\[webpack\.Progress] \d+ ms setup/);
+        }
         expect(stderr).toContain('[webpack.Progress] 100%');
         expect(stdout).toContain('main.js');
     });


### PR DESCRIPTION
**What kind of change does this PR introduce?**

chore

**Did you add tests for your changes?**
Yes

**If relevant, did you update the documentation?**
NA

**Summary**
This display running webpack version during tests, useful to check if the CI cache is working correctly and locally to ensure we're running tests on correct env.

**Does this PR introduce a breaking change?**
No

**Other information**
/cc @evilebottnawi 