### PR TITLE
feat: allow to pass parseOption to CLI class

### DIFF
--- a/packages/webpack-cli/lib/index.js
+++ b/packages/webpack-cli/lib/index.js
@@ -1,13 +1,7 @@
-const WebpackCLI = require('./webpack-cli');
-const { commands } = require('./utils/cli-flags');
+const CLI = require('./webpack-cli');
 const logger = require('./utils/logger');
 const getPackageManager = require('./utils/get-package-manager');
 
-module.exports = WebpackCLI;
-
+module.exports = CLI;
 // export additional utils used by other packages
-module.exports.utils = {
-    logger,
-    commands,
-    getPackageManager,
-};
+module.exports.utils = { logger, getPackageManager };

--- a/packages/webpack-cli/lib/webpack-cli.js
+++ b/packages/webpack-cli/lib/webpack-cli.js
@@ -219,7 +219,7 @@ class WebpackCLI {
         return flags;
     }
 
-    async run(args) {
+    async run(args, parseOptions) {
         // Built-in internal commands
         const bundleCommandOptions = {
             name: 'bundle',
@@ -708,7 +708,7 @@ class WebpackCLI {
             await this.program.parseAsync([commandName, ...options], { from: 'user' });
         });
 
-        await this.program.parseAsync(args);
+        await this.program.parseAsync(args, parseOptions);
     }
 
     async resolveConfig(options) {
@@ -732,7 +732,7 @@ class WebpackCLI {
                     }
 
                     logger.error(error);
-                    process.exit(2);
+                    // process.exit(2);
                 }
             }
 

--- a/packages/webpack-cli/lib/webpack-cli.js
+++ b/packages/webpack-cli/lib/webpack-cli.js
@@ -732,7 +732,7 @@ class WebpackCLI {
                     }
 
                     logger.error(error);
-                    // process.exit(2);
+                    process.exit(2);
                 }
             }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

feature

**Did you add tests for your changes?**

No, it is for future tests and public API

**If relevant, did you update the documentation?**

No need right now, it is not public

**Summary**

For tests

**Does this PR introduce a breaking change?**

No

**Other information**

Fix export, bevause we don't have commands right now, and we should pass `cli` instance to commands instead export utils