### PR TITLE
chore(ci): upgrade to using environment files

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -117,5 +117,5 @@ jobs:
       - run: npm install
       - name: conventional-changelog-lint-config-cz
         # $GITHUB_WORKSPACE is the path to your repository
-        run: echo "::set-env name=NODE_PATH::$GITHUB_WORKSPACE/node_modules"
+        run: echo "NODE_PATH=$GITHUB_WORKSPACE/node_modules" >> $GITHUB_ENV
       - uses: wagoid/commitlint-github-action@v2


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bugfix

**Did you add tests for your changes?**
N/A

**If relevant, did you update the documentation?**
N/A

**Summary**
> The `set-env` command is deprecated and will be disabled on November 16th. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

**Does this PR introduce a breaking change?**
No

**Other information**
