### PR TITLE
fix: remove unnecessary group filtering in flags

### DIFF
--- a/packages/webpack-cli/lib/utils/cli-flags.js
+++ b/packages/webpack-cli/lib/utils/cli-flags.js
@@ -271,10 +271,10 @@ const coreFlags = cli
           const inBuiltIn = builtInFlags.find((builtInFlag) => builtInFlag.name === flag);
 
           if (inBuiltIn) {
-              return { ...meta, name: flag, group: 'core', ...inBuiltIn };
+              return { ...meta, name: flag, ...inBuiltIn };
           }
 
-          return { ...meta, name: flag, group: 'core' };
+          return { ...meta, name: flag };
       })
     : [];
 const flags = []
@@ -290,5 +290,6 @@ module.exports = {
     commands,
     cli,
     flags,
+    coreFlags,
     isCommandUsed,
 };

--- a/packages/webpack-cli/lib/webpack-cli.js
+++ b/packages/webpack-cli/lib/webpack-cli.js
@@ -6,7 +6,7 @@ const { writeFileSync, existsSync } = require('fs');
 const { options: coloretteOptions, yellow } = require('colorette');
 
 const logger = require('./utils/logger');
-const { cli, flags } = require('./utils/cli-flags');
+const { cli, flags, coreFlags } = require('./utils/cli-flags');
 const argParser = require('./utils/arg-parser');
 const CLIPlugin = require('./plugins/CLIPlugin');
 const promptInstallation = require('./utils/prompt-installation');
@@ -230,13 +230,11 @@ class WebpackCLI {
 
         if (cli) {
             const processArguments = (options) => {
-                const coreFlagMap = flags
-                    .filter((flag) => flag.group === 'core')
-                    .reduce((accumulator, flag) => {
-                        accumulator[flag.name] = flag;
+                const coreFlagMap = coreFlags.reduce((accumulator, flag) => {
+                    accumulator[flag.name] = flag;
 
-                        return accumulator;
-                    }, {});
+                    return accumulator;
+                }, {});
                 const coreConfig = Object.keys(args).reduce((accumulator, name) => {
                     const kebabName = toKebabCase(name);
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**
refactor/perf improvement

**Did you add tests for your changes?**
Yes

**If relevant, did you update the documentation?**
NA

**Summary**
- Removes unnecessary group filtering for core flags, we can use them directly

**Does this PR introduce a breaking change?**
No

**Other information**
