### PR TITLE
docs: remove references to init package

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Thus, webpack CLI provides different commands for many common tasks.
 -   `build|bundle|b [entries...] [options]` - Run webpack (default command, can be omitted).
 -   [`configtest|t [config-path]`](./packages/configtest/README.md#webpack-cli-configtest) - Validate a webpack configuration.
 -   `help|h [command] [option]` - Display help for commands and options.
--   [`init|c [scaffold...] [options]`](./packages/init/README.md#webpack-cli-init) - Create a new webpack configuration.
+-   [`init|c [scaffold...] [options]`](./INIT.md#webpack-cli-init) - Create a new webpack configuration.
 -   [`info|i [options]`](./packages/info/README.md#webpack-cli-info) - Returns information related to the local environment.
 -   [`migrate|m <config-path> [new-config-path]`](https://www.npmjs.com/package/@webpack-cli/migrate) - Migrate project from one version to another.
 -   [`plugin|p [output-path]`](./packages/generators#generators) - Initiate new plugin project.

--- a/packages/README.md
+++ b/packages/README.md
@@ -16,10 +16,9 @@ This folder is the collection of those packages.
 1. [configtest](https://github.com/webpack/webpack-cli/tree/master/packages/configtest)
 2. [generators](https://github.com/webpack/webpack-cli/tree/master/packages/generators)
 3. [info](https://github.com/webpack/webpack-cli/tree/master/packages/info)
-4. [init](https://github.com/webpack/webpack-cli/tree/master/packages/init)
-5. [migrate](https://www.npmjs.com/package/@webpack-cli/migrate)
-6. [serve](https://github.com/webpack/webpack-cli/tree/master/packages/serve)
-7. [webpack-cli](https://github.com/webpack/webpack-cli/tree/master/packages/webpack-cli)
+4. [migrate](https://www.npmjs.com/package/@webpack-cli/migrate)
+5. [serve](https://github.com/webpack/webpack-cli/tree/master/packages/serve)
+6. [webpack-cli](https://github.com/webpack/webpack-cli/tree/master/packages/webpack-cli)
 
 ## Generic Installation
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Docs update

**Did you add tests for your changes?**
N/A

**If relevant, did you update the documentation?**
Yup

**Summary**
Remove references to the `init` package, which was unioned to `generators`.

**Does this PR introduce a breaking change?**
Nope

**Other information**
#2393