### PR TITLE
fix: continue to print stats after storing as json

### DIFF
--- a/packages/webpack-cli/lib/webpack-cli.js
+++ b/packages/webpack-cli/lib/webpack-cli.js
@@ -488,19 +488,20 @@ class WebpackCLI {
 
             if (args.json === true) {
                 process.stdout.write(JSON.stringify(stats.toJson(foundStats), null, 2) + '\n');
-            } else if (typeof args.json === 'string') {
-                const JSONStats = JSON.stringify(stats.toJson(foundStats), null, 2);
-
-                try {
-                    writeFileSync(args.json, JSONStats);
-
-                    logger.success(`stats are successfully stored as json to ${args.json}`);
-                } catch (error) {
-                    logger.error(error);
-
-                    process.exit(2);
-                }
             } else {
+                if (typeof args.json === 'string') {
+                    const JSONStats = JSON.stringify(stats.toJson(foundStats), null, 2);
+
+                    try {
+                        writeFileSync(args.json, JSONStats);
+
+                        logger.success(`stats are successfully stored as json to ${args.json}`);
+                    } catch (error) {
+                        logger.error(error);
+
+                        process.exit(2);
+                    }
+                }
                 const printedStats = stats.toString(foundStats);
 
                 // Avoid extra empty line when `stats: 'none'`

--- a/test/json/json.test.js
+++ b/test/json/json.test.js
@@ -7,18 +7,22 @@ const successMessage = 'stats are successfully stored as json to stats.json';
 
 describe('json flag', () => {
     it('should return valid json', () => {
-        const { stdout, exitCode } = run(__dirname, ['--json']);
-        expect(() => JSON.parse(stdout)).not.toThrow();
+        const { exitCode, stderr, stdout } = run(__dirname, ['--json']);
+
         expect(exitCode).toBe(0);
+        expect(stderr).toBeFalsy();
+        expect(() => JSON.parse(stdout)).not.toThrow();
         expect(JSON.parse(stdout)['hash']).toBeDefined();
     });
 
     it('should store json to a file', (done) => {
-        const { stdout, exitCode } = run(__dirname, ['--json', 'stats.json']);
+        const { exitCode, stderr, stdout } = run(__dirname, ['--json', 'stats.json']);
 
         expect(stdout).toContain(successMessage);
+        expect(stderr).toBeFalsy();
         expect(exitCode).toBe(0);
         expect(existsSync(resolve(__dirname, './stats.json'))).toBeTruthy();
+
         readFile(resolve(__dirname, 'stats.json'), 'utf-8', (err, data) => {
             expect(err).toBe(null);
             expect(JSON.parse(data)['hash']).toBeTruthy();
@@ -30,10 +34,13 @@ describe('json flag', () => {
     });
 
     it('should store json to a file and respect --color flag', (done) => {
-        const { stdout, exitCode } = run(__dirname, ['--json', 'stats.json', '--color']);
+        const { exitCode, stderr, stdout } = run(__dirname, ['--json', 'stats.json', '--color']);
 
-        expect(stdout).toContain(`[webpack-cli] \u001b[32m${successMessage}`);
         expect(exitCode).toBe(0);
+        expect(stderr).toBeFalsy();
+        expect(stdout).toContain(`[webpack-cli] \u001b[32m${successMessage}`);
+        // should print stats too
+        expect(stdout).toContain('./src/index.js');
 
         expect(existsSync(resolve(__dirname, './stats.json'))).toBeTruthy();
 
@@ -48,11 +55,14 @@ describe('json flag', () => {
     });
 
     it('should store json to a file and respect --no-color', (done) => {
-        const { stdout, exitCode } = run(__dirname, ['--json', 'stats.json', '--no-color']);
+        const { exitCode, stderr, stdout } = run(__dirname, ['--json', 'stats.json', '--no-color']);
 
+        expect(exitCode).toBe(0);
+        expect(stderr).toBeFalsy();
         expect(stdout).not.toContain(`[webpack-cli] \u001b[32m${successMessage}`);
         expect(stdout).toContain(`[webpack-cli] ${successMessage}`);
-        expect(exitCode).toBe(0);
+        // should print stats too
+        expect(stdout).toContain('./src/index.js');
 
         expect(existsSync(resolve(__dirname, './stats.json'))).toBeTruthy();
 
@@ -67,9 +77,31 @@ describe('json flag', () => {
     });
 
     it('should return valid json with -j alias', () => {
-        const { stdout, exitCode } = run(__dirname, ['-j']);
-        expect(() => JSON.parse(stdout)).not.toThrow();
+        const { exitCode, stderr, stdout } = run(__dirname, ['-j']);
+
         expect(exitCode).toBe(0);
+        expect(stderr).toBeFalsy();
+        expect(() => JSON.parse(stdout)).not.toThrow();
         expect(JSON.parse(stdout)['hash']).toBeDefined();
+    });
+
+    it('should store valid json with -j alias', (done) => {
+        const { exitCode, stderr, stdout } = run(__dirname, ['-j', 'stats.json']);
+
+        expect(exitCode).toBe(0);
+        expect(stderr).toBeFalsy();
+        expect(stdout).toContain(successMessage);
+        // should print stats too
+        expect(stdout).toContain('./src/index.js');
+        expect(existsSync(resolve(__dirname, './stats.json'))).toBeTruthy();
+
+        readFile(resolve(__dirname, 'stats.json'), 'utf-8', (err, data) => {
+            expect(err).toBe(null);
+            expect(JSON.parse(data)['hash']).toBeTruthy();
+            expect(JSON.parse(data)['version']).toBeTruthy();
+            expect(JSON.parse(data)['time']).toBeTruthy();
+            expect(() => JSON.parse(data)).not.toThrow();
+            done();
+        });
     });
 });

--- a/test/json/webpack.config.js
+++ b/test/json/webpack.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+    mode: 'development',
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
fix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
yes
**If relevant, did you update the documentation?**
no
**Summary**
continue to print stats after storing as JSON. 

### Before
![Screenshot at 2020-12-02 07-47-15](https://user-images.githubusercontent.com/46647141/100819661-9d9a8e00-3472-11eb-8a20-f865b0f22dfb.png)

### After
![Screenshot at 2020-12-02 07-29-51](https://user-images.githubusercontent.com/46647141/100819610-82c81980-3472-11eb-9bc9-3d4da97036a3.png)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
https://github.com/webpack/webpack-cli/pull/2152#issuecomment-736934318