### PR TITLE
fix: catch dev server import during webpack serve

### DIFF
--- a/packages/serve/src/startDevServer.ts
+++ b/packages/serve/src/startDevServer.ts
@@ -1,6 +1,10 @@
+import { utils } from 'webpack-cli';
+
 import createConfig from './createConfig';
 import getDevServerOptions from './getDevServerOptions';
 import mergeOptions from './mergeOptions';
+
+const { logger } = utils;
 
 /**
  *
@@ -12,8 +16,14 @@ import mergeOptions from './mergeOptions';
  * @returns {Object[]} array of resulting servers
  */
 export default function startDevServer(compiler, devServerArgs): object[] {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires, node/no-extraneous-require
-    const Server = require('webpack-dev-server/lib/Server');
+    let Server;
+    try {
+        // eslint-disable-next-line node/no-extraneous-require
+        Server = require('webpack-dev-server/lib/Server');
+    } catch (err) {
+        logger.error(`You need to install 'webpack-dev-server' for running 'webpack serve'.\n${err}`);
+        process.exit(2);
+    }
     const cliOptions = createConfig(devServerArgs);
     const devServerOptions = getDevServerOptions(compiler);
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**
No, not sure how to test this behaviour

**If relevant, did you update the documentation?**
NA

**Summary**
- Catch dev server import when importing from webpack-dev-server, in future if FS in dev-server side changes, this can potentially break, so we need to catch this behaviour.

**Does this PR introduce a breaking change?**
No

**Other information**
No