### PR TITLE
fix: comment on config resolution priority

### DIFF
--- a/packages/webpack-cli/lib/webpack-cli.js
+++ b/packages/webpack-cli/lib/webpack-cli.js
@@ -1337,7 +1337,7 @@ class WebpackCLI {
         } else {
             const { interpret } = this.utils;
 
-            // Order defines the priority, in increasing order
+            // Order defines the priority, in decreasing order
             const defaultConfigFiles = ['webpack.config', '.webpack/webpack.config', '.webpack/webpackfile']
                 .map((filename) =>
                     // Since .cjs is not available on interpret side add it manually to default config extension list


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
minor comment change, currently tells opposite
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
N/A

**If relevant, did you update the documentation?**
N/A

**Summary**
Comment previously told that `['webpack.config', '.webpack/webpack.config', '.webpack/webpackfile']` this is priority in the increasing order for location of configuration, but actually it is in decreasing order. First one being highest priority.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
N/A