### PR TITLE
docs: remove scaffold guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@
     -   [Commands](#commands)
     -   [Utilities](#utilities)
 -   [Getting started](#getting-started)
--   [webpack CLI Scaffolds](#webpack-cli-scaffolds)
 -   [Exit codes and their meanings](#exit-codes-and-their-meanings)
 -   [Contributing and Internal Documentation](#contributing-and-internal-documentation)
 -   [Open Collective](#open-collective)


### PR DESCRIPTION
**What kind of change does this PR introduce?**

docs

**Did you add tests for your changes?**
NA

**If relevant, did you update the documentation?**
NA

**Summary**
- we don't have scaffold guide anymore

**Does this PR introduce a breaking change?**
no

**Other information**
https://github.com/webpack/webpack-cli/pull/2677