### PR TITLE
fix: ignore __tests__ directories

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,6 +7,7 @@ lib
 .editorconfig
 .eslintignore
 __testfixtures__
+*/__tests__/*
 *.test.js
 *.input.js
 types.js


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Closes #2560. 

This was causing issues for a Sonatype scanner my org uses, because an empty `package-lock.json` file appeared in the source tree. (Which the scanner tried to parse, and an empty file is not a valid json object.) 

As you can see in the line below this, `*.test.js` files are already excluded, just not other content in the test folders.

**Did you add tests for your changes?**

Not relevant.

**If relevant, did you update the documentation?**

Not relevant.

**Summary**

See #2560 for more detail.

**Does this PR introduce a breaking change?**

No.

**Other information**

I was running into this issue on `webpack-cli@4.5.0`