### PR TITLE
fix: parsing of --amd flag

### DIFF
--- a/packages/webpack-cli/lib/groups/basicResolver.js
+++ b/packages/webpack-cli/lib/groups/basicResolver.js
@@ -30,6 +30,9 @@ function resolveArgs(args) {
         if (arg === 'watch') {
             finalOptions.options.watch = true;
         }
+        if (arg === 'amd') {
+            finalOptions.options.amd = args[arg];
+        }
         if (arg === 'entry') {
             finalOptions.options[arg] = args[arg];
         }

--- a/test/core-flags/amd-flag.test.js
+++ b/test/core-flags/amd-flag.test.js
@@ -3,6 +3,15 @@
 const { run } = require('../utils/test-utils');
 
 describe('--no-amd flag', () => {
+    it('throw error for --amd', () => {
+        const { stderr, stdout, exitCode } = run(__dirname, ['--amd']);
+
+        expect(stderr).toContain('Invalid configuration object');
+        expect(stderr).toContain('configuration.amd should be false');
+        expect(exitCode).toBe(2);
+        expect(stdout).toBeFalsy();
+    });
+
     it('should accept --no-amd', () => {
         const { stderr, stdout, exitCode } = run(__dirname, ['--no-amd']);
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
fix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
yes
**If relevant, did you update the documentation?**
no
**Summary**
`amd` can accept only `false` as boolean. Hence only `--no-amd` is valid.

### Before
![Screenshot at 2020-11-05 08-38-11](https://user-images.githubusercontent.com/46647141/98193268-c34f7880-1f42-11eb-8bd8-cf78f912a9a6.png)

### After
![Screenshot at 2020-11-05 08-36-39](https://user-images.githubusercontent.com/46647141/98193289-d2cec180-1f42-11eb-8a06-093d4327a386.png)



<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
Open to suggestions 😄 