### PR TITLE
feat: add WEBPACK_SERVE environment variable

### DIFF
--- a/packages/serve/__tests__/__snapshots__/parseArgs.test.ts.snap
+++ b/packages/serve/__tests__/__snapshots__/parseArgs.test.ts.snap
@@ -11,6 +11,9 @@ Object {
   },
   "webpackArgs": Object {
     "color": true,
+    "env": Object {
+      "WEBPACK_SERVE": true,
+    },
     "hot": true,
   },
 }
@@ -39,6 +42,9 @@ Object {
   },
   "webpackArgs": Object {
     "color": true,
+    "env": Object {
+      "WEBPACK_SERVE": true,
+    },
     "mode": "development",
   },
 }

--- a/packages/serve/src/index.ts
+++ b/packages/serve/src/index.ts
@@ -12,6 +12,10 @@ import parseArgs from './parseArgs';
 export default function serve(...args: string[]): void {
     const cli = new WebpackCLI();
 
+    // add WEBPACK_SERVE to main process and compilation environment
+    process.env['WEBPACK_SERVE'] = JSON.stringify(true);
+    args = [...args, '--env', 'process.env.WEBPACK_SERVE=true'];
+
     const { webpackArgs, devServerArgs } = parseArgs(cli, args);
 
     cli.getCompiler(webpackArgs).then((compiler): void => {

--- a/packages/serve/src/index.ts
+++ b/packages/serve/src/index.ts
@@ -12,9 +12,8 @@ import parseArgs from './parseArgs';
 export default function serve(...args: string[]): void {
     const cli = new WebpackCLI();
 
-    // add WEBPACK_SERVE to main process and compilation environment
-    process.env['WEBPACK_SERVE'] = JSON.stringify(true);
-    args = [...args, '--env', 'process.env.WEBPACK_SERVE=true'];
+    // add WEBPACK_SERVE to compilation environment
+    args = [...args, '--env', 'WEBPACK_SERVE=true'];
 
     const { webpackArgs, devServerArgs } = parseArgs(cli, args);
 

--- a/packages/serve/src/index.ts
+++ b/packages/serve/src/index.ts
@@ -12,9 +12,6 @@ import parseArgs from './parseArgs';
 export default function serve(...args: string[]): void {
     const cli = new WebpackCLI();
 
-    // add WEBPACK_SERVE to compilation environment
-    args = [...args, '--env', 'WEBPACK_SERVE=true'];
-
     const { webpackArgs, devServerArgs } = parseArgs(cli, args);
 
     cli.getCompiler(webpackArgs).then((compiler): void => {

--- a/packages/serve/src/parseArgs.ts
+++ b/packages/serve/src/parseArgs.ts
@@ -38,6 +38,13 @@ export default function parseArgs(cli: WebpackCLIType, args: string[]): ArgsType
     const parsedWebpackArgs = cli.argParser(core, parsedDevServerArgs.unknownArgs, true, process.title);
     const webpackArgs = parsedWebpackArgs.opts;
 
+    // Add WEBPACK_SERVE environment variable
+    if (webpackArgs.env) {
+        webpackArgs.env.WEBPACK_SERVE = true;
+    } else {
+        webpackArgs.env = { WEBPACK_SERVE: true };
+    }
+
     // pass along the 'hot' argument to the dev server if it exists
     if (webpackArgs && webpackArgs.hot !== undefined) {
         devServerArgs['hot'] = webpackArgs.hot;

--- a/test/serve/serve-variable/serve-basic.test.js
+++ b/test/serve/serve-variable/serve-basic.test.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const path = require('path');
+const getPort = require('get-port');
+const { runServe } = require('../../utils/test-utils');
+
+const testPath = path.resolve(__dirname);
+
+describe('serve variable', () => {
+    let port;
+
+    beforeEach(async () => {
+        port = await getPort();
+    });
+
+    const isWindows = process.platform === 'win32';
+
+    // TODO fix me on windows
+    if (isWindows) {
+        it('TODO: Fix on windows', () => {
+            expect(true).toBe(true);
+        });
+        return;
+    }
+
+    it('compiles without flags and export variable', async () => {
+        const { stdout, stderr } = await runServe(['--port', port], testPath);
+        expect(stdout).toContain('main.js');
+        expect(stdout).not.toContain('HotModuleReplacementPlugin');
+        expect(stderr).toHaveLength(0);
+        expect(stdout).toContain('Variable Defined!');
+    });
+});

--- a/test/serve/serve-variable/serve-basic.test.js
+++ b/test/serve/serve-variable/serve-basic.test.js
@@ -28,6 +28,6 @@ describe('serve variable', () => {
         expect(stdout).toContain('main.js');
         expect(stdout).not.toContain('HotModuleReplacementPlugin');
         expect(stderr).toHaveLength(0);
-        expect(stdout).toContain('Variable Defined!');
+        expect(stdout).toContain('PASS');
     });
 });

--- a/test/serve/serve-variable/src/index.js
+++ b/test/serve/serve-variable/src/index.js
@@ -1,0 +1,1 @@
+console.log('hello world');

--- a/test/serve/serve-variable/webpack.config.js
+++ b/test/serve/serve-variable/webpack.config.js
@@ -1,17 +1,22 @@
 class CustomTestPlugin {
+    constructor(isInEnvironment) {
+        this.isInEnvironment = isInEnvironment;
+    }
     apply(compiler) {
-        compiler.hooks.beforeCompile.tap('testPlugin', () => {
-            if (process.env.WEPACK_SERVE) {
-                console.log('Variable Defined!');
+        compiler.hooks.done.tap('testPlugin', () => {
+            if (process.env.WEBPACK_SERVE && this.isInEnvironment) {
+                console.log('PASS');
             } else {
-                console.log('Not Defined');
+                console.log('FAIL');
             }
         });
     }
 }
 
-module.exports = {
-    mode: 'development',
-    devtool: false,
-    plugins: [new CustomTestPlugin()],
+module.exports = (env) => {
+    return {
+        mode: 'development',
+        devtool: false,
+        plugins: [new CustomTestPlugin(env.process.env.WEBPACK_SERVE)],
+    };
 };

--- a/test/serve/serve-variable/webpack.config.js
+++ b/test/serve/serve-variable/webpack.config.js
@@ -6,7 +6,7 @@ class CustomTestPlugin {
     }
     apply(compiler) {
         compiler.hooks.done.tap('testPlugin', () => {
-            if (isInProcess && this.isInEnvironment) {
+            if (!isInProcess && this.isInEnvironment) {
                 console.log('PASS');
             } else {
                 console.log('FAIL');
@@ -19,6 +19,6 @@ module.exports = (env) => {
     return {
         mode: 'development',
         devtool: false,
-        plugins: [new CustomTestPlugin(env.process.env.WEBPACK_SERVE)],
+        plugins: [new CustomTestPlugin(env.WEBPACK_SERVE)],
     };
 };

--- a/test/serve/serve-variable/webpack.config.js
+++ b/test/serve/serve-variable/webpack.config.js
@@ -1,10 +1,12 @@
+const isInProcess = process.env.WEBPACK_SERVE;
+
 class CustomTestPlugin {
     constructor(isInEnvironment) {
         this.isInEnvironment = isInEnvironment;
     }
     apply(compiler) {
         compiler.hooks.done.tap('testPlugin', () => {
-            if (process.env.WEBPACK_SERVE && this.isInEnvironment) {
+            if (isInProcess && this.isInEnvironment) {
                 console.log('PASS');
             } else {
                 console.log('FAIL');

--- a/test/serve/serve-variable/webpack.config.js
+++ b/test/serve/serve-variable/webpack.config.js
@@ -1,0 +1,17 @@
+class CustomTestPlugin {
+    apply(compiler) {
+        compiler.hooks.beforeCompile.tap('testPlugin', () => {
+            if (process.env.WEPACK_SERVE) {
+                console.log('Variable Defined!');
+            } else {
+                console.log('Not Defined');
+            }
+        });
+    }
+}
+
+module.exports = {
+    mode: 'development',
+    devtool: false,
+    plugins: [new CustomTestPlugin()],
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Add WEBPACK_SERVE variable in environment and in main process if `webpack serve` is used.
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
Yes
**If relevant, did you update the documentation?**
No
**Summary**
Fixes #1973 
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
Yes,
1. Exposing `WEBPACK_SERVE` variable which was earlier `WEBPACK_DEV_SERVER` when dev server was not integrated into CLI.
2. New variable `WEBPACK_SERVE` is now accessable only through `env` argument supplied to webpack configuration of type `function`.
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
/cc @evilebottnawi 