### PR TITLE
docs: fix broken references

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ Thus, webpack CLI provides different commands for many common tasks.
 -   [`webpack-cli init`](./packages/init/README.md#webpack-cli-init) - Create a new webpack configuration.
 -   [`webpack-cli info`](./packages/info/README.md#webpack-cli-info) - Returns information related to the local environment.
 -   [`webpack-cli migrate`](./packages/migrate/README.md#webpack-cli-migrate) - Migrate project from one version to another.
--   [`webpack-cli plugin`](./packages/generate-plugin/README.md#webpack-cli-generate-plugin) - Initiate new plugin project.
--   [`webpack-cli loader`](./packages/generate-loader/README.md#webpack-cli-generate-loader) - Initiate new loader project.
+-   [`webpack-cli plugin`](./packages/generators#generators) - Initiate new plugin project.
+-   [`webpack-cli loader`](./packages/generators#generators) - Initiate new loader project.
 -   [`webpack-cli serve`](./packages/serve/README.md#webpack-cli-serve) - Use webpack with a development server that provides live reloading.
 
 ### Utilities

--- a/packages/README.md
+++ b/packages/README.md
@@ -13,15 +13,13 @@ This folder is the collection of those packages.
 
 ## Packages
 
-1. [generate-loader](https://github.com/webpack/webpack-cli/tree/master/packages/generate-loader)
-2. [generate-plugin](https://github.com/webpack/webpack-cli/tree/master/packages/generate-plugin)
-3. [generators](https://github.com/webpack/webpack-cli/tree/master/packages/generators)
-4. [info](https://github.com/webpack/webpack-cli/tree/master/packages/info)
-5. [init](https://github.com/webpack/webpack-cli/tree/master/packages/init)
-6. [migrate](https://github.com/webpack/webpack-cli/tree/master/packages/migrate)
-7. [serve](https://github.com/webpack/webpack-cli/tree/master/packages/serve)
-8. [utils](https://github.com/webpack/webpack-cli/tree/master/packages/utils)
-9. [webpack-cli](https://github.com/webpack/webpack-cli/tree/master/packages/webpack-cli)
+1. [generators](https://github.com/webpack/webpack-cli/tree/master/packages/generators)
+2. [info](https://github.com/webpack/webpack-cli/tree/master/packages/info)
+3. [init](https://github.com/webpack/webpack-cli/tree/master/packages/init)
+4. [migrate](https://github.com/webpack/webpack-cli/tree/master/packages/migrate)
+5. [serve](https://github.com/webpack/webpack-cli/tree/master/packages/serve)
+6. [utils](https://github.com/webpack/webpack-cli/tree/master/packages/utils)
+7. [webpack-cli](https://github.com/webpack/webpack-cli/tree/master/packages/webpack-cli)
 
 ## Generic Installation
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Docs update

**Did you add tests for your changes?**
N/A

**If relevant, did you update the documentation?**
Yup

**Summary**
`generate-plugin` and `generate-loader` packages were unioned into the `generators` package; however, docs had outdated references.

**Does this PR introduce a breaking change?**
Nope

**Other information**
N/A