### PR TITLE
Fixed a broken link to this repository

### DIFF
--- a/packages/generators/init-template/default/webpack.configjs.tpl
+++ b/packages/generators/init-template/default/webpack.configjs.tpl
@@ -1,4 +1,4 @@
-// Generated using webpack-cli http://github.com/webpack-cli
+// Generated using webpack-cli https://github.com/webpack/webpack-cli
 const path = require('path');<% if (htmlWebpackPlugin) { %>
 const HtmlWebpackPlugin = require('html-webpack-plugin');<% } %><% if (isExtractPlugin) { %>
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');<% } %>


### PR DESCRIPTION
the old url :  https://github.com/webpack-cli leads to a 404 page 
new url :  https://github.com/webpack/webpack-cli is the right one I think