### PR TITLE
refactor: backward compatible flags for dev server

### DIFF
--- a/packages/serve/src/index.ts
+++ b/packages/serve/src/index.ts
@@ -18,8 +18,18 @@ class ServeCommand {
                 let devServerFlags = [];
 
                 try {
-                    // eslint-disable-next-line
-                    devServerFlags = require('webpack-dev-server/bin/cli-flags').devServer;
+                    devServerFlags = (() => {
+                        // eslint-disable-next-line
+                        const flags = require('webpack-dev-server/bin/cli-flags');
+                        // running the old format of flags
+                        // { devServer: [{...}, {}...] }
+                        if (flags.devServer) {
+                            return flags.devServer;
+                        }
+                        // new flag format
+                        // { flag1: {}, flag2: {} }
+                        return Object.values(flags);
+                    })();
                 } catch (error) {
                     logger.error(`You need to install 'webpack-dev-server' for running 'webpack serve'.\n${error}`);
                     process.exit(2);
@@ -34,8 +44,18 @@ class ServeCommand {
                 let devServerFlags = [];
 
                 try {
-                    // eslint-disable-next-line
-                    devServerFlags = require('webpack-dev-server/bin/cli-flags').devServer;
+                    devServerFlags = (() => {
+                        // eslint-disable-next-line
+                        const flags = require('webpack-dev-server/bin/cli-flags');
+                        // running the old format of flags
+                        // { devServer: [{...}, {}...] }
+                        if (flags.devServer) {
+                            return flags.devServer;
+                        }
+                        // new flag format
+                        // { flag1: {}, flag2: {} }
+                        return Object.values(flags);
+                    })();
                 } catch (error) {
                     // Nothing, to prevent future updates
                 }

--- a/packages/serve/src/index.ts
+++ b/packages/serve/src/index.ts
@@ -5,6 +5,25 @@ class ServeCommand {
     async apply(cli: any): Promise<void> {
         const { logger } = cli;
 
+        const loadDevServerOptions = () => {
+            // eslint-disable-next-line @typescript-eslint/no-var-requires, node/no-extraneous-require
+            const options = require('webpack-dev-server/bin/cli-flags');
+
+            // Old options format
+            // { devServer: [{...}, {}...] }
+            if (options.devServer) {
+                return options.devServer;
+            }
+
+            // New options format
+            // { flag1: {}, flag2: {} }
+            return Object.keys(options).map((key) => {
+                options[key].name = key;
+
+                return options[key];
+            });
+        };
+
         await cli.makeCommand(
             {
                 name: 'serve [entries...]',
@@ -18,18 +37,7 @@ class ServeCommand {
                 let devServerFlags = [];
 
                 try {
-                    devServerFlags = (() => {
-                        // eslint-disable-next-line
-                        const flags = require('webpack-dev-server/bin/cli-flags');
-                        // running the old format of flags
-                        // { devServer: [{...}, {}...] }
-                        if (flags.devServer) {
-                            return flags.devServer;
-                        }
-                        // new flag format
-                        // { flag1: {}, flag2: {} }
-                        return Object.values(flags);
-                    })();
+                    devServerFlags = loadDevServerOptions();
                 } catch (error) {
                     logger.error(`You need to install 'webpack-dev-server' for running 'webpack serve'.\n${error}`);
                     process.exit(2);
@@ -44,18 +52,7 @@ class ServeCommand {
                 let devServerFlags = [];
 
                 try {
-                    devServerFlags = (() => {
-                        // eslint-disable-next-line
-                        const flags = require('webpack-dev-server/bin/cli-flags');
-                        // running the old format of flags
-                        // { devServer: [{...}, {}...] }
-                        if (flags.devServer) {
-                            return flags.devServer;
-                        }
-                        // new flag format
-                        // { flag1: {}, flag2: {} }
-                        return Object.values(flags);
-                    })();
+                    devServerFlags = loadDevServerOptions();
                 } catch (error) {
                     // Nothing, to prevent future updates
                 }


### PR DESCRIPTION
**What kind of change does this PR introduce?**
fix/feat/refactor?

**Did you add tests for your changes?**
tested manually, no way to test rn

**If relevant, did you update the documentation?**
no need I think

**Summary**
we're migrating all flags to a single format, core/cli built in/server flags so this is to handle backward compatibility with dev server flags in migration to new format, once this is released we can go ahead with the migration

Ref https://github.com/webpack/webpack-dev-server/pull/3213

**Does this PR introduce a breaking change?**
no

**Other information**
