### PR TITLE
fix(serve): do not default host in webpack-dev-server v4

### DIFF
--- a/packages/serve/src/startDevServer.ts
+++ b/packages/serve/src/startDevServer.ts
@@ -36,9 +36,9 @@ export default function startDevServer(compiler, cliOptions): object[] {
     const usedPorts: number[] = [];
     devServerOptions.forEach((devServerOpts): void => {
         const options = mergeOptions(cliOptions, devServerOpts);
-        options.host = options.host || 'localhost';
-        // devSever v4 handles the default port itself
+        // devSever v4 handles the default host and port itself
         if (!isDevServer4) {
+            options.host = options.host || 'localhost';
             options.port = options.port || 8080;
         }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bug fix

**Did you add tests for your changes?**
Integration tests will be possible once after webpack-dev-server v4 has been released.

**If relevant, did you update the documentation?**
N/A

**Summary**
https://github.com/webpack/webpack-cli/pull/2126#discussion_r529471961

With https://github.com/webpack/webpack-dev-server/pull/2869, it'd be possible to pass `undefined` as the host to let `listen()` handle the address to bind to.

Depends on the PR above.

**Does this PR introduce a breaking change?**
N/A

**Other information**
