### PR TITLE
fix: show a warning if serve and `--watch` are used together

### DIFF
--- a/packages/serve/src/index.ts
+++ b/packages/serve/src/index.ts
@@ -24,7 +24,7 @@ class ServeCommand {
                     process.exit(2);
                 }
 
-                const builtInOptions = cli.getBuiltInOptions();
+                const builtInOptions = cli.getBuiltInOptions().filter((option) => option.name !== 'watch');
 
                 return [...builtInOptions, ...devServerFlags];
             },
@@ -54,11 +54,6 @@ class ServeCommand {
                         kebabedOption !== 'hot' && builtInOptions.find((builtInOption) => builtInOption.name === kebabedOption);
 
                     if (isBuiltInOption) {
-                        // warn user about using '--watch' with serve
-                        if (optionName === 'watch') {
-                            logger.warn("Do not use '--watch' with 'serve'. It has no effect.");
-                        }
-
                         webpackOptions[optionName] = options[optionName];
                     } else {
                         const needToProcess = devServerFlags.find(

--- a/packages/serve/src/index.ts
+++ b/packages/serve/src/index.ts
@@ -54,6 +54,11 @@ class ServeCommand {
                         kebabedOption !== 'hot' && builtInOptions.find((builtInOption) => builtInOption.name === kebabedOption);
 
                     if (isBuiltInOption) {
+                        // warn user about using '--watch' with serve
+                        if (optionName === 'watch') {
+                            logger.warn("Do not use '--watch' with 'serve'. It has no effect.");
+                        }
+
                         webpackOptions[optionName] = options[optionName];
                     } else {
                         const needToProcess = devServerFlags.find(

--- a/packages/webpack-cli/lib/webpack-cli.js
+++ b/packages/webpack-cli/lib/webpack-cli.js
@@ -547,6 +547,10 @@ class WebpackCLI {
                             options.entry = [...entries, ...(options.entry || [])];
                         }
 
+                        if (isWatchCommandUsed) {
+                            options.watch = true;
+                        }
+
                         await this.buildCommand(options);
                     },
                 );

--- a/packages/webpack-cli/lib/webpack-cli.js
+++ b/packages/webpack-cli/lib/webpack-cli.js
@@ -1360,18 +1360,20 @@ class WebpackCLI {
         }
 
         const outputHints = (configOptions) => {
-            const isWatchCommand = options.argv.env['WEBPACK_WATCH'];
-            const isServeCommand = options.argv.env['WEBPACK_SERVE'];
+            if (options.argv) {
+                const isWatchCommand = options.argv.env['WEBPACK_WATCH'];
+                const isServeCommand = options.argv.env['WEBPACK_SERVE'];
 
-            if (configOptions.watch && (isWatchCommand || isServeCommand)) {
-                this.logger.warn(
-                    `No need to use the '${
-                        isWatchCommand ? 'watch' : 'serve'
-                    }' command together with '{ watch: true }' configuration, it does not make sense.`,
-                );
+                if (configOptions.watch && (isWatchCommand || isServeCommand)) {
+                    this.logger.warn(
+                        `No need to use the '${
+                            isWatchCommand ? 'watch' : 'serve'
+                        }' command together with '{ watch: true }' configuration, it does not make sense.`,
+                    );
 
-                if (isServeCommand) {
-                    configOptions.watch = false;
+                    if (isServeCommand) {
+                        configOptions.watch = false;
+                    }
                 }
             }
 

--- a/packages/webpack-cli/lib/webpack-cli.js
+++ b/packages/webpack-cli/lib/webpack-cli.js
@@ -537,24 +537,14 @@ class WebpackCLI {
             const isWatchCommandUsed = isCommand(commandName, watchCommandOptions);
 
             if (isBuildCommandUsed || isWatchCommandUsed) {
+                const options = this.getBuiltInOptions();
+
                 await this.makeCommand(
                     isBuildCommandUsed ? buildCommandOptions : watchCommandOptions,
-                    this.getBuiltInOptions(),
+                    isWatchCommandUsed ? options.filter((option) => option.name !== 'watch') : options,
                     async (entries, options) => {
                         if (entries.length > 0) {
                             options.entry = [...entries, ...(options.entry || [])];
-                        }
-
-                        if (isWatchCommandUsed) {
-                            if (typeof options.watch !== 'undefined') {
-                                this.logger.warn(
-                                    `No need to use the ${
-                                        options.watch ? "'--watch, -w'" : "'--no-watch'"
-                                    } option together with the 'watch' command, it does not make sense`,
-                                );
-                            }
-
-                            options.watch = true;
                         }
 
                         await this.buildCommand(options);

--- a/packages/webpack-cli/lib/webpack-cli.js
+++ b/packages/webpack-cli/lib/webpack-cli.js
@@ -547,11 +547,7 @@ class WebpackCLI {
                             options.entry = [...entries, ...(options.entry || [])];
                         }
 
-                        if (isWatchCommandUsed) {
-                            options.watch = true;
-                        }
-
-                        await this.buildCommand(options);
+                        await this.buildCommand(options, isWatchCommandUsed);
                     },
                 );
             } else if (isCommand(commandName, helpCommandOptions)) {
@@ -1660,7 +1656,7 @@ class WebpackCLI {
         return compiler;
     }
 
-    async buildCommand(options) {
+    async buildCommand(options, isWatchCommand) {
         let compiler;
 
         const callback = (error, stats) => {
@@ -1725,7 +1721,16 @@ class WebpackCLI {
             }
         };
 
-        options.argv = { ...options, env: { WEBPACK_BUNDLE: true, WEBPACK_BUILD: true, ...options.env } };
+        const env =
+            isWatchCommand || options.watch
+                ? { WEBPACK_WATCH: true, ...options.env }
+                : { WEBPACK_BUNDLE: true, WEBPACK_BUILD: true, ...options.env };
+
+        options.argv = { ...options, env };
+
+        if (isWatchCommand) {
+            options.watch = true;
+        }
 
         compiler = await this.createCompiler(options, callback);
 

--- a/packages/webpack-cli/lib/webpack-cli.js
+++ b/packages/webpack-cli/lib/webpack-cli.js
@@ -1360,20 +1360,20 @@ class WebpackCLI {
         }
 
         const outputHints = (configOptions) => {
-            if (options.argv) {
-                const isWatchCommand = options.argv.env['WEBPACK_WATCH'];
-                const isServeCommand = options.argv.env['WEBPACK_SERVE'];
+            if (
+                configOptions.watch &&
+                options.argv &&
+                options.argv.env &&
+                (options.argv.env['WEBPACK_WATCH'] || options.argv.env['WEBPACK_SERVE'])
+            ) {
+                this.logger.warn(
+                    `No need to use the '${
+                        options.argv.env['WEBPACK_WATCH'] ? 'watch' : 'serve'
+                    }' command together with '{ watch: true }' configuration, it does not make sense.`,
+                );
 
-                if (configOptions.watch && (isWatchCommand || isServeCommand)) {
-                    this.logger.warn(
-                        `No need to use the '${
-                            isWatchCommand ? 'watch' : 'serve'
-                        }' command together with '{ watch: true }' configuration, it does not make sense.`,
-                    );
-
-                    if (isServeCommand) {
-                        configOptions.watch = false;
-                    }
+                if (options.argv.env['WEBPACK_SERVE']) {
+                    configOptions.watch = false;
                 }
             }
 

--- a/packages/webpack-cli/lib/webpack-cli.js
+++ b/packages/webpack-cli/lib/webpack-cli.js
@@ -1359,6 +1359,29 @@ class WebpackCLI {
             process.exit(2);
         }
 
+        const outputHints = (configOptions) => {
+            const isWatchCommand = options.argv.env['WEBPACK_WATCH'];
+            const isServeCommand = options.argv.env['WEBPACK_SERVE'];
+
+            if (configOptions.watch && (isWatchCommand || isServeCommand)) {
+                this.logger.warn(
+                    `No need to use the '${
+                        isWatchCommand ? 'watch' : 'serve'
+                    }' command together with '{ watch: true }' configuration, it does not make sense.`,
+                );
+
+                if (isServeCommand) {
+                    configOptions.watch = false;
+                }
+            }
+
+            return configOptions;
+        };
+
+        config.options = Array.isArray(config.options)
+            ? config.options.map((options) => outputHints(options))
+            : outputHints(config.options);
+
         if (this.webpack.cli) {
             const processArguments = (configOptions) => {
                 const args = this.getBuiltInOptions()

--- a/test/serve/basic/serve-basic.test.js
+++ b/test/serve/basic/serve-basic.test.js
@@ -304,6 +304,14 @@ describe('basic serve usage', () => {
         expect(stdout.match(/HotModuleReplacementPlugin/g)).toBeNull();
     });
 
+    it("should log warning on using '-w' alias with serve", async () => {
+        const { stdout, stderr } = await runServe(testPath, ['-w']);
+
+        expect(stderr).toContain("Do not use '--watch' with 'serve'. It has no effect.");
+        expect(stdout).toContain('main.js');
+        expect(stdout.match(/HotModuleReplacementPlugin/g)).toBeNull();
+    });
+
     it('should log an error on unknown flag', async () => {
         const { exitCode, stdout, stderr } = await runServe(testPath, ['--port', port, '--unknown-flag']);
 

--- a/test/serve/basic/serve-basic.test.js
+++ b/test/serve/basic/serve-basic.test.js
@@ -296,20 +296,20 @@ describe('basic serve usage', () => {
         expect(stdout.match(/HotModuleReplacementPlugin/g)).toBeNull();
     });
 
-    it("should log warning on using '--watch' flag with serve", async () => {
+    it("should log error on using '--watch' flag with serve", async () => {
         const { stdout, stderr } = await runServe(testPath, ['--watch']);
 
-        expect(stderr).toContain("Do not use '--watch' with 'serve'. It has no effect.");
-        expect(stdout).toContain('main.js');
-        expect(stdout.match(/HotModuleReplacementPlugin/g)).toBeNull();
+        expect(stderr).toContain("Error: Unknown option '--watch'");
+        expect(stderr).toContain("Run 'webpack --help' to see available commands and options");
+        expect(stdout).toBeFalsy();
     });
 
-    it("should log warning on using '-w' alias with serve", async () => {
+    it("should log error on using '-w' alias with serve", async () => {
         const { stdout, stderr } = await runServe(testPath, ['-w']);
 
-        expect(stderr).toContain("Do not use '--watch' with 'serve'. It has no effect.");
-        expect(stdout).toContain('main.js');
-        expect(stdout.match(/HotModuleReplacementPlugin/g)).toBeNull();
+        expect(stderr).toContain("Error: Unknown option '-w'");
+        expect(stderr).toContain("Run 'webpack --help' to see available commands and options");
+        expect(stdout).toBeFalsy();
     });
 
     it('should log an error on unknown flag', async () => {

--- a/test/serve/basic/serve-basic.test.js
+++ b/test/serve/basic/serve-basic.test.js
@@ -296,6 +296,16 @@ describe('basic serve usage', () => {
         expect(stdout.match(/HotModuleReplacementPlugin/g)).toBeNull();
     });
 
+    it('should work and log warning on the `watch option in a configuration', async () => {
+        const { stderr, stdout } = await runServe(__dirname, ['--config', './watch.config.js', '--port', port]);
+
+        expect(stderr).toContain(
+            "No need to use the 'serve' command together with '{ watch: true }' configuration, it does not make sense.",
+        );
+        expect(stdout).toContain('development');
+        expect(stdout.match(/HotModuleReplacementPlugin/g)).toBeNull();
+    });
+
     it("should log error on using '--watch' flag with serve", async () => {
         const { stdout, stderr } = await runServe(testPath, ['--watch']);
 

--- a/test/serve/basic/serve-basic.test.js
+++ b/test/serve/basic/serve-basic.test.js
@@ -296,7 +296,15 @@ describe('basic serve usage', () => {
         expect(stdout.match(/HotModuleReplacementPlugin/g)).toBeNull();
     });
 
-    it('should log and error on unknown flag', async () => {
+    it("should log warning on using '--watch' flag with serve", async () => {
+        const { stdout, stderr } = await runServe(testPath, ['--watch']);
+
+        expect(stderr).toContain("Do not use '--watch' with 'serve'. It has no effect.");
+        expect(stdout).toContain('main.js');
+        expect(stdout.match(/HotModuleReplacementPlugin/g)).toBeNull();
+    });
+
+    it('should log an error on unknown flag', async () => {
         const { exitCode, stdout, stderr } = await runServe(testPath, ['--port', port, '--unknown-flag']);
 
         expect(exitCode).toBe(2);

--- a/test/serve/basic/watch.config.js
+++ b/test/serve/basic/watch.config.js
@@ -1,0 +1,8 @@
+const WebpackCLITestPlugin = require('../../utils/webpack-cli-test-plugin');
+
+module.exports = {
+    mode: 'development',
+    devtool: false,
+    plugins: [new WebpackCLITestPlugin(['mode'], false, 'hooks.compilation.taps')],
+    watch: true,
+};

--- a/test/watch/basic/basic.test.js
+++ b/test/watch/basic/basic.test.js
@@ -18,8 +18,6 @@ describe('basic', () => {
     });
 
     it('should recompile upon file change using the `--watch` option', (done) => {
-        expect.assertions(6);
-
         const proc = runAndGetWatchProc(__dirname, ['--watch', '--mode', 'development'], false, '', true);
 
         let modified = false;
@@ -53,8 +51,6 @@ describe('basic', () => {
     });
 
     it('should recompile upon file change using the `watch` command', (done) => {
-        expect.assertions(6);
-
         const proc = runAndGetWatchProc(__dirname, ['watch', '--mode', 'development'], false, '', true);
 
         let modified = false;
@@ -88,8 +84,6 @@ describe('basic', () => {
     });
 
     it('should recompile upon file change using the `watch` command and entries syntax', (done) => {
-        expect.assertions(6);
-
         const proc = runAndGetWatchProc(__dirname, ['watch', './src/entry.js', '--mode', 'development'], false, '', true);
 
         let modified = false;
@@ -125,8 +119,6 @@ describe('basic', () => {
     });
 
     it('should log warning about the `watch` option in the configuration and recompile upon file change using the `watch` command', (done) => {
-        expect.assertions(7);
-
         const proc = runAndGetWatchProc(__dirname, ['--watch', '--mode', 'development', '--config', './watch.config.js'], false, '', true);
 
         let modified = false;

--- a/test/watch/basic/basic.test.js
+++ b/test/watch/basic/basic.test.js
@@ -118,87 +118,21 @@ describe('basic', () => {
         });
     });
 
-    it('should recompile upon file change using the `command` option and the `--watch` option and log warning', (done) => {
-        const proc = runAndGetWatchProc(__dirname, ['watch', '--watch', '--mode', 'development'], false, '', true);
+    it('should recompile upon file change using the `command` option and the `--watch` option and log warning', async () => {
+        const { exitCode, stderr, stdout } = await run(__dirname, ['watch', '--watch', '--mode', 'development']);
 
-        let modified = false;
-        let hasWarning = false;
-
-        proc.stdout.on('data', (chunk) => {
-            const data = stripAnsi(chunk.toString());
-
-            if (data.includes('index.js')) {
-                if (isWebpack5) {
-                    for (const word of wordsInStatsv5) {
-                        expect(data).toContain(word);
-                    }
-                } else {
-                    for (const word of wordsInStatsv4) {
-                        expect(data).toContain(word);
-                    }
-                }
-
-                if (!modified && !hasWarning) {
-                    process.nextTick(() => {
-                        writeFileSync(resolve(__dirname, './src/index.js'), `console.log('watch flag test');`);
-                    });
-
-                    modified = true;
-                } else {
-                    proc.kill();
-                    done();
-                }
-            }
-        });
-
-        proc.stderr.on('data', (chunk) => {
-            const data = stripAnsi(chunk.toString());
-
-            hasWarning = true;
-
-            expect(data).toContain("No need to use the '--watch, -w' option together with the 'watch' command, it does not make sense");
-        });
+        expect(exitCode).toBe(2);
+        expect(stderr).toContain("Error: Unknown option '--watch'");
+        expect(stderr).toContain("Run 'webpack --help' to see available commands and options");
+        expect(stdout).toBeFalsy();
     });
 
-    it('should recompile upon file change using the `command` option and the `--no-watch` option and log warning', (done) => {
-        const proc = runAndGetWatchProc(__dirname, ['watch', '--no-watch', '--mode', 'development'], false, '', true);
+    it('should recompile upon file change using the `command` option and the `--no-watch` option and log warning', async () => {
+        const { exitCode, stderr, stdout } = await run(__dirname, ['watch', '--no-watch', '--mode', 'development']);
 
-        let modified = false;
-        let hasWarning = false;
-
-        proc.stdout.on('data', (chunk) => {
-            const data = stripAnsi(chunk.toString());
-
-            if (data.includes('index.js')) {
-                if (isWebpack5) {
-                    for (const word of wordsInStatsv5) {
-                        expect(data).toContain(word);
-                    }
-                } else {
-                    for (const word of wordsInStatsv4) {
-                        expect(data).toContain(word);
-                    }
-                }
-
-                if (!modified && !hasWarning) {
-                    process.nextTick(() => {
-                        writeFileSync(resolve(__dirname, './src/index.js'), `console.log('watch flag test');`);
-                    });
-
-                    modified = true;
-                } else {
-                    proc.kill();
-                    done();
-                }
-            }
-        });
-
-        proc.stderr.on('data', (chunk) => {
-            const data = stripAnsi(chunk.toString());
-
-            hasWarning = true;
-
-            expect(data).toContain("No need to use the '--no-watch' option together with the 'watch' command, it does not make sense");
-        });
+        expect(exitCode).toBe(2);
+        expect(stderr).toContain("Error: Unknown option '--no-watch'");
+        expect(stderr).toContain("Run 'webpack --help' to see available commands and options");
+        expect(stdout).toBeFalsy();
     });
 });

--- a/test/watch/watch-variable/src/index.js
+++ b/test/watch/watch-variable/src/index.js
@@ -1,0 +1,1 @@
+console.log('watch flag test');

--- a/test/watch/watch-variable/watch-variable.test.js
+++ b/test/watch/watch-variable/watch-variable.test.js
@@ -5,11 +5,13 @@ const { runAndGetWatchProc, isWebpack5 } = require('../../utils/test-utils');
 const { writeFileSync } = require('fs');
 const { resolve } = require('path');
 
-const wordsInStatsv4 = ['Hash', 'Version', 'Time', 'Built at:', 'main.js'];
+const wordsInStatsv4 = ['Hash', 'Built at:', 'main.js'];
 const wordsInStatsv5 = ['asset', 'index.js', 'compiled successfully'];
 
 describe('watch variable', () => {
     it('should pass `WEBPACK_WATCH` env variable and recompile upon file change using the `watch` command', (done) => {
+        expect.assertions(10);
+
         const proc = runAndGetWatchProc(__dirname, ['watch', '--mode', 'development'], false, '', true);
 
         let modified = false;
@@ -45,6 +47,8 @@ describe('watch variable', () => {
     });
 
     it('should pass `WEBPACK_WATCH` env variable and recompile upon file change using the `--watch` option', (done) => {
+        expect.assertions(10);
+
         const proc = runAndGetWatchProc(__dirname, ['--watch', '--mode', 'development'], false, '', true);
 
         let modified = false;

--- a/test/watch/watch-variable/watch-variable.test.js
+++ b/test/watch/watch-variable/watch-variable.test.js
@@ -1,0 +1,81 @@
+'use strict';
+
+const stripAnsi = require('strip-ansi');
+const { runAndGetWatchProc, isWebpack5 } = require('../../utils/test-utils');
+const { writeFileSync } = require('fs');
+const { resolve } = require('path');
+
+const wordsInStatsv4 = ['Hash', 'Version', 'Time', 'Built at:', 'main.js'];
+const wordsInStatsv5 = ['asset', 'index.js', 'compiled successfully'];
+
+describe('watch variable', () => {
+    it('should pass `WEBPACK_WATCH` env variable and recompile upon file change using the `watch` command', (done) => {
+        const proc = runAndGetWatchProc(__dirname, ['watch', '--mode', 'development'], false, '', true);
+
+        let modified = false;
+
+        proc.stdout.on('data', (chunk) => {
+            const data = stripAnsi(chunk.toString());
+
+            expect(data).not.toContain('FAIL');
+
+            if (data.includes('index.js')) {
+                if (isWebpack5) {
+                    for (const word of wordsInStatsv5) {
+                        expect(data).toContain(word);
+                    }
+                } else {
+                    for (const word of wordsInStatsv4) {
+                        expect(data).toContain(word);
+                    }
+                }
+
+                if (!modified) {
+                    process.nextTick(() => {
+                        writeFileSync(resolve(__dirname, './src/index.js'), `console.log('watch flag test');`);
+                    });
+
+                    modified = true;
+                } else {
+                    proc.kill();
+                    done();
+                }
+            }
+        });
+    });
+
+    it('should pass `WEBPACK_WATCH` env variable and recompile upon file change using the `--watch` option', (done) => {
+        const proc = runAndGetWatchProc(__dirname, ['--watch', '--mode', 'development'], false, '', true);
+
+        let modified = false;
+
+        proc.stdout.on('data', (chunk) => {
+            const data = stripAnsi(chunk.toString());
+
+            expect(data).not.toContain('FAIL');
+
+            if (data.includes('index.js')) {
+                if (isWebpack5) {
+                    for (const word of wordsInStatsv5) {
+                        expect(data).toContain(word);
+                    }
+                } else {
+                    for (const word of wordsInStatsv4) {
+                        expect(data).toContain(word);
+                    }
+                }
+
+                if (!modified) {
+                    process.nextTick(() => {
+                        writeFileSync(resolve(__dirname, './src/index.js'), `console.log('watch flag test');`);
+                    });
+
+                    modified = true;
+                } else {
+                    proc.kill();
+                    done();
+                }
+            }
+        });
+    });
+});

--- a/test/watch/watch-variable/watch-variable.test.js
+++ b/test/watch/watch-variable/watch-variable.test.js
@@ -10,8 +10,6 @@ const wordsInStatsv5 = ['asset', 'index.js', 'compiled successfully'];
 
 describe('watch variable', () => {
     it('should pass `WEBPACK_WATCH` env variable and recompile upon file change using the `watch` command', (done) => {
-        expect.assertions(10);
-
         const proc = runAndGetWatchProc(__dirname, ['watch', '--mode', 'development'], false, '', true);
 
         let modified = false;
@@ -47,8 +45,6 @@ describe('watch variable', () => {
     });
 
     it('should pass `WEBPACK_WATCH` env variable and recompile upon file change using the `--watch` option', (done) => {
-        expect.assertions(10);
-
         const proc = runAndGetWatchProc(__dirname, ['--watch', '--mode', 'development'], false, '', true);
 
         let modified = false;

--- a/test/watch/watch-variable/webpack.config.js
+++ b/test/watch/watch-variable/webpack.config.js
@@ -1,0 +1,24 @@
+const isInProcess = process.env.WEBPACK_WATCH;
+
+class CustomTestPlugin {
+    constructor(isInEnvironment) {
+        this.isInEnvironment = isInEnvironment;
+    }
+    apply(compiler) {
+        compiler.hooks.done.tap('testPlugin', () => {
+            if (!isInProcess && this.isInEnvironment) {
+                console.log('PASS');
+            } else {
+                console.log('FAIL');
+            }
+        });
+    }
+}
+
+module.exports = (env) => {
+    return {
+        mode: 'development',
+        devtool: false,
+        plugins: [new CustomTestPlugin(env.WEBPACK_WATCH)],
+    };
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
fix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
yes
**If relevant, did you update the documentation?**
no
**Summary**
fixes https://github.com/webpack/webpack-cli/issues/2370
show a warning if `serve` and `--watch` are used together

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
I will work on removing `--watch` & `--no-watch` options from `serve` help output in next PR.