### PR TITLE
fix: add serve script if opted for WDS with init

### DIFF
--- a/packages/generators/init-template/package.json.js
+++ b/packages/generators/init-template/package.json.js
@@ -3,7 +3,7 @@ module.exports = (isUsingDevServer) => {
         build: 'webpack',
     };
     if (isUsingDevServer) {
-        scripts.start = 'webpack serve';
+        scripts.serve = 'webpack serve';
     }
 
     return {

--- a/packages/generators/init-template/package.json.js
+++ b/packages/generators/init-template/package.json.js
@@ -1,9 +1,9 @@
-module.exports = (usingDefaults) => {
+module.exports = (isUsingDevServer) => {
     const scripts = {
         build: 'webpack',
     };
-    if (usingDefaults) {
-        scripts.start = 'webpack-dev-server';
+    if (isUsingDevServer) {
+        scripts.start = 'webpack serve';
     }
 
     return {

--- a/packages/generators/src/init-generator.ts
+++ b/packages/generators/src/init-generator.ts
@@ -244,9 +244,13 @@ export default class InitGenerator extends CustomGenerator {
     public writing(): void {
         this.config.set('configuration', this.configuration);
 
+        const isUsingDevServer = this.dependencies.includes('webpack-dev-server');
         const packageJsonTemplatePath = '../init-template/package.json.js';
-        // eslint-disable-next-line @typescript-eslint/no-var-requires
-        this.fs.extendJSON(this.destinationPath('package.json'), require(packageJsonTemplatePath)(this.autoGenerateConfig));
+        this.fs.extendJSON(
+            this.destinationPath('package.json'),
+            // eslint-disable-next-line @typescript-eslint/no-var-requires
+            require(packageJsonTemplatePath)(isUsingDevServer),
+        );
 
         const generateEntryFile = (entryPath: string, name: string): void => {
             entryPath = entryPath.replace(/'/g, '');

--- a/test/init/auto/init-auto.test.js
+++ b/test/init/auto/init-auto.test.js
@@ -51,7 +51,9 @@ describe('init auto flag', () => {
             expect(pkgJson).toBeTruthy();
             expect(pkgJson['devDependencies']).toBeTruthy();
             expect(pkgJson['devDependencies']['webpack']).toBeTruthy();
+            expect(pkgJson['devDependencies']['webpack-dev-server']).toBeTruthy();
             expect(pkgJson['scripts']['build'] == 'webpack').toBeTruthy();
+            expect(pkgJson['scripts']['start'] == 'webpack serve').toBeTruthy();
         };
         expect(pkgJsonTests).not.toThrow();
 

--- a/test/init/auto/init-auto.test.js
+++ b/test/init/auto/init-auto.test.js
@@ -53,7 +53,7 @@ describe('init auto flag', () => {
             expect(pkgJson['devDependencies']['webpack']).toBeTruthy();
             expect(pkgJson['devDependencies']['webpack-dev-server']).toBeTruthy();
             expect(pkgJson['scripts']['build'] == 'webpack').toBeTruthy();
-            expect(pkgJson['scripts']['start'] == 'webpack serve').toBeTruthy();
+            expect(pkgJson['scripts']['serve'] == 'webpack serve').toBeTruthy();
         };
         expect(pkgJsonTests).not.toThrow();
 

--- a/test/init/generation-path/init-generation-path.test.js
+++ b/test/init/generation-path/init-generation-path.test.js
@@ -44,7 +44,7 @@ describe('init generate-path flag', () => {
             expect(pkgJson['devDependencies']['webpack']).toBeTruthy();
             expect(pkgJson['devDependencies']['webpack-dev-server']).toBeTruthy();
             expect(pkgJson['scripts']['build'] == 'webpack').toBeTruthy();
-            expect(pkgJson['scripts']['start'] == 'webpack-dev-server').toBeTruthy();
+            expect(pkgJson['scripts']['serve'] == 'webpack serve').toBeTruthy();
         };
         expect(pkgJsonTests).not.toThrow();
     });
@@ -82,7 +82,7 @@ describe('init generate-path flag', () => {
             expect(pkgJson['devDependencies']['webpack']).toBeTruthy();
             expect(pkgJson['devDependencies']['webpack-dev-server']).toBeTruthy();
             expect(pkgJson['scripts']['build'] == 'webpack').toBeTruthy();
-            expect(pkgJson['scripts']['start'] == 'webpack serve').toBeTruthy();
+            expect(pkgJson['scripts']['serve'] == 'webpack serve').toBeTruthy();
         };
         expect(pkgJsonTests).not.toThrow();
     });

--- a/test/init/generation-path/init-generation-path.test.js
+++ b/test/init/generation-path/init-generation-path.test.js
@@ -42,7 +42,9 @@ describe('init generate-path flag', () => {
             expect(pkgJson).toBeTruthy();
             expect(pkgJson['devDependencies']).toBeTruthy();
             expect(pkgJson['devDependencies']['webpack']).toBeTruthy();
+            expect(pkgJson['devDependencies']['webpack-dev-server']).toBeTruthy();
             expect(pkgJson['scripts']['build'] == 'webpack').toBeTruthy();
+            expect(pkgJson['scripts']['start'] == 'webpack-dev-server').toBeTruthy();
         };
         expect(pkgJsonTests).not.toThrow();
     });
@@ -78,7 +80,9 @@ describe('init generate-path flag', () => {
             expect(pkgJson).toBeTruthy();
             expect(pkgJson['devDependencies']).toBeTruthy();
             expect(pkgJson['devDependencies']['webpack']).toBeTruthy();
+            expect(pkgJson['devDependencies']['webpack-dev-server']).toBeTruthy();
             expect(pkgJson['scripts']['build'] == 'webpack').toBeTruthy();
+            expect(pkgJson['scripts']['start'] == 'webpack serve').toBeTruthy();
         };
         expect(pkgJsonTests).not.toThrow();
     });

--- a/test/init/generator/init-inquirer.test.js
+++ b/test/init/generator/init-inquirer.test.js
@@ -46,7 +46,9 @@ describe('init', () => {
             expect(pkgJson).toBeTruthy();
             expect(pkgJson['devDependencies']).toBeTruthy();
             expect(pkgJson['devDependencies']['webpack']).toBeTruthy();
+            expect(pkgJson['devDependencies']['webpack-dev-server']).toBeTruthy();
             expect(pkgJson['scripts']['build'] == 'webpack').toBeTruthy();
+            expect(pkgJson['scripts']['serve'] == 'webpack serve').toBeTruthy();
         };
         expect(pkgJsonTests).not.toThrow();
 

--- a/test/init/language/css/init-language-css.test.js
+++ b/test/init/language/css/init-language-css.test.js
@@ -76,7 +76,7 @@ describe('init with SCSS', () => {
             expect(pkgJson['devDependencies']['node-sass']).toBeTruthy();
             expect(pkgJson['devDependencies']['mini-css-extract-plugin']).toBeTruthy();
             expect(pkgJson['scripts']['build'] == 'webpack').toBeTruthy();
-            expect(pkgJson['scripts']['start'] == 'webpack serve').toBeTruthy();
+            expect(pkgJson['scripts']['serve'] == 'webpack serve').toBeTruthy();
         };
         expect(pkgJsonTests).not.toThrow();
     });

--- a/test/init/language/css/init-language-css.test.js
+++ b/test/init/language/css/init-language-css.test.js
@@ -72,9 +72,11 @@ describe('init with SCSS', () => {
             expect(pkgJson).toBeTruthy();
             expect(pkgJson['devDependencies']).toBeTruthy();
             expect(pkgJson['devDependencies']['webpack']).toBeTruthy();
+            expect(pkgJson['devDependencies']['webpack-dev-server']).toBeTruthy();
             expect(pkgJson['devDependencies']['node-sass']).toBeTruthy();
             expect(pkgJson['devDependencies']['mini-css-extract-plugin']).toBeTruthy();
             expect(pkgJson['scripts']['build'] == 'webpack').toBeTruthy();
+            expect(pkgJson['scripts']['start'] == 'webpack serve').toBeTruthy();
         };
         expect(pkgJsonTests).not.toThrow();
     });

--- a/test/init/language/js/init-language-js.test.js
+++ b/test/init/language/js/init-language-js.test.js
@@ -56,9 +56,11 @@ describe('init with Typescript', () => {
             expect(pkgJson).toBeTruthy();
             expect(pkgJson['devDependencies']).toBeTruthy();
             expect(pkgJson['devDependencies']['webpack']).toBeTruthy();
+            expect(pkgJson['devDependencies']['webpack-dev-server']).toBeTruthy();
             expect(pkgJson['devDependencies']['typescript']).toBeTruthy();
             expect(pkgJson['devDependencies']['ts-loader']).toBeTruthy();
             expect(pkgJson['scripts']['build'] == 'webpack').toBeTruthy();
+            expect(pkgJson['scripts']['start'] == 'webpack serve').toBeTruthy();
         };
         expect(pkgJsonTests).not.toThrow();
     });

--- a/test/init/language/js/init-language-js.test.js
+++ b/test/init/language/js/init-language-js.test.js
@@ -60,7 +60,7 @@ describe('init with Typescript', () => {
             expect(pkgJson['devDependencies']['typescript']).toBeTruthy();
             expect(pkgJson['devDependencies']['ts-loader']).toBeTruthy();
             expect(pkgJson['scripts']['build'] == 'webpack').toBeTruthy();
-            expect(pkgJson['scripts']['start'] == 'webpack serve').toBeTruthy();
+            expect(pkgJson['scripts']['serve'] == 'webpack serve').toBeTruthy();
         };
         expect(pkgJsonTests).not.toThrow();
     });

--- a/test/init/multipleEntries/init-multipleEntries.test.js
+++ b/test/init/multipleEntries/init-multipleEntries.test.js
@@ -51,8 +51,10 @@ describe('init with multiple entries', () => {
             expect(pkgJson).toBeTruthy();
             expect(pkgJson['devDependencies']).toBeTruthy();
             expect(pkgJson['devDependencies']['webpack']).toBeTruthy();
+            expect(pkgJson['devDependencies']['webpack-dev-server']).toBeTruthy();
             expect(pkgJson['devDependencies']['terser-webpack-plugin']).toBeTruthy();
             expect(pkgJson['scripts']['build'] == 'webpack').toBeTruthy();
+            expect(pkgJson['scripts']['start'] == 'webpack-dev-server').toBeTruthy();
         };
         expect(pkgJsonTests).not.toThrow();
     });

--- a/test/init/multipleEntries/init-multipleEntries.test.js
+++ b/test/init/multipleEntries/init-multipleEntries.test.js
@@ -54,7 +54,7 @@ describe('init with multiple entries', () => {
             expect(pkgJson['devDependencies']['webpack-dev-server']).toBeTruthy();
             expect(pkgJson['devDependencies']['terser-webpack-plugin']).toBeTruthy();
             expect(pkgJson['scripts']['build'] == 'webpack').toBeTruthy();
-            expect(pkgJson['scripts']['start'] == 'webpack-dev-server').toBeTruthy();
+            expect(pkgJson['scripts']['serve'] == 'webpack-dev-server').toBeTruthy();
         };
         expect(pkgJsonTests).not.toThrow();
     });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
patch

**Did you add tests for your changes?**
Update existing test suite.

**If relevant, did you update the documentation?**
Nope

**Summary**
https://github.com/webpack/webpack-cli/blob/dd0f1632217a40c04c19af973ef3d696cc595d21/packages/generators/init-template/package.json.js#L6
The current implementation adds a `start` script that invokes `webpack-dev-server`. However, the intended way would be to have `webpack serve` instead.

Adds a `serve` script if the user opts for `webpack-dev-server`.

**Does this PR introduce a breaking change?**
Nope

**Other information**
N/A