### PR TITLE
fix: do not run CI on docs changes

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -5,10 +5,14 @@ on:
     branches:
       - master
       - next
+    paths:
+      - '!**.md'
   pull_request:
     branches:
       - master
       - next
+    paths:
+      - '!**.md'
   workflow_dispatch:
     inputs:
       tags:


### PR DESCRIPTION
**What kind of change does this PR introduce?**
fix

**Did you add tests for your changes?**
no

**If relevant, did you update the documentation?**
no

**Summary**
Running CI for docs changes is useless and takes up CI time unnecessarily

**Does this PR introduce a breaking change?**
no

**Other information**
/cc evilebot @alexander-akait 