### PR TITLE
feat: display used config path when logging level=log

### DIFF
--- a/packages/webpack-cli/__tests__/applyCLIPlugin.test.js
+++ b/packages/webpack-cli/__tests__/applyCLIPlugin.test.js
@@ -5,7 +5,7 @@ const applyCLIPlugin = new webpackCLI().applyCLIPlugin;
 
 describe('CLIPluginResolver', () => {
     it('should add CLI plugin to single compiler object', async () => {
-        const result = await applyCLIPlugin({ options: {} }, { hot: true, prefetch: true });
+        const result = await applyCLIPlugin({ options: {}, path: new WeakMap() }, { hot: true, prefetch: true });
         expect(result.options.plugins[0] instanceof CLIPlugin).toBeTruthy();
         expect(result.options.plugins[0].options).toEqual({
             configPath: undefined,
@@ -18,7 +18,7 @@ describe('CLIPluginResolver', () => {
     });
 
     it('should add CLI plugin to multi compiler object', async () => {
-        const result = await applyCLIPlugin({ options: [{}, {}] }, { hot: true, prefetch: true });
+        const result = await applyCLIPlugin({ options: [{}, {}], path: new WeakMap() }, { hot: true, prefetch: true });
         expect(result.options[0].plugins[0] instanceof CLIPlugin).toBeTruthy();
         expect(result.options[1].plugins[0] instanceof CLIPlugin).toBeTruthy();
         expect(result.options).toEqual([

--- a/packages/webpack-cli/lib/plugins/CLIPlugin.js
+++ b/packages/webpack-cli/lib/plugins/CLIPlugin.js
@@ -41,7 +41,12 @@ class CLIPlugin {
         const pluginName = 'webpack-cli';
         const getCompilationName = () => (compiler.name ? ` '${compiler.name}'` : '');
 
+        const { configPath } = this.options;
+
         compiler.hooks.run.tap(pluginName, () => {
+            if (configPath) {
+                this.logger.log(`Using config ${configPath}`);
+            }
             this.logger.log(`Compilation${getCompilationName()} starting...`);
         });
 
@@ -50,6 +55,10 @@ class CLIPlugin {
 
             if (bail && watch) {
                 this.logger.warn('You are using "bail" with "watch". "bail" will still exit webpack when the first error is found.');
+            }
+
+            if (configPath) {
+                this.logger.log(`Using config ${configPath}`);
             }
 
             this.logger.log(`Compilation${getCompilationName()} starting...`);

--- a/packages/webpack-cli/lib/webpack-cli.js
+++ b/packages/webpack-cli/lib/webpack-cli.js
@@ -1631,7 +1631,7 @@ class WebpackCLI {
 
             configOptions.plugins.unshift(
                 new CLIPlugin({
-                    configPath: config.path,
+                    configPath: config.path.get(configOptions),
                     helpfulOutput: !cliOptions.json,
                     hot: cliOptions.hot,
                     progress: cliOptions.progress,

--- a/test/build/basic/basic.test.js
+++ b/test/build/basic/basic.test.js
@@ -1,6 +1,6 @@
 'use strict';
-
-const { run } = require('../../utils/test-utils');
+const { resolve } = require('path');
+const { run, isWebpack5 } = require('../../utils/test-utils');
 
 describe('bundle command', () => {
     it('should work without command (default command)', async () => {
@@ -139,5 +139,15 @@ describe('bundle command', () => {
         expect(stderr).toContain("Did you mean 'build' (alias 'bundle, b')?");
         expect(stderr).toContain("Run 'webpack --help' to see available commands and options");
         expect(stdout).toBeFalsy();
+    });
+
+    it('should log supplied config when logging level is log', () => {
+        if (isWebpack5) {
+            const { exitCode, stderr, stdout } = run(__dirname, ['--config', './entry.config.js', '--infrastructure-logging-level', 'log']);
+            expect(exitCode).toBe(0);
+            const configPath = resolve(__dirname, './entry.config.js');
+            expect(stderr).toContain(`Using config ${configPath}`);
+            expect(stdout).toBeFalsy();
+        }
     });
 });

--- a/test/build/basic/basic.test.js
+++ b/test/build/basic/basic.test.js
@@ -1,6 +1,6 @@
 'use strict';
 const { resolve } = require('path');
-const { run, isWebpack5 } = require('../../utils/test-utils');
+const { run } = require('../../utils/test-utils');
 
 describe('bundle command', () => {
     it('should work without command (default command)', async () => {
@@ -142,12 +142,10 @@ describe('bundle command', () => {
     });
 
     it('should log supplied config when logging level is log', () => {
-        if (isWebpack5) {
-            const { exitCode, stderr, stdout } = run(__dirname, ['--config', './entry.config.js', '--infrastructure-logging-level', 'log']);
-            expect(exitCode).toBe(0);
-            const configPath = resolve(__dirname, './entry.config.js');
-            expect(stderr).toContain(`Using config ${configPath}`);
-            expect(stdout).toBeFalsy();
-        }
+        const { exitCode, stderr, stdout } = run(__dirname, ['--config', './log.config.js']);
+        expect(exitCode).toBe(0);
+        const configPath = resolve(__dirname, './log.config.js');
+        expect(stderr).toContain(`Using config ${configPath}`);
+        expect(stdout).toBeTruthy();
     });
 });

--- a/test/build/basic/log.config.js
+++ b/test/build/basic/log.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+    mode: 'development',
+    infrastructureLogging: {
+        level: 'log',
+    },
+};

--- a/test/core-flags/infrastructure-logging.test.js
+++ b/test/core-flags/infrastructure-logging.test.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const { run } = require('../utils/test-utils');
-const { resolve } = require('path');
 
 describe('infrastructure logging related flag', () => {
     it('should set infrastructureLogging.debug properly', () => {
@@ -25,17 +24,6 @@ describe('infrastructure logging related flag', () => {
 
         expect(exitCode).toBe(0);
         expect(stderr).toContain("Compilation 'compiler' starting...");
-        expect(stderr).toContain("Compilation 'compiler' finished");
-        expect(stdout).toContain(`level: 'log'`);
-    });
-
-    it('should log used default config when level is log', () => {
-        const { exitCode, stderr, stdout } = run(__dirname, ['--infrastructure-logging-level', 'log']);
-
-        expect(exitCode).toBe(0);
-        const configPath = resolve(__dirname, './webpack.config.js');
-        expect(stderr).toContain("Compilation 'compiler' starting...");
-        expect(stderr).toContain(`Using config ${configPath}`);
         expect(stderr).toContain("Compilation 'compiler' finished");
         expect(stdout).toContain(`level: 'log'`);
     });

--- a/test/core-flags/infrastructure-logging.test.js
+++ b/test/core-flags/infrastructure-logging.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { run, runWatch } = require('../utils/test-utils');
+const { run } = require('../utils/test-utils');
 const { resolve } = require('path');
 
 describe('infrastructure logging related flag', () => {
@@ -37,47 +37,6 @@ describe('infrastructure logging related flag', () => {
         expect(stderr).toContain("Compilation 'compiler' starting...");
         expect(stderr).toContain(`Using config ${configPath}`);
         expect(stderr).toContain("Compilation 'compiler' finished");
-        expect(stdout).toContain(`level: 'log'`);
-    });
-
-    it('should log used supplied config when level is log', () => {
-        const { exitCode, stderr, stdout } = run(__dirname, [
-            '--config',
-            'webpack.cache.config.js',
-            '--infrastructure-logging-level',
-            'log',
-        ]);
-
-        expect(exitCode).toBe(0);
-        const configPath = resolve(__dirname, './webpack.cache.config.js');
-        expect(stderr).toContain(`Using config ${configPath}`);
-        expect(stdout).toContain(`level: 'log'`);
-    });
-
-    it('should log used supplied config with watch', async () => {
-        const { stderr, stdout } = await runWatch(__dirname, [
-            '--config',
-            'webpack.cache.config.js',
-            '--infrastructure-logging-level',
-            'log',
-        ]);
-
-        const configPath = resolve(__dirname, './webpack.cache.config.js');
-        expect(stderr).toContain(`Using config ${configPath}`);
-        expect(stdout).toContain(`level: 'log'`);
-    });
-
-    it('should log used supplied config with serve', async () => {
-        const { stderr, stdout } = await runWatch(__dirname, [
-            'serve',
-            '--config',
-            'webpack.cache.config.js',
-            '--infrastructure-logging-level',
-            'log',
-        ]);
-
-        const configPath = resolve(__dirname, './webpack.cache.config.js');
-        expect(stderr).toContain(`Using config ${configPath}`);
         expect(stdout).toContain(`level: 'log'`);
     });
 });

--- a/test/core-flags/infrastructure-logging.test.js
+++ b/test/core-flags/infrastructure-logging.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
-const { run } = require('../utils/test-utils');
+const { run, runWatch } = require('../utils/test-utils');
+const { resolve } = require('path');
 
 describe('infrastructure logging related flag', () => {
     it('should set infrastructureLogging.debug properly', () => {
@@ -25,6 +26,58 @@ describe('infrastructure logging related flag', () => {
         expect(exitCode).toBe(0);
         expect(stderr).toContain("Compilation 'compiler' starting...");
         expect(stderr).toContain("Compilation 'compiler' finished");
+        expect(stdout).toContain(`level: 'log'`);
+    });
+
+    it('should log used default config when level is log', () => {
+        const { exitCode, stderr, stdout } = run(__dirname, ['--infrastructure-logging-level', 'log']);
+
+        expect(exitCode).toBe(0);
+        const configPath = resolve(__dirname, './webpack.config.js');
+        expect(stderr).toContain("Compilation 'compiler' starting...");
+        expect(stderr).toContain(`Using config ${configPath}`);
+        expect(stderr).toContain("Compilation 'compiler' finished");
+        expect(stdout).toContain(`level: 'log'`);
+    });
+
+    it('should log used supplied config when level is log', () => {
+        const { exitCode, stderr, stdout } = run(__dirname, [
+            '--config',
+            'webpack.cache.config.js',
+            '--infrastructure-logging-level',
+            'log',
+        ]);
+
+        expect(exitCode).toBe(0);
+        const configPath = resolve(__dirname, './webpack.cache.config.js');
+        expect(stderr).toContain(`Using config ${configPath}`);
+        expect(stdout).toContain(`level: 'log'`);
+    });
+
+    it('should log used supplied config with watch', async () => {
+        const { stderr, stdout } = await runWatch(__dirname, [
+            '--config',
+            'webpack.cache.config.js',
+            '--infrastructure-logging-level',
+            'log',
+        ]);
+
+        const configPath = resolve(__dirname, './webpack.cache.config.js');
+        expect(stderr).toContain(`Using config ${configPath}`);
+        expect(stdout).toContain(`level: 'log'`);
+    });
+
+    it('should log used supplied config with serve', async () => {
+        const { stderr, stdout } = await runWatch(__dirname, [
+            'serve',
+            '--config',
+            'webpack.cache.config.js',
+            '--infrastructure-logging-level',
+            'log',
+        ]);
+
+        const configPath = resolve(__dirname, './webpack.cache.config.js');
+        expect(stderr).toContain(`Using config ${configPath}`);
         expect(stdout).toContain(`level: 'log'`);
     });
 });

--- a/test/serve/basic/log.config.js
+++ b/test/serve/basic/log.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+    mode: 'development',
+    infrastructureLogging: {
+        level: 'log',
+    },
+};

--- a/test/serve/basic/serve-basic.test.js
+++ b/test/serve/basic/serve-basic.test.js
@@ -331,17 +331,10 @@ describe('basic serve usage', () => {
     });
 
     it('should log used supplied config with serve', async () => {
-        if (isWebpack5) {
-            const { stderr, stdout } = await runServe(__dirname, [
-                '--config',
-                'webpack.config.js',
-                '--infrastructure-logging-level',
-                'log',
-            ]);
+        const { stderr, stdout } = await runServe(__dirname, ['--config', 'log.config.js']);
 
-            const configPath = path.resolve(__dirname, './webpack.cache.config.js');
-            expect(stderr).toContain(`Using config ${configPath}`);
-            expect(stdout).toBeFalsy();
-        }
+        const configPath = path.resolve(__dirname, './log.config.js');
+        expect(stderr).toContain(`Using config ${configPath}`);
+        expect(stdout).toBeTruthy();
     });
 });

--- a/test/serve/basic/serve-basic.test.js
+++ b/test/serve/basic/serve-basic.test.js
@@ -329,4 +329,19 @@ describe('basic serve usage', () => {
         expect(stderr).toContain("Error: Unknown option '--unknown-flag'");
         expect(stdout).toBeFalsy();
     });
+
+    it('should log used supplied config with serve', async () => {
+        if (isWebpack5) {
+            const { stderr, stdout } = await runServe(__dirname, [
+                '--config',
+                'webpack.config.js',
+                '--infrastructure-logging-level',
+                'log',
+            ]);
+
+            const configPath = path.resolve(__dirname, './webpack.cache.config.js');
+            expect(stderr).toContain(`Using config ${configPath}`);
+            expect(stdout).toBeFalsy();
+        }
+    });
 });

--- a/test/watch/basic/basic.test.js
+++ b/test/watch/basic/basic.test.js
@@ -178,18 +178,10 @@ describe('basic', () => {
     });
 
     it('should log supplied config with watch', async () => {
-        if (isWebpack5) {
-            const { stderr, stdout } = await run(__dirname, [
-                'watch',
-                '--config',
-                'watch.config.js',
-                '--infrastructure-logging-level',
-                'log',
-            ]);
+        const { stderr, stdout } = await run(__dirname, ['watch', '--config', 'log.config.js']);
 
-            const configPath = resolve(__dirname, './watch.config.js');
-            expect(stderr).toContain(`Using config ${configPath}`);
-            expect(stdout).toBeFalsy();
-        }
+        const configPath = resolve(__dirname, './log.config.js');
+        expect(stderr).toContain(`Using config ${configPath}`);
+        expect(stdout).toBeTruthy();
     });
 });

--- a/test/watch/basic/basic.test.js
+++ b/test/watch/basic/basic.test.js
@@ -176,4 +176,20 @@ describe('basic', () => {
         expect(stderr).toContain("Run 'webpack --help' to see available commands and options");
         expect(stdout).toBeFalsy();
     });
+
+    it('should log supplied config with watch', async () => {
+        if (isWebpack5) {
+            const { stderr, stdout } = await run(__dirname, [
+                'watch',
+                '--config',
+                'watch.config.js',
+                '--infrastructure-logging-level',
+                'log',
+            ]);
+
+            const configPath = resolve(__dirname, './watch.config.js');
+            expect(stderr).toContain(`Using config ${configPath}`);
+            expect(stdout).toBeFalsy();
+        }
+    });
 });

--- a/test/watch/basic/log.config.js
+++ b/test/watch/basic/log.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+    mode: 'development',
+    infrastructureLogging: {
+        level: 'log',
+    },
+};


### PR DESCRIPTION
**What kind of change does this PR introduce?**

feat

**Did you add tests for your changes?**
yes

**If relevant, did you update the documentation?**
NA

**Summary**
- Displays the used config when infra logging level is log, helpful to know which config is in use when there are multiple

**Does this PR introduce a breaking change?**
No

**Other information**
