### PR TITLE
refactor(generators): remove extraneous args to addon-generator

### DIFF
--- a/packages/generators/src/addon-generator.ts
+++ b/packages/generators/src/addon-generator.ts
@@ -100,8 +100,14 @@ const addonGenerator = (
             // eslint-disable-next-line @typescript-eslint/no-var-requires
             this.fs.extendJSON(this.destinationPath('package.json'), require(packageJsonTemplatePath)(this.props.name));
 
-            // An array of file paths (relative to `./templates`) of files to be copied to the generated project
-            const files = getFiles(this.resolvedTemplatePath);
+            let files = [];
+            try {
+                // An array of file paths (relative to `./templates`) of files to be copied to the generated project
+                files = getFiles(this.resolvedTemplatePath);
+            } catch (error) {
+                this.utils.logger.error(`Failed to generate starter template.\n ${error}`);
+                process.exit(2);
+            }
 
             // Template file paths should be of the form `path/to/_file.js.tpl`
             const copyTemplateFiles = files.filter((filePath) => path.basename(filePath).startsWith('_'));

--- a/packages/generators/src/loader-generator.ts
+++ b/packages/generators/src/loader-generator.ts
@@ -40,18 +40,6 @@ export const LoaderGenerator = addonGenerator(
         },
     ],
     path.resolve(__dirname, '../loader-template'),
-    [
-        'src/cjs.js.tpl',
-        'test/test-utils.js.tpl',
-        'test/unit.test.js.tpl',
-        'test/functional.test.js.tpl',
-        'test/fixtures/simple-file.js.tpl',
-        'examples/simple/webpack.config.js.tpl',
-        'examples/simple/src/index.js.tpl',
-        'examples/simple/src/lazy-module.js.tpl',
-        'examples/simple/src/static-esm-module.js.tpl',
-    ],
-    ['src/_index.js.tpl'],
     (gen): Record<string, unknown> => ({ name: gen.props.name }),
 );
 

--- a/packages/generators/src/plugin-generator.ts
+++ b/packages/generators/src/plugin-generator.ts
@@ -22,15 +22,6 @@ export const PluginGenerator = addonGenerator(
         },
     ],
     path.resolve(__dirname, '../plugin-template'),
-    [
-        'src/cjs.js.tpl',
-        'test/test-utils.js.tpl',
-        'test/functional.test.js.tpl',
-        'examples/simple/src/index.js.tpl',
-        'examples/simple/src/lazy-module.js.tpl',
-        'examples/simple/src/static-esm-module.js.tpl',
-    ],
-    ['src/_index.js.tpl', 'examples/simple/_webpack.config.js.tpl'],
     (gen): Record<string, unknown> => ({ name: toUpperCamelCase(gen.props.name) }),
 );
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
refactoring

**Did you add tests for your changes?**
Already present

**If relevant, did you update the documentation?**
N/A

**Summary**
https://github.com/webpack/webpack-cli/blob/65ae77d98e918ea5907de89c9c87b797f57f1b2f/packages/generators/src/addon-generator.ts#L30

Directory content is inferred from the `templateDir` argument. Hence, it is not necessary to explicitly specify the template files.

**Does this PR introduce a breaking change?**
No

**Other information**
N/A