### PR TITLE
test: init generator throws if the path is not writable

### DIFF
--- a/test/init/init.test.js
+++ b/test/init/init.test.js
@@ -2,7 +2,7 @@ const { mkdirSync, existsSync, readFileSync } = require('fs');
 const { join, resolve } = require('path');
 // eslint-disable-next-line node/no-unpublished-require
 const rimraf = require('rimraf');
-const { run, runPromptWithAnswers } = require('../utils/test-utils');
+const { isWindows, run, runPromptWithAnswers } = require('../utils/test-utils');
 
 const assetsPath = resolve(__dirname, './test-assets');
 const ENTER = '\x0D';
@@ -335,5 +335,17 @@ describe('init command', () => {
 
         // Check if the generated webpack configuration matches the snapshot
         expect(readFromWebpackConfig(assetsPath)).toMatchSnapshot();
+    });
+
+    it('should throw if the current path is not writable', async () => {
+        const projectPath = join(assetsPath, 'non-writable-path');
+        mkdirSync(projectPath, 0o500);
+        const { exitCode, stderr } = await run(projectPath, ['init', 'my-app'], { reject: false });
+
+        if (isWindows) {
+            return;
+        }
+        expect(exitCode).toBe(2);
+        expect(stderr).toContain('Failed to create directory');
     });
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Test update

**Did you add tests for your changes?**
Update test suite.

**If relevant, did you update the documentation?**
N/A

**Summary**
This PR aims at adding a test case to ensure the behavior of `init-generator` throwing if the current path is non-writable.

**Does this PR introduce a breaking change?**
Nope

**Other information**
#2569