### PR TITLE
fix(init): remove style-loader from the loader chain

### DIFF
--- a/packages/generators/__tests__/__snapshots__/init-generator.test.ts.snap
+++ b/packages/generators/__tests__/__snapshots__/init-generator.test.ts.snap
@@ -112,9 +112,6 @@ Object {
             "loader": "MiniCssExtractPlugin.loader",
           },
           Object {
-            "loader": "\\"style-loader\\"",
-          },
-          Object {
             "loader": "\\"css-loader\\"",
             "options": Object {
               "sourceMap": true,

--- a/packages/generators/__tests__/init-generator.test.ts
+++ b/packages/generators/__tests__/init-generator.test.ts
@@ -113,10 +113,9 @@ describe('init generator', () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const config = (Object.entries(output)[0][1] as any).configuration.config.webpackOptions;
         expect(config.module.rules[0].test).toEqual('/.css$/');
-        expect(config.module.rules[0].use.length).toEqual(3);
+        expect(config.module.rules[0].use.length).toEqual(2);
         expect(config.module.rules[0].use[0].loader).toEqual('MiniCssExtractPlugin.loader');
-        expect(config.module.rules[0].use[1].loader).toEqual('"style-loader"');
-        expect(config.module.rules[0].use[2].loader).toEqual('"css-loader"');
+        expect(config.module.rules[0].use[1].loader).toEqual('"css-loader"');
         //match config snapshot
         expect(config).toMatchSnapshot();
     });

--- a/packages/generators/src/init-generator.ts
+++ b/packages/generators/src/init-generator.ts
@@ -187,6 +187,9 @@ export default class InitGenerator extends CustomGenerator {
                     );
                 }
 
+                // Remove style-loader from the loader chain
+                ExtractUseProps.shift();
+
                 ExtractUseProps.unshift({
                     loader: 'MiniCssExtractPlugin.loader',
                 });

--- a/test/init/language/css/init-language-css.test.js
+++ b/test/init/language/css/init-language-css.test.js
@@ -49,9 +49,6 @@ describe('init with SCSS', () => {
                         loader: MiniCssExtractPlugin.loader, // eslint-disable-line
                     },
                     {
-                        loader: 'style-loader',
-                    },
-                    {
                         loader: 'css-loader',
 
                         options: {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
bugfix

**Did you add tests for your changes?**
Updated existing test suite.

**If relevant, did you update the documentation?**
N/A

**Summary**
Do not use `style-loader` and `mini-css-extract-plugin` together in the loaders chain.
closes #2308 

**Does this PR introduce a breaking change?**
Nope

**Other information**
N/A