### PR TITLE
fix: use worker from plugin and remove default

### DIFF
--- a/packages/generators/init-template/sw.js
+++ b/packages/generators/init-template/sw.js
@@ -1,8 +1,0 @@
-/* eslint-env browser */
-self.addEventListener('install', (event) => {
-    event.waitUntil(
-        caches.open('v1').then((cache) => {
-            return cache.addAll(['./index.html', './src/index.js']);
-        }),
-    );
-});

--- a/packages/generators/src/init-generator.ts
+++ b/packages/generators/src/init-generator.ts
@@ -264,7 +264,7 @@ export default class InitGenerator extends CustomGenerator {
         // Generate README
         this.fs.copyTpl(path.resolve(__dirname, '../init-template/README.md'), this.destinationPath('README.md'), {});
 
-        // Generate HTML template file, copy the default service worker
+        // Generate HTML template file
         this.fs.copyTpl(path.resolve(__dirname, '../init-template/template.html'), this.destinationPath('index.html'), {});
 
         if (this.langType === LangType.ES6) {


### PR DESCRIPTION
**What kind of change does this PR introduce?**
chore

**Did you add tests for your changes?**
yes

**If relevant, did you update the documentation?**
yes

**Summary**
- removes default sw which is no longer used, instead we injest sw using workbox plugin in webpack build chain

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
no

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
no