### PR TITLE
fix: use content hash for css assets in init-generator

### DIFF
--- a/packages/generators/__tests__/__snapshots__/init-generator.test.ts.snap
+++ b/packages/generators/__tests__/__snapshots__/init-generator.test.ts.snap
@@ -128,7 +128,7 @@ Object {
   },
   "plugins": Array [
     "new webpack.ProgressPlugin()",
-    "new MiniCssExtractPlugin({ filename:'main.[chunkhash].css' })",
+    "new MiniCssExtractPlugin({ filename:'main.[contenthash].css' })",
   ],
 }
 `;

--- a/packages/generators/src/init-generator.ts
+++ b/packages/generators/src/init-generator.ts
@@ -177,8 +177,7 @@ export default class InitGenerator extends CustomGenerator {
                 );
                 if (cssBundleName.length !== 0) {
                     (this.configuration.config.webpackOptions.plugins as string[]).push(
-                        // TODO: use [contenthash] after it is supported
-                        `new MiniCssExtractPlugin({ filename:'${cssBundleName}.[chunkhash].css' })`,
+                        `new MiniCssExtractPlugin({ filename:'${cssBundleName}.[contenthash].css' })`,
                     );
                 } else {
                     (this.configuration.config.webpackOptions.plugins as string[]).push(


### PR DESCRIPTION
**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**
Updated snapshots

**If relevant, did you update the documentation?**
No

**Summary**
- Using contenthash is preferred for long term caching, clear todo

**Does this PR introduce a breaking change?**
Shouldn't

**Other information**
/cc @evilebottnawi 