### PR TITLE
feat: allow to use `help` command to show option information

### DIFF
--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -700,8 +700,8 @@ Global options:
 
 Commands:
   build|bundle|b [options]                   Run webpack (default command, can be omitted).
-  version|v                                  Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and commands.
-  help|h                                     Display help for commands and options.
+  version|v [commands...]                    Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and commands.
+  help|h [command] [option]                  Display help for commands and options.
   serve|s [options]                          Run the webpack dev server.
   info|i [options]                           Outputs information about your system.
   init|c [options] [scaffold...]             Initialize a new webpack configuration.

--- a/packages/webpack-cli/lib/webpack-cli.js
+++ b/packages/webpack-cli/lib/webpack-cli.js
@@ -284,21 +284,21 @@ class WebpackCLI {
         ];
 
         const knownCommands = [buildCommandOptions, versionCommandOptions, helpCommandOptions, ...externalBuiltInCommandsInfo];
-        // TODO fix and test `webpack buil`
+        const getCommandName = (name) => name.split(' ')[0];
         const isKnownCommand = (name) =>
             knownCommands.find(
                 (command) =>
-                    command.name.split(' ')[0] === name ||
+                    getCommandName(command.name) === name ||
                     (Array.isArray(command.alias) ? command.alias.includes(name) : command.alias === name),
             );
         const isBuildCommand = (name) =>
-            buildCommandOptions.name.split(' ')[0] === name ||
+            getCommandName(buildCommandOptions.name) === name ||
             (Array.isArray(buildCommandOptions.alias) ? buildCommandOptions.alias.includes(name) : buildCommandOptions.alias === name);
         const isHelpCommand = (name) =>
-            helpCommandOptions.name.split(' ')[0] === name ||
+            getCommandName(helpCommandOptions.name) === name ||
             (Array.isArray(helpCommandOptions.alias) ? helpCommandOptions.alias.includes(name) : helpCommandOptions.alias === name);
         const isVersionCommand = (name) =>
-            versionCommandOptions.name.split(' ')[0] === name ||
+            getCommandName(versionCommandOptions.name) === name ||
             (Array.isArray(versionCommandOptions.alias)
                 ? versionCommandOptions.alias.includes(name)
                 : versionCommandOptions.alias === name);
@@ -600,7 +600,7 @@ class WebpackCLI {
             if (options.length === 0) {
                 await Promise.all(
                     knownCommands.map((knownCommand) => {
-                        return loadCommandByName(knownCommand.name);
+                        return loadCommandByName(getCommandName(knownCommand.name));
                     }),
                 );
 
@@ -784,11 +784,13 @@ class WebpackCLI {
             } else {
                 logger.error(`Unknown command '${commandName}'`);
 
-                const found = knownCommands.find((commandOptions) => distance(commandName, commandOptions.name) < 3);
+                const found = knownCommands.find((commandOptions) => distance(commandName, getCommandName(commandOptions.name)) < 3);
 
                 if (found) {
                     logger.error(
-                        `Did you mean '${found.name}' (alias '${Array.isArray(found.alias) ? found.alias.join(', ') : found.alias}')?`,
+                        `Did you mean '${getCommandName(found.name)}' (alias '${
+                            Array.isArray(found.alias) ? found.alias.join(', ') : found.alias
+                        }')?`,
                     );
                 }
 

--- a/packages/webpack-cli/lib/webpack-cli.js
+++ b/packages/webpack-cli/lib/webpack-cli.js
@@ -310,7 +310,7 @@ class WebpackCLI {
             value === '--no-color' ||
             value === '-v' ||
             value === '--version' ||
-            value === '--h' ||
+            value === '-h' ||
             value === '--help';
 
         const getCommandNameAndOptions = (args) => {

--- a/packages/webpack-cli/lib/webpack-cli.js
+++ b/packages/webpack-cli/lib/webpack-cli.js
@@ -284,19 +284,21 @@ class WebpackCLI {
         ];
 
         const knownCommands = [buildCommandOptions, versionCommandOptions, helpCommandOptions, ...externalBuiltInCommandsInfo];
+        // TODO fix and test `webpack buil`
         const isKnownCommand = (name) =>
             knownCommands.find(
                 (command) =>
-                    command.name.startsWith(name) || (Array.isArray(command.alias) ? command.alias.includes(name) : command.alias === name),
+                    command.name.split(' ')[0] === name ||
+                    (Array.isArray(command.alias) ? command.alias.includes(name) : command.alias === name),
             );
         const isBuildCommand = (name) =>
-            buildCommandOptions.name.startsWith(name) ||
+            buildCommandOptions.name.split(' ')[0] === name ||
             (Array.isArray(buildCommandOptions.alias) ? buildCommandOptions.alias.includes(name) : buildCommandOptions.alias === name);
         const isHelpCommand = (name) =>
-            helpCommandOptions.name.startsWith(name) ||
+            helpCommandOptions.name.split(' ')[0] === name ||
             (Array.isArray(helpCommandOptions.alias) ? helpCommandOptions.alias.includes(name) : helpCommandOptions.alias === name);
         const isVersionCommand = (name) =>
-            versionCommandOptions.name.startsWith(name) ||
+            versionCommandOptions.name.split(' ')[0] === name ||
             (Array.isArray(versionCommandOptions.alias)
                 ? versionCommandOptions.alias.includes(name)
                 : versionCommandOptions.alias === name);

--- a/test/build/basic/basic.test.js
+++ b/test/build/basic/basic.test.js
@@ -27,6 +27,16 @@ describe('bundle command', () => {
         expect(stdout).toBeTruthy();
     });
 
+    it('should log error and suggest right name on the "buil" command', async () => {
+        const { exitCode, stderr, stdout } = run(__dirname, ['buil'], false);
+
+        expect(exitCode).toBe(2);
+        expect(stderr).toContain("Unknown command 'buil'");
+        expect(stderr).toContain("Did you mean 'build' (alias 'bundle, b')?");
+        expect(stderr).toContain("Run 'webpack --help' to see available commands and options");
+        expect(stdout).toBeFalsy();
+    });
+
     it('should log error with multi commands', async () => {
         const { exitCode, stderr, stdout } = run(__dirname, ['bundle', 'info'], false);
 

--- a/test/help/help.test.js
+++ b/test/help/help.test.js
@@ -242,8 +242,15 @@ describe('help', () => {
 
         expect(exitCode).toBe(0);
         expect(stderr).toBeFalsy();
-        expect(stdout).toContain('Usage: webpack --target <value...>');
-        expect(stdout).toContain('Short: webpack -t <value...>');
+
+        if (isWebpack5) {
+            expect(stdout).toContain('Usage: webpack --target <value...>');
+            expect(stdout).toContain('Short: webpack -t <value...>');
+        } else {
+            expect(stdout).toContain('Usage: webpack --target <value>');
+            expect(stdout).toContain('Short: webpack -t <value>');
+        }
+
         expect(stdout).toContain('Description: Sets the build target e.g. node.');
         expect(stdout).toContain("To see list of all supported commands and options run 'webpack --help=verbose'.");
         expect(stdout).toContain('CLI documentation: https://webpack.js.org/api/cli/.');

--- a/test/help/help.test.js
+++ b/test/help/help.test.js
@@ -434,6 +434,15 @@ describe('help', () => {
         expect(stdout).toBeFalsy();
     });
 
+    it('should log error for unknown option using command syntax #4', () => {
+        const { exitCode, stderr, stdout } = run(__dirname, ['help', 'bui', '--mode'], false);
+
+        expect(exitCode).toBe(2);
+        expect(stderr).toContain("Can't find and load command 'bui'");
+        expect(stderr).toContain("Run 'webpack --help' to see available commands and options");
+        expect(stdout).toBeFalsy();
+    });
+
     it('should log error for invalid command using command syntax #3', () => {
         const { exitCode, stderr, stdout } = run(__dirname, ['help', '--mode', 'serve'], false);
 

--- a/test/help/help.test.js
+++ b/test/help/help.test.js
@@ -208,7 +208,7 @@ describe('help', () => {
         expect(stdout).toContain('Made with ♥ by the webpack team');
     });
 
-    it('should show help information and taking precedence when "--help" and "--verison" option using together', () => {
+    it('should show help information and taking precedence when "--help" and "--version" option using together', () => {
         const { exitCode, stderr, stdout } = run(__dirname, ['--help', '--version'], false);
 
         expect(exitCode).toBe(0);
@@ -226,6 +226,143 @@ describe('help', () => {
         // expect(coloretteEnabled ? stripAnsi(stdout) : stdout).toContain('Made with ♥ by the webpack team.');
     });
 
+    it('should show help information using the "help --mode" option', () => {
+        const { exitCode, stderr, stdout } = run(__dirname, ['help', '--mode'], false);
+
+        expect(exitCode).toBe(0);
+        expect(stderr).toBeFalsy();
+        expect(stdout).toContain('Usage: webpack --mode <value>');
+        expect(stdout).toContain('Description: Defines the mode to pass to webpack.');
+        expect(stdout).toContain("To see list of all supported commands and options run 'webpack --help=verbose'.");
+        expect(stdout).toContain('CLI documentation: https://webpack.js.org/api/cli/.');
+    });
+
+    it('should show help information using the "help --target" option', () => {
+        const { exitCode, stderr, stdout } = run(__dirname, ['help', '--target'], false);
+
+        expect(exitCode).toBe(0);
+        expect(stderr).toBeFalsy();
+        expect(stdout).toContain('Usage: webpack --target <value...>');
+        expect(stdout).toContain('Short: webpack -t <value...>');
+        expect(stdout).toContain('Description: Sets the build target e.g. node.');
+        expect(stdout).toContain("To see list of all supported commands and options run 'webpack --help=verbose'.");
+        expect(stdout).toContain('CLI documentation: https://webpack.js.org/api/cli/.');
+    });
+
+    it('should show help information using the "help --stats" option', () => {
+        const { exitCode, stderr, stdout } = run(__dirname, ['help', '--stats'], false);
+
+        expect(exitCode).toBe(0);
+        expect(stderr).toBeFalsy();
+        expect(stdout).toContain('Usage: webpack --stats [value]');
+        expect(stdout).toContain('Description: It instructs webpack on how to treat the stats e.g. verbose.');
+        expect(stdout).toContain("To see list of all supported commands and options run 'webpack --help=verbose'.");
+        expect(stdout).toContain('CLI documentation: https://webpack.js.org/api/cli/.');
+    });
+
+    it('should show help information using the "help --no-stats" option', () => {
+        const { exitCode, stderr, stdout } = run(__dirname, ['help', '--no-stats'], false);
+
+        expect(exitCode).toBe(0);
+        expect(stderr).toBeFalsy();
+        expect(stdout).toContain('Usage: webpack --no-stats');
+        expect(stdout).toContain('Description: Disable stats output.');
+        expect(stdout).toContain("To see list of all supported commands and options run 'webpack --help=verbose'.");
+        expect(stdout).toContain('CLI documentation: https://webpack.js.org/api/cli/.');
+    });
+
+    it('should show help information using the "help --mode" option', () => {
+        const { exitCode, stderr, stdout } = run(__dirname, ['help', '--mode'], false);
+
+        expect(exitCode).toBe(0);
+        expect(stderr).toBeFalsy();
+        expect(stdout).toContain('Usage: webpack --mode <value>');
+        expect(stdout).toContain('Description: Defines the mode to pass to webpack.');
+        expect(stdout).toContain("To see list of all supported commands and options run 'webpack --help=verbose'.");
+        expect(stdout).toContain('CLI documentation: https://webpack.js.org/api/cli/.');
+    });
+
+    it('should show help information using the "help serve --mode" option', () => {
+        const { exitCode, stderr, stdout } = run(__dirname, ['help', 'serve', '--mode'], false);
+
+        expect(exitCode).toBe(0);
+        expect(stderr).toBeFalsy();
+        expect(stdout).toContain('Usage: webpack serve --mode <value>');
+        expect(stdout).toContain('Description: Defines the mode to pass to webpack.');
+        expect(stdout).toContain("To see list of all supported commands and options run 'webpack --help=verbose'.");
+        expect(stdout).toContain('CLI documentation: https://webpack.js.org/api/cli/.');
+    });
+
+    it('should show help information using the "help --color" option', () => {
+        const { exitCode, stderr, stdout } = run(__dirname, ['help', '--color'], false);
+
+        expect(exitCode).toBe(0);
+        expect(stderr).toBeFalsy();
+        expect(stdout).toContain('Usage: webpack --color');
+        expect(stdout).toContain('Description: Enable colors on console.');
+        expect(stdout).toContain("To see list of all supported commands and options run 'webpack --help=verbose'.");
+        expect(stdout).toContain('CLI documentation: https://webpack.js.org/api/cli/.');
+    });
+
+    it('should show help information using the "help --no-color" option', () => {
+        const { exitCode, stderr, stdout } = run(__dirname, ['help', '--no-color'], false);
+
+        expect(exitCode).toBe(0);
+        expect(stderr).toBeFalsy();
+        expect(stdout).toContain('Usage: webpack --no-color');
+        expect(stdout).toContain('Description: Disable colors on console.');
+        expect(stdout).toContain("To see list of all supported commands and options run 'webpack --help=verbose'.");
+        expect(stdout).toContain('CLI documentation: https://webpack.js.org/api/cli/.');
+    });
+
+    it('should show help information using the "help serve --color" option', () => {
+        const { exitCode, stderr, stdout } = run(__dirname, ['help', 'serve', '--color'], false);
+
+        expect(exitCode).toBe(0);
+        expect(stderr).toBeFalsy();
+        expect(stdout).toContain('Usage: webpack serve --color');
+        expect(stdout).toContain('Description: Enable colors on console.');
+        expect(stdout).toContain("To see list of all supported commands and options run 'webpack --help=verbose'.");
+        expect(stdout).toContain('CLI documentation: https://webpack.js.org/api/cli/.');
+    });
+
+    it('should show help information using the "help serve --no-color" option', () => {
+        const { exitCode, stderr, stdout } = run(__dirname, ['help', 'serve', '--no-color'], false);
+
+        expect(exitCode).toBe(0);
+        expect(stderr).toBeFalsy();
+        expect(stdout).toContain('Usage: webpack serve --no-color');
+        expect(stdout).toContain('Description: Disable colors on console.');
+        expect(stdout).toContain("To see list of all supported commands and options run 'webpack --help=verbose'.");
+        expect(stdout).toContain('CLI documentation: https://webpack.js.org/api/cli/.');
+    });
+
+    it('should show help information using the "help --version" option', () => {
+        const { exitCode, stderr, stdout } = run(__dirname, ['help', '--version'], false);
+
+        expect(exitCode).toBe(0);
+        expect(stderr).toBeFalsy();
+        expect(stdout).toContain('Usage: webpack --version');
+        expect(stdout).toContain('Short: webpack -v');
+        expect(stdout).toContain(
+            "Description: Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and commands.",
+        );
+        expect(stdout).toContain('CLI documentation: https://webpack.js.org/api/cli/.');
+    });
+
+    it('should show help information using the "help -v" option', () => {
+        const { exitCode, stderr, stdout } = run(__dirname, ['help', '-v'], false);
+
+        expect(exitCode).toBe(0);
+        expect(stderr).toBeFalsy();
+        expect(stdout).toContain('Usage: webpack --version');
+        expect(stdout).toContain('Short: webpack -v');
+        expect(stdout).toContain(
+            "Description: Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and commands.",
+        );
+        expect(stdout).toContain('CLI documentation: https://webpack.js.org/api/cli/.');
+    });
+
     it('should log error for invalid command using the "--help" option', () => {
         const { exitCode, stderr, stdout } = run(__dirname, ['--help', 'myCommand'], false);
 
@@ -234,7 +371,27 @@ describe('help', () => {
         expect(stdout).toBeFalsy();
     });
 
-    it('should log error for invalid command using command syntax', () => {
+    it('should log error for invalid command using the "--help" option #2', () => {
+        const { exitCode, stderr, stdout } = run(__dirname, ['--flag', '--help'], false);
+
+        expect(exitCode).toBe(2);
+        expect(stderr).toContain('Incorrect use of help');
+        expect(stderr).toContain("Please use: 'webpack help [command] [option]' | 'webpack [command] --help'");
+        expect(stderr).toContain("Run 'webpack --help' to see available commands and options");
+        expect(stdout).toBeFalsy();
+    });
+
+    it('should log error for invalid command using the "--help" option #3', () => {
+        const { exitCode, stderr, stdout } = run(__dirname, ['serve', '--flag', '--help'], false);
+
+        expect(exitCode).toBe(2);
+        expect(stderr).toContain('Incorrect use of help');
+        expect(stderr).toContain("Please use: 'webpack help [command] [option]' | 'webpack [command] --help'");
+        expect(stderr).toContain("Run 'webpack --help' to see available commands and options");
+        expect(stdout).toBeFalsy();
+    });
+
+    it('should log error for unknown command using command syntax', () => {
         const { exitCode, stderr, stdout } = run(__dirname, ['help', 'myCommand'], false);
 
         expect(exitCode).toBe(2);
@@ -243,7 +400,7 @@ describe('help', () => {
         expect(stdout).toBeFalsy();
     });
 
-    it('should log error for invalid command using command syntax #2', () => {
+    it('should log error for unknown command using command syntax #2', () => {
         const { exitCode, stderr, stdout } = run(__dirname, ['help', 'verbose'], false);
 
         expect(exitCode).toBe(2);
@@ -252,11 +409,50 @@ describe('help', () => {
         expect(stdout).toBeFalsy();
     });
 
+    it('should log error for unknown option using command syntax #2', () => {
+        const { exitCode, stderr, stdout } = run(__dirname, ['help', '--made'], false);
+
+        expect(exitCode).toBe(2);
+        expect(stderr).toContain("Unknown option '--made'");
+        expect(stderr).toContain("Run 'webpack --help' to see available commands and options");
+        expect(stdout).toBeFalsy();
+    });
+
+    it('should log error for unknown option using command syntax #3', () => {
+        const { exitCode, stderr, stdout } = run(__dirname, ['help', 'serve', '--made'], false);
+
+        expect(exitCode).toBe(2);
+        expect(stderr).toContain("Unknown option '--made'");
+        expect(stderr).toContain("Run 'webpack --help' to see available commands and options");
+        expect(stdout).toBeFalsy();
+    });
+
+    it('should log error for invalid command using command syntax #3', () => {
+        const { exitCode, stderr, stdout } = run(__dirname, ['help', '--mode', 'serve'], false);
+
+        expect(exitCode).toBe(2);
+        expect(stderr).toContain('Incorrect use of help');
+        expect(stderr).toContain("Please use: 'webpack help [command] [option]' | 'webpack [command] --help'");
+        expect(stderr).toContain("Run 'webpack --help' to see available commands and options");
+        expect(stdout).toBeFalsy();
+    });
+
+    it('should log error for invalid command using command syntax #4', () => {
+        const { exitCode, stderr, stdout } = run(__dirname, ['help', 'serve', '--mode', '--mode'], false);
+
+        expect(exitCode).toBe(2);
+        expect(stderr).toContain('Incorrect use of help');
+        expect(stderr).toContain("Please use: 'webpack help [command] [option]' | 'webpack [command] --help'");
+        expect(stderr).toContain("Run 'webpack --help' to see available commands and options");
+        expect(stdout).toBeFalsy();
+    });
+
     it('should log error for invalid flag with the "--help" option', () => {
         const { exitCode, stderr, stdout } = run(__dirname, ['--help', '--my-flag'], false);
 
         expect(exitCode).toBe(2);
-        expect(stderr).toContain("Unknown option '--my-flag'");
+        expect(stderr).toContain('Incorrect use of help');
+        expect(stderr).toContain("Please use: 'webpack help [command] [option]' | 'webpack [command] --help'");
         expect(stderr).toContain("Run 'webpack --help' to see available commands and options");
         expect(stdout).toBeFalsy();
     });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

feature

**Did you add tests for your changes?**

Yes

**If relevant, did you update the documentation?**

Yes

**Summary**

allow to show help information for options 

**Does this PR introduce a breaking change?**

No

**Other information**

fixes #1463