### PR TITLE
fix: improve init generator

### DIFF
--- a/packages/generators/__tests__/__snapshots__/init-generator.test.ts.snap
+++ b/packages/generators/__tests__/__snapshots__/init-generator.test.ts.snap
@@ -188,7 +188,7 @@ Object {
     "host": "'localhost'",
     "open": true,
   },
-  "mode": "'production'",
+  "mode": "'development'",
   "module": Object {
     "rules": Array [],
   },

--- a/packages/generators/__tests__/init-generator.test.ts
+++ b/packages/generators/__tests__/init-generator.test.ts
@@ -13,14 +13,13 @@ describe('init generator', () => {
         });
 
         // Check that all the project files are generated with the correct name
-        const filePaths = ['package.json', 'README.md', 'src/index.js', 'sw.js'];
+        const filePaths = ['package.json', 'README.md', 'src/index.js'];
         assert.file(filePaths.map((file) => join(outputDir, file)));
 
         // Check generated file contents
         assert.fileContent(join(outputDir, 'package.json'), '"name": "my-webpack-project"');
         assert.fileContent(join(outputDir, 'README.md'), 'Welcome to your new awesome project!');
         assert.fileContent(join(outputDir, 'src', 'index.js'), "console.log('Hello World from your main file!');");
-        assert.fileContent(join(outputDir, 'sw.js'), "self.addEventListener('install'");
 
         // eslint-disable-next-line @typescript-eslint/no-var-requires
         const output = require(join(outputDir, '.yo-rc.json'));

--- a/test/init/auto/init-auto.test.js
+++ b/test/init/auto/init-auto.test.js
@@ -35,7 +35,7 @@ describe('init auto flag', () => {
         }
 
         // Test regressively files are scaffolded
-        const files = ['./sw.js', './package.json', './src/index.js', './webpack.config.js'];
+        const files = ['./package.json', './src/index.js', './webpack.config.js'];
 
         files.forEach((file) => {
             expect(fs.existsSync(resolve(genPath, file))).toBeTruthy();

--- a/test/init/force/init-force.test.js
+++ b/test/init/force/init-force.test.js
@@ -34,7 +34,7 @@ describe('init force flag', () => {
         }
 
         // Test regressively files are scaffolded
-        const files = ['./sw.js', './package.json', './src/index.js', './webpack.config.js'];
+        const files = ['./package.json', './src/index.js', './webpack.config.js'];
 
         files.forEach((file) => {
             expect(fs.existsSync(resolve(genPath, file))).toBeTruthy();

--- a/test/init/generation-path/init-generation-path.test.js
+++ b/test/init/generation-path/init-generation-path.test.js
@@ -26,7 +26,7 @@ describe('init generate-path flag', () => {
         }
 
         // Test regressively files are scaffolded
-        const files = ['./sw.js', './package.json', './src/index.js', './webpack.config.js'];
+        const files = ['./package.json', './src/index.js', './webpack.config.js'];
 
         files.forEach((file) => {
             expect(fs.existsSync(resolve(genPath, file))).toBeTruthy();
@@ -62,7 +62,7 @@ describe('init generate-path flag', () => {
         }
 
         // Test regressively files are scaffolded
-        const files = ['./sw.js', './package.json', './src/index.js', './webpack.config.js'];
+        const files = ['./package.json', './src/index.js', './webpack.config.js'];
 
         files.forEach((file) => {
             expect(fs.existsSync(resolve(genPath, file))).toBeTruthy();

--- a/test/init/generator/init-inquirer.test.js
+++ b/test/init/generator/init-inquirer.test.js
@@ -30,7 +30,7 @@ describe('init', () => {
         }
 
         // Test regressively files are scaffolded
-        const files = ['./sw.js', './package.json', './src/index.js', './webpack.config.js'];
+        const files = ['./package.json', './src/index.js', './webpack.config.js'];
 
         files.forEach((file) => {
             expect(fs.existsSync(resolve(genPath, file))).toBeTruthy();


### PR DESCRIPTION
**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**
yes

**If relevant, did you update the documentation?**
NA

**Summary**
- Fixed the default logic in the init generator which was broken
- Removed pasting sw.js since workbox plugin does that already in webpack build pipeline, no need to copy manually.

**Does this PR introduce a breaking change?**
No

**Other information**
