### PR TITLE
fix(serve): do not set port for modern client

### DIFF
--- a/packages/serve/src/startDevServer.ts
+++ b/packages/serve/src/startDevServer.ts
@@ -72,16 +72,7 @@ export default async function startDevServer(
         const options = mergeOptions(compilerWithDevServerOption.options.devServer || {}, devServerCliOptions);
 
         if (isDevServer4) {
-            // eslint-disable-next-line node/no-extraneous-require
-            const devServerFlags = require('webpack-dev-server/bin/cli-flags').devServer;
-
-            const isModernClient = Boolean(devServerFlags.find((flag) => flag.name === 'client-web-socket-url'));
-
-            if (!isModernClient) {
-                options.port = await findPort(options.port);
-                options.client = options.client || {};
-                options.client.port = options.client.port || options.port;
-            }
+            options.port = await findPort(options.port);
         } else {
             const getPublicPathOption = (): string => {
                 const normalizePublicPath = (publicPath): string =>

--- a/packages/serve/src/startDevServer.ts
+++ b/packages/serve/src/startDevServer.ts
@@ -72,9 +72,17 @@ export default async function startDevServer(
         const options = mergeOptions(compilerWithDevServerOption.options.devServer || {}, devServerCliOptions);
 
         if (isDevServer4) {
+            // eslint-disable-next-line node/no-extraneous-require
+            const devServerFlags = require('webpack-dev-server/bin/cli-flags').devServer;
+
+            const isModernClient = Boolean(devServerFlags.find((flag) => flag.name === 'client-web-socket-url'));
+
             options.port = await findPort(options.port);
             options.client = options.client || {};
-            options.client.port = options.client.port || options.port;
+
+            if (!isModernClient) {
+                options.client.port = options.client.port || options.port;
+            }
         } else {
             const getPublicPathOption = (): string => {
                 const normalizePublicPath = (publicPath): string =>

--- a/packages/serve/src/startDevServer.ts
+++ b/packages/serve/src/startDevServer.ts
@@ -77,10 +77,9 @@ export default async function startDevServer(
 
             const isModernClient = Boolean(devServerFlags.find((flag) => flag.name === 'client-web-socket-url'));
 
-            options.port = await findPort(options.port);
-            options.client = options.client || {};
-
             if (!isModernClient) {
+                options.port = await findPort(options.port);
+                options.client = options.client || {};
                 options.client.port = options.client.port || options.port;
             }
         } else {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
fix
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
NA

**If relevant, did you update the documentation?**
NA
**Summary**

we removed `client.port` in https://github.com/webpack/webpack-dev-server/pull/3181

Refer https://github.com/webpack/webpack-dev-server/pull/3181#issuecomment-818921391
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
No