### PR TITLE
Using bundleCommand instead of createCompiler in webpack-cli/serve

### DIFF
--- a/packages/serve/src/index.ts
+++ b/packages/serve/src/index.ts
@@ -80,7 +80,7 @@ class ServeCommand {
 
                 webpackOptions.env = { WEBPACK_SERVE: true, ...options.env };
 
-                const compiler = await cli.createCompiler(webpackOptions);
+                const compiler = await cli.bundleCommand(webpackOptions);
 
                 if (!compiler) {
                     return;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**
Need help as this is my first time contributing to webpack

**If relevant, did you update the documentation?**
N/A

**Summary**
- The serve command uses [webpack-cli](https://github.com/webpack/webpack-cli/blob/master/packages/serve/src/index.ts#L83) but it creates a compiler without options which gives a deprecation warning on webpack@5, this one uses changes the use to [bundleCommand](https://github.com/webpack/webpack-cli/blob/master/packages/webpack-cli/lib/webpack-cli.js#L1124), which wraps the callabck inside it

This results in this error - [Issue#1918](https://github.com/webpack/webpack-cli/issues/1918) when we run
- `npx webpack-dev-server --watch`

**Does this PR introduce a breaking change?**
No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
@alexander-akait 