### PR TITLE
fix: respect `stats` from the config for webpack@4

### DIFF
--- a/packages/webpack-cli/lib/webpack-cli.js
+++ b/packages/webpack-cli/lib/webpack-cli.js
@@ -653,7 +653,7 @@ class WebpackCLI {
         compiler = this.createCompiler(options, callback);
 
         // TODO webpack@4 return Watching and MultiWathing instead Compiler and MultiCompiler, remove this after drop webpack@4
-        if (compiler.compiler) {
+        if (compiler && compiler.compiler) {
             compiler = compiler.compiler;
         }
 

--- a/packages/webpack-cli/lib/webpack-cli.js
+++ b/packages/webpack-cli/lib/webpack-cli.js
@@ -652,7 +652,7 @@ class WebpackCLI {
 
         compiler = this.createCompiler(options, callback);
 
-        // TODO webpack@4 return Watching and MultiWathing instad Compiler and MultiCompiler, remove this after drop webpack@4
+        // TODO webpack@4 return Watching and MultiWathing instead Compiler and MultiCompiler, remove this after drop webpack@4
         if (compiler.compiler) {
             compiler = compiler.compiler;
         }

--- a/packages/webpack-cli/lib/webpack-cli.js
+++ b/packages/webpack-cli/lib/webpack-cli.js
@@ -641,11 +641,22 @@ class WebpackCLI {
                     process.exit(2);
                 }
             } else {
-                logger.raw(`${stats.toString(foundStats)}`);
+                const printedStats = stats.toString(foundStats);
+
+                // Avoid extra empty line when `stats: 'none'`
+                if (printedStats) {
+                    logger.raw(`${stats.toString(foundStats)}`);
+                }
             }
         };
 
         compiler = this.createCompiler(options, callback);
+
+        // TODO webpack@4 return Watching and MultiWathing instad Compiler and MultiCompiler, remove this after drop webpack@4
+        if (compiler.compiler) {
+            compiler = compiler.compiler;
+        }
+
         return Promise.resolve();
     }
 }

--- a/test/stats/watch/multi-webpack.config.js
+++ b/test/stats/watch/multi-webpack.config.js
@@ -1,0 +1,10 @@
+module.exports = [
+    {
+        watch: true,
+        stats: 'none',
+    },
+    {
+        watch: true,
+        stats: 'none',
+    },
+];

--- a/test/stats/watch/src/index.js
+++ b/test/stats/watch/src/index.js
@@ -1,0 +1,1 @@
+console.log('TEST');

--- a/test/stats/watch/stats-and-watch.test.js
+++ b/test/stats/watch/stats-and-watch.test.js
@@ -4,19 +4,21 @@ const { runWatch, isWebpack5 } = require('../../utils/test-utils');
 
 describe('stats and watch', () => {
     it('should not log stats with the "none" value from the configuration', async () => {
-        const { stderr, stdout } = await runWatch(__dirname, ['-c', './webpack.config.js']);
+        const { stderr, stdout } = await runWatch(__dirname, ['-c', './webpack.config.js', '--color']);
 
-        expect(stdout).toContain('[webpack-cli] Compilation starting...');
-        expect(stdout).toContain('[webpack-cli] Compilation finished');
-        expect(stdout).toContain('[webpack-cli] watching files for updates...');
+        expect(stdout).toMatchInlineSnapshot(`
+            "[webpack-cli] 
+            [webpack-cli] [32mCompilation finished[39m
+            [webpack-cli] [32mwatching files for updates...[39m"
+        `);
         expect(stderr).toBeFalsy();
     });
 
     it('should not log stats with the "none" value from the configuration and multi compiler mode', async () => {
         const { stderr, stdout } = await runWatch(__dirname, ['-c', './multi-webpack.config.js']);
 
-        expect(stdout).toContain('[webpack-cli] Compilation starting...');
-        expect(stdout).toContain('[webpack-cli] Compilation finished');
+        expect(stdout).toMatchInlineSnapshot('[webpack-cli] [32mCompilation starting...[39m');
+        expect(stdout).toContain('[webpack-cli] [32mCompilation starting...[39m');
         expect(stdout).toContain('[webpack-cli] watching files for updates...');
         expect(stderr).toBeFalsy();
     });

--- a/test/stats/watch/stats-and-watch.test.js
+++ b/test/stats/watch/stats-and-watch.test.js
@@ -13,7 +13,7 @@ describe('stats and watch', () => {
     });
 
     it('should not log stats with the "none" value from the configuration and multi compiler mode', async () => {
-        const { stderr, stdout } = await runWatch(__dirname, ['-c', './multi-webpack.config.js']);
+        const { stderr, stdout } = await runWatch(__dirname, ['-c', './multi-webpack.config.js', '--color']);
 
         expect(stdout).toContain('[webpack-cli] [32mCompilation starting...[39m');
         expect(stdout).toContain('[webpack-cli] [32mCompilation finished[39m');
@@ -22,7 +22,7 @@ describe('stats and watch', () => {
     });
 
     it('should log stats with the "normal" value in arguments', async () => {
-        const { stderr, stdout } = await runWatch(__dirname, ['-c', './webpack.config.js', '--stats', 'normal']);
+        const { stderr, stdout } = await runWatch(__dirname, ['-c', './webpack.config.js', '--stats', 'normal', '--color']);
 
         const output = isWebpack5 ? 'successfully' : 'main.js';
 

--- a/test/stats/watch/stats-and-watch.test.js
+++ b/test/stats/watch/stats-and-watch.test.js
@@ -6,20 +6,18 @@ describe('stats and watch', () => {
     it('should not log stats with the "none" value from the configuration', async () => {
         const { stderr, stdout } = await runWatch(__dirname, ['-c', './webpack.config.js', '--color']);
 
-        expect(stdout).toMatchInlineSnapshot(`
-            "[webpack-cli] 
-            [webpack-cli] [32mCompilation finished[39m
-            [webpack-cli] [32mwatching files for updates...[39m"
-        `);
+        expect(stdout).toContain('[webpack-cli] [32mCompilation starting...[39m');
+        expect(stdout).toContain('[webpack-cli] [32mCompilation finished[39m');
+        expect(stdout).toContain('[webpack-cli] [32mwatching files for updates...[39m');
         expect(stderr).toBeFalsy();
     });
 
     it('should not log stats with the "none" value from the configuration and multi compiler mode', async () => {
         const { stderr, stdout } = await runWatch(__dirname, ['-c', './multi-webpack.config.js']);
 
-        expect(stdout).toMatchInlineSnapshot('[webpack-cli] [32mCompilation starting...[39m');
         expect(stdout).toContain('[webpack-cli] [32mCompilation starting...[39m');
-        expect(stdout).toContain('[webpack-cli] watching files for updates...');
+        expect(stdout).toContain('[webpack-cli] [32mCompilation finished[39m');
+        expect(stdout).toContain('[webpack-cli] [32mwatching files for updates...[39m');
         expect(stderr).toBeFalsy();
     });
 
@@ -28,10 +26,10 @@ describe('stats and watch', () => {
 
         const output = isWebpack5 ? 'successfully' : 'main.js';
 
-        expect(stdout).toContain('[webpack-cli] Compilation starting...');
-        expect(stdout).toContain('[webpack-cli] Compilation finished');
+        expect(stdout).toContain('[webpack-cli] [32mCompilation starting...[39m');
+        expect(stdout).toContain('[webpack-cli] [32mCompilation finished[39m');
+        expect(stdout).toContain('[webpack-cli] [32mwatching files for updates...[39m');
         expect(stdout).toContain(output);
-        expect(stdout).toContain('[webpack-cli] watching files for updates...');
         expect(stderr).toBeFalsy();
     });
 });

--- a/test/stats/watch/watch.test.js
+++ b/test/stats/watch/watch.test.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const { runWatch, isWebpack5 } = require('../../utils/test-utils');
+
+describe('stats and watch', () => {
+    it('should not log stats with the "none" value from the configuration', async () => {
+        const { stderr, stdout } = await runWatch(__dirname, ['-c', './webpack.config.js']);
+
+        expect(stdout).toContain('[webpack-cli] Compilation starting...');
+        expect(stdout).toContain('[webpack-cli] Compilation finished');
+        expect(stdout).toContain('[webpack-cli] watching files for updates...');
+        expect(stderr).toBeFalsy();
+    });
+
+    it('should not log stats with the "none" value from the configuration and multi compiler mode', async () => {
+        const { stderr, stdout } = await runWatch(__dirname, ['-c', './multi-webpack.config.js']);
+
+        expect(stdout).toContain('[webpack-cli] Compilation starting...');
+        expect(stdout).toContain('[webpack-cli] Compilation finished');
+        expect(stdout).toContain('[webpack-cli] watching files for updates...');
+        expect(stderr).toBeFalsy();
+    });
+
+    it('should log stats with the "normal" value in arguments', async () => {
+        const { stderr, stdout } = await runWatch(__dirname, ['-c', './webpack.config.js', '--stats', 'normal']);
+
+        const output = isWebpack5 ? 'successfully' : 'main.js';
+
+        expect(stdout).toContain('[webpack-cli] Compilation starting...');
+        expect(stdout).toContain('[webpack-cli] Compilation finished');
+        expect(stdout).toContain(output);
+        expect(stdout).toContain('[webpack-cli] watching files for updates...');
+        expect(stderr).toBeFalsy();
+    });
+});

--- a/test/stats/watch/webpack.config.js
+++ b/test/stats/watch/webpack.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+    watch: true,
+    stats: 'none',
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**

Yes

**If relevant, did you update the documentation?**

No

**Summary**

fixes #2052

**Does this PR introduce a breaking change?**

No

**Other information**

webpack@4 doesn't return `compier` when `watch: true` in the config, fixed in webpack@5