### PR TITLE
fix(serve): set client port when using default port

### DIFF
--- a/packages/serve/__tests__/mergeOptions.test.ts
+++ b/packages/serve/__tests__/mergeOptions.test.ts
@@ -1,12 +1,13 @@
 'use strict';
 
 import mergeOptions from '../src/mergeOptions';
+import { devServerClientLogging } from '../src/types';
 
 describe('mergeOptions', () => {
     it('merges CLI and devServer options correctly', () => {
         const cliOptions = {
             client: {
-                logging: 'verbose',
+                logging: devServerClientLogging.verbose,
             },
             hot: true,
             bonjour: true,
@@ -14,7 +15,7 @@ describe('mergeOptions', () => {
         const devServerOptions = {
             client: {
                 host: 'localhost',
-                logging: 'none',
+                logging: devServerClientLogging.none,
             },
             hot: false,
             liveReload: false,

--- a/packages/serve/__tests__/startDevServer.test.ts
+++ b/packages/serve/__tests__/startDevServer.test.ts
@@ -14,7 +14,7 @@ describe('startDevServer', () => {
         DevServer.mockClear();
     });
 
-    it('should start dev server correctly for single compiler', () => {
+    it('should start dev server correctly for single compiler', async () => {
         const config = {
             devServer: {
                 port: 9000,
@@ -24,7 +24,7 @@ describe('startDevServer', () => {
         };
         const compiler = webpack(config);
 
-        const servers = startDevServer(compiler, {
+        const servers = await startDevServer(compiler, {
             host: 'my.host',
             hot: true,
             progress: true,
@@ -43,13 +43,13 @@ describe('startDevServer', () => {
         expect(DevServer.mock.instances[0].listen.mock.calls[0]).toMatchSnapshot();
     });
 
-    it('should set default port and host if not provided', () => {
+    it('should set default port and host if not provided', async () => {
         const config = {
             devServer: {},
         };
         const compiler = webpack(config);
 
-        const servers = startDevServer(compiler, {});
+        const servers = await startDevServer(compiler, {});
 
         expect(servers.length).toEqual(1);
         expect(servers).toEqual(DevServer.mock.instances);
@@ -64,7 +64,7 @@ describe('startDevServer', () => {
         expect(DevServer.mock.instances[0].listen.mock.calls[0]).toMatchSnapshot();
     });
 
-    it('should start dev server correctly for multi compiler with 1 devServer config', () => {
+    it('should start dev server correctly for multi compiler with 1 devServer config', async () => {
         const config = [
             {
                 devServer: {
@@ -77,7 +77,7 @@ describe('startDevServer', () => {
         ];
         const compiler = webpack(config);
 
-        const servers = startDevServer(compiler, {
+        const servers = await startDevServer(compiler, {
             host: 'my.host',
             hot: true,
             progress: true,
@@ -96,7 +96,7 @@ describe('startDevServer', () => {
         expect(DevServer.mock.instances[0].listen.mock.calls[0]).toMatchSnapshot();
     });
 
-    it('should start dev servers correctly for multi compiler with 2 devServer configs', () => {
+    it('should start dev servers correctly for multi compiler with 2 devServer configs', async () => {
         const config = [
             {
                 devServer: {
@@ -113,7 +113,7 @@ describe('startDevServer', () => {
         ];
         const compiler = webpack(config);
 
-        const servers = startDevServer(compiler, {
+        const servers = await startDevServer(compiler, {
             // this progress CLI flag should override progress: false above
             progress: true,
         });
@@ -137,8 +137,8 @@ describe('startDevServer', () => {
         expect(DevServer.mock.instances[1].listen.mock.calls[0]).toMatchSnapshot();
     });
 
-    it('should handle 2 multi compiler devServer configs with conflicting ports', () => {
-        expect(() => {
+    it('should handle 2 multi compiler devServer configs with conflicting ports', async () => {
+        await expect(async () => {
             const config = [
                 {
                     devServer: {
@@ -153,8 +153,8 @@ describe('startDevServer', () => {
             ];
             const compiler = webpack(config);
 
-            startDevServer(compiler, {});
-        }).toThrow(
+            await startDevServer(compiler, {});
+        }).rejects.toThrow(
             'Unique ports must be specified for each devServer option in your webpack configuration. Alternatively, run only 1 devServer config using the --config-name flag to specify your desired config.',
         );
     });

--- a/packages/serve/src/types.ts
+++ b/packages/serve/src/types.ts
@@ -1,6 +1,6 @@
 export type devServerOptionsType = {
     bonjour?: boolean;
-    client?: object;
+    client?: devServerClientOptions;
     compress?: boolean;
     dev?: object;
     firewall?: boolean | string[];
@@ -28,3 +28,20 @@ export type devServerOptionsType = {
     transportMode?: object | string;
     useLocalIp?: boolean;
 };
+
+type devServerClientOptions = {
+    host?: string;
+    path?: string;
+    port?: string | number | null;
+    logging?: devServerClientLogging;
+    progress?: boolean;
+};
+
+export enum devServerClientLogging {
+    none = 'none',
+    error = 'error',
+    warn = 'warn',
+    info = 'info',
+    log = 'log',
+    verbose = 'verbose',
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Resolves https://github.com/webpack/webpack-dev-server/issues/2873. This fixes a regression where `webpack serve` is not equivalent to the older `webpack-dev-server` command.

**Did you add tests for your changes?**

No, since the serve plugin's tests only run on webpack-dev-server@3 and my changes only apply to webpack-dev-server@4. If there is a way to run certain tests against different versions of webpack-dev-server, I'm happy to add tests.

**If relevant, did you update the documentation?**

N/A

**Summary**

webpack-dev-server adds a new entry point which loads the webpack-dev-server webpack client. The entry has a resource query which determines the host, port, and protocol of the websocket connection. That resource query must be created *synchronously*, since modifying the entry points must be done synchronously before webpack starts compilation. The problem is that `findPort()` (used within webpack-dev-server to find a default server port) is asynchronous.

webpack-dev-server@3 worked around this issue by having the webpack-dev-server CLI delay starting webpack until `findPort()` finishes. The following code shows where this used to happen:

https://github.com/webpack/webpack-dev-server/blob/4ab1f21bc85cc1695255c739160ad00dc14375f1/bin/webpack-dev-server.js#L165-L167

https://github.com/webpack/webpack-dev-server/blob/4ab1f21bc85cc1695255c739160ad00dc14375f1/lib/utils/processOptions.js#L30-L34

When the webpack-dev-server CLI was abandoned in favor of `webpack serve`, this behavior was lost. As a result, the webpack-dev-server socket client attempts to connect to the wrong port when you let webpack-dev-server find a default port for you.

I made the code change here in webpack-cli because it is the equivalent to the previous webpack-dev-server CLI code. I do not believe that any code change to webpack-dev-server could solve this issue, since the entries must be modified synchronously but findPort() is asynchronous.

**Does this PR introduce a breaking change?**

I don't think so. The `startDevServer` function within `@webpack-cli/serve` has changed to return a promise, but its use seems to be entirely internal to webpack-cli and so I don't consider it part of the package's public API.

**Other information**
