### PR TITLE
fix: flaky cache test on macOS

### DIFF
--- a/test/cache/cache.test.js
+++ b/test/cache/cache.test.js
@@ -35,7 +35,7 @@ describe('cache', () => {
     });
 
     it('should work in multi compiler mode', () => {
-        rimraf.sync(path.join(__dirname, '../../node_modules/.cache/webpack/cache-test-{first,second}-development'));
+        rimraf.sync(path.join(__dirname, '../../node_modules/.cache/webpack/**'));
 
         let { exitCode, stderr, stdout } = run(__dirname, ['-c', './multi.config.js'], false);
 
@@ -47,7 +47,7 @@ describe('cache', () => {
             expect(stderr).toContain("Compilation 'cache-test-second' starting...");
             expect(stderr).toContain("Compilation 'cache-test-second' finished");
             expect(stderr.match(/No pack exists at/g)).toHaveLength(2);
-            expect(stderr.match(/Stored pack/g).length).toBeGreaterThan(1);
+            expect(stderr.match(/Stored pack/g)).toHaveLength(2);
             expect(stdout).toBeTruthy();
         }
 

--- a/test/cache/cache.test.js
+++ b/test/cache/cache.test.js
@@ -47,7 +47,7 @@ describe('cache', () => {
             expect(stderr).toContain("Compilation 'cache-test-second' starting...");
             expect(stderr).toContain("Compilation 'cache-test-second' finished");
             expect(stderr.match(/No pack exists at/g)).toHaveLength(2);
-            expect(stderr.match(/Stored pack/g)).toHaveLength(2);
+            expect(stderr.match(/Stored pack/g).length).toBeGreaterThan(1);
             expect(stdout).toBeTruthy();
         }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
tests, fix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
yes
**If relevant, did you update the documentation?**
no
**Summary**
I see some flakiness in the cache test on macOS after the release of `5.10.0`.

References - 
https://github.com/webpack/webpack-cli/runs/1503646276?check_suite_focus=true
https://github.com/webpack/webpack-cli/runs/1503607410?check_suite_focus=true
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
no