### PR TITLE
fix: avoid unnecessary searching port

### DIFF
--- a/packages/serve/src/startDevServer.ts
+++ b/packages/serve/src/startDevServer.ts
@@ -21,15 +21,13 @@ export default async function startDevServer(
     cliOptions: any,
     logger: any,
 ): Promise<Record<string, unknown>[]> {
-    let devServerVersion, Server, findPort;
+    let devServerVersion, Server;
 
     try {
         // eslint-disable-next-line node/no-extraneous-require
         devServerVersion = require('webpack-dev-server/package.json').version;
         // eslint-disable-next-line node/no-extraneous-require
         Server = require('webpack-dev-server/lib/Server');
-        // eslint-disable-next-line node/no-extraneous-require
-        findPort = require('webpack-dev-server/lib/utils/findPort');
     } catch (err) {
         logger.error(`You need to install 'webpack-dev-server' for running 'webpack serve'.\n${err}`);
         process.exit(2);
@@ -71,9 +69,7 @@ export default async function startDevServer(
     for (const compilerWithDevServerOption of compilersWithDevServerOption) {
         const options = mergeOptions(compilerWithDevServerOption.options.devServer || {}, devServerCliOptions);
 
-        if (isDevServer4) {
-            options.port = await findPort(options.port);
-        } else {
+        if (!isDevServer4) {
             const getPublicPathOption = (): string => {
                 const normalizePublicPath = (publicPath): string =>
                     typeof publicPath === 'undefined' || publicPath === 'auto' ? '/' : publicPath;
@@ -85,11 +81,6 @@ export default async function startDevServer(
                 // webpack-dev-server@3
                 if (options.publicPath) {
                     return normalizePublicPath(options.publicPath);
-                }
-
-                // webpack-dev-server@4
-                if (options.dev && options.dev.publicPath) {
-                    return normalizePublicPath(options.dev.publicPath);
                 }
 
                 return normalizePublicPath(compilerWithDevServerOption.options.output.publicPath);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

bugfix/refactor

**Did you add tests for your changes?**

Will be added with `webpack-dev-server@beta`

**If relevant, did you update the documentation?**

No need

**Summary**

we don't need to search free port before start webpack dev server, v4 do it automatically, so let's simplify it and avoid unnecessary code (also remove `dev.publicPath`, this option doesn't exist in webpack dev server v3)

**Does this PR introduce a breaking change?**

No

**Other information**

No