### PR TITLE
fix: show exact package name while prompting for installation

### DIFF
--- a/packages/webpack-cli/lib/webpack-cli.js
+++ b/packages/webpack-cli/lib/webpack-cli.js
@@ -357,7 +357,7 @@ class WebpackCLI {
 
                     try {
                         pkg = await promptInstallation(pkg, () => {
-                            logger.error(`For using this command you need to install: '${green(commandName)}' package`);
+                            logger.error(`For using this command you need to install: '${green(pkg)}' package`);
                         });
                     } catch (error) {
                         logger.error(`Action Interrupted, use '${cyan('webpack-cli help')}' to see possible commands`);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
bugfix

**Did you add tests for your changes?**
Nope

**If relevant, did you update the documentation?**
N/A

**Summary**

Currently, the package name that shows up while prompting for installation is the same as the argument supplied as part of `process.argv`. However, this would be misleading if the user supplies the alias or the `loader`/`plugin` command (`generators`).

https://github.com/webpack/webpack-cli/blob/767fe6b4b4d4980b5b5cf8fd5dafb0aa84465625/packages/webpack-cli/lib/webpack-cli.js#L359-L361

```bash
$ webpack loader
```

#### Before
<img width="1296" alt="before" src="https://user-images.githubusercontent.com/25279263/104115579-cac24200-5336-11eb-96fc-eacf4a534c68.png">

#### After
<img width="1317" alt="Screenshot 2021-01-10 at 2 29 10 PM" src="https://user-images.githubusercontent.com/25279263/104118583-42509b00-5350-11eb-837c-81f868b99feb.png">

**Does this PR introduce a breaking change?**
Nope

**Other information**
N/A