### PR TITLE
Stringify stats using streaming approach

### DIFF
--- a/packages/webpack-cli/package.json
+++ b/packages/webpack-cli/package.json
@@ -27,6 +27,7 @@
     "lib"
   ],
   "dependencies": {
+    "@discoveryjs/json-ext": "^0.5.0",
     "@webpack-cli/info": "^1.1.0",
     "@webpack-cli/serve": "^1.1.0",
     "colorette": "^1.2.1",


### PR DESCRIPTION
**What kind of change does this PR introduce?**

This PR changes the approach for stats stringify to use stream instead of JSON.stringify() + sync write. No API or functionality is changed.

**Did you add tests for your changes?**

No

**If relevant, did you update the documentation?**

Not needed

**Summary**

It makes stats available for huge projects. Changes has the follow effects:
- Memory
  - Allows to avoid max string length limit of V8 engine (500MB). In other words, stats becomes available for huge projects, whose stats exceed 500MB.
  - Reduces memory consumption on serialization.
- Adds time penalty. However, this make sense for huge stats only and seems to be an acceptable, given that otherwise stats may be unavailable (due max string limit hit or out of memory).
- Adds new dependency "json-ext", which is dependency free and most effective solution for a huge JSON parse/stringify at the moment. Other solutions have troubles to handle huge JSON (see [benchmark](https://github.com/discoveryjs/json-ext/blob/master/benchmarks/README.md#stream-stringifying)).

**Does this PR introduce a breaking change?**

No

**Other information**

Tested on AST Explorer (https://github.com/fkling/astexplorer)

Command (cwd website):
> npm run build -- --json stats.json

### BEFORE:
> fs.writeFileSync(dest, JSON.stringify(stats.toJson(...)))

Time: 4583ms
Memory used: +1_850_027_831 (heap: +1_508_459_432, external: +341_568_399)

### AFTER:
> createJsonStringifyStream(stats.toJson(...)).pipe(fs.createWriteStream(dest))

Time: 5881ms
Memory used: -90_171_587 (heap: -32_339_984, external: -57_831_603)

So it's a bit slower, but much effective in memory consumption.