### PR TITLE
refactor: loading packages

### DIFF
--- a/packages/serve/src/startDevServer.ts
+++ b/packages/serve/src/startDevServer.ts
@@ -27,7 +27,7 @@ export default async function startDevServer(
         // eslint-disable-next-line node/no-extraneous-require
         devServerVersion = require("webpack-dev-server/package.json").version;
         // eslint-disable-next-line node/no-extraneous-require
-        Server = require("webpack-dev-server/lib/Server");
+        Server = require("webpack-dev-server");
     } catch (err) {
         logger.error(
             `You need to install 'webpack-dev-server' for running 'webpack serve'.\n${err}`,

--- a/packages/webpack-cli/lib/webpack-cli.js
+++ b/packages/webpack-cli/lib/webpack-cli.js
@@ -47,7 +47,8 @@ class WebpackCLI {
             }
 
             if (
-                (error.code === 'ERR_REQUIRE_ESM' || process.env.WEBPACK_CLI_FORCE_LOAD_ESM_CONFIG) &&
+                (error.code === "ERR_REQUIRE_ESM" ||
+                    process.env.WEBPACK_CLI_FORCE_LOAD_ESM_CONFIG) &&
                 pathToFileURL &&
                 dynamicImportLoader
             ) {
@@ -1033,7 +1034,9 @@ class WebpackCLI {
                     }
 
                     try {
-                        const { name, version } = this.loadJSONFile(`${foundCommand.pkg}/package.json`);
+                        const { name, version } = this.loadJSONFile(
+                            `${foundCommand.pkg}/package.json`,
+                        );
 
                         this.logger.raw(`${name} ${version}`);
                     } catch (e) {
@@ -1045,14 +1048,14 @@ class WebpackCLI {
                 }
             }
 
-            const pkgJSON = this.loadJSONFile('../package.json');
+            const pkgJSON = this.loadJSONFile("../package.json");
 
             this.logger.raw(`webpack ${this.webpack.version}`);
             this.logger.raw(`webpack-cli ${pkgJSON.version}`);
 
             if (this.utils.packageExists("webpack-dev-server")) {
                 // eslint-disable-next-line
-                const { version } = this.loadJSONFile('webpack-dev-server/package.json');
+                const { version } = this.loadJSONFile("webpack-dev-server/package.json");
 
                 this.logger.raw(`webpack-dev-server ${version}`);
             }
@@ -1682,7 +1685,7 @@ class WebpackCLI {
         }
 
         if (options.merge) {
-            const merge = await this.tryRequireThenImport('webpack-merge');
+            const merge = await this.tryRequireThenImport("webpack-merge");
 
             // we can only merge when there are multiple configurations
             // either by passing multiple configs by flags or passing a
@@ -1990,7 +1993,7 @@ class WebpackCLI {
     }
 
     async applyCLIPlugin(config, cliOptions) {
-        const CLIPlugin = await this.tryRequireThenImport('./plugins/CLIPlugin');
+        const CLIPlugin = await this.tryRequireThenImport("./plugins/CLIPlugin");
 
         const addCLIPlugin = (configOptions) => {
             if (!configOptions.plugins) {
@@ -2085,7 +2088,7 @@ class WebpackCLI {
         let createJsonStringifyStream;
 
         if (options.json) {
-            const jsonExt = await this.tryRequireThenImport('@discoveryjs/json-ext');
+            const jsonExt = await this.tryRequireThenImport("@discoveryjs/json-ext");
 
             createJsonStringifyStream = jsonExt.stringifyStream;
         }

--- a/packages/webpack-cli/lib/webpack-cli.js
+++ b/packages/webpack-cli/lib/webpack-cli.js
@@ -79,7 +79,7 @@ class WebpackCLI {
         let result;
 
         try {
-            result = require(pathToFile + 1);
+            result = require(pathToFile);
         } catch (error) {
             this.logger.error(error);
             process.exit(2);

--- a/packages/webpack-cli/lib/webpack-cli.js
+++ b/packages/webpack-cli/lib/webpack-cli.js
@@ -25,6 +25,51 @@ class WebpackCLI {
         });
     }
 
+    async tryRequireThenImport(module) {
+        let result;
+
+        try {
+            result = require(module);
+        } catch (error) {
+            let previousModuleCompile;
+
+            // TODO Workaround https://github.com/zertosh/v8-compile-cache/issues/30
+            if (this._originalModuleCompile) {
+                previousModuleCompile = Module.prototype._compile;
+
+                Module.prototype._compile = this._originalModuleCompile;
+            }
+
+            const dynamicImportLoader = this.utils.dynamicImportLoader();
+
+            if (this._originalModuleCompile) {
+                Module.prototype._compile = previousModuleCompile;
+            }
+
+            if (
+                (error.code === 'ERR_REQUIRE_ESM' || process.env.WEBPACK_CLI_FORCE_LOAD_ESM_CONFIG) &&
+                pathToFileURL &&
+                dynamicImportLoader
+            ) {
+                const urlForConfig = pathToFileURL(module);
+
+                result = await dynamicImportLoader(urlForConfig);
+                result = result.default;
+
+                return result;
+            }
+
+            throw error;
+        }
+
+        // For babel/typescript
+        if (result.default) {
+            result = result.default;
+        }
+
+        return result;
+    }
+
     async makeCommand(commandOptions, options, action) {
         const alreadyLoaded = this.program.commands.find(
             (command) =>
@@ -828,15 +873,11 @@ class WebpackCLI {
                 let loadedCommand;
 
                 try {
-                    loadedCommand = require(pkg);
+                    loadedCommand = await this.tryRequireThenImport(pkg);
                 } catch (error) {
                     // Ignore, command is not installed
 
                     return;
-                }
-
-                if (loadedCommand.default) {
-                    loadedCommand = loadedCommand.default;
                 }
 
                 let command;
@@ -1472,40 +1513,7 @@ class WebpackCLI {
             let options;
 
             try {
-                try {
-                    options = require(configPath);
-                } catch (error) {
-                    let previousModuleCompile;
-
-                    // TODO Workaround https://github.com/zertosh/v8-compile-cache/issues/30
-                    if (this._originalModuleCompile) {
-                        previousModuleCompile = Module.prototype._compile;
-
-                        Module.prototype._compile = this._originalModuleCompile;
-                    }
-
-                    const dynamicImportLoader = this.utils.dynamicImportLoader();
-
-                    if (this._originalModuleCompile) {
-                        Module.prototype._compile = previousModuleCompile;
-                    }
-
-                    if (
-                        (error.code === "ERR_REQUIRE_ESM" ||
-                            process.env.WEBPACK_CLI_FORCE_LOAD_ESM_CONFIG) &&
-                        pathToFileURL &&
-                        dynamicImportLoader
-                    ) {
-                        const urlForConfig = pathToFileURL(configPath);
-
-                        options = await dynamicImportLoader(urlForConfig);
-                        options = options.default;
-
-                        return { options, path: configPath };
-                    }
-
-                    throw error;
-                }
+                options = await this.tryRequireThenImport(configPath);
             } catch (error) {
                 this.logger.error(`Failed to load '${configPath}' config`);
 
@@ -1516,10 +1524,6 @@ class WebpackCLI {
                 }
 
                 process.exit(2);
-            }
-
-            if (options.default) {
-                options = options.default;
             }
 
             return { options, path: configPath };
@@ -1660,7 +1664,7 @@ class WebpackCLI {
         }
 
         if (options.merge) {
-            const { merge } = require("webpack-merge");
+            const merge = await this.tryRequireThenImport('webpack-merge');
 
             // we can only merge when there are multiple configurations
             // either by passing multiple configs by flags or passing a
@@ -1968,12 +1972,12 @@ class WebpackCLI {
     }
 
     async applyCLIPlugin(config, cliOptions) {
+        const CLIPlugin = await this.tryRequireThenImport('./plugins/CLIPlugin');
+
         const addCLIPlugin = (configOptions) => {
             if (!configOptions.plugins) {
                 configOptions.plugins = [];
             }
-
-            const CLIPlugin = require("./plugins/CLIPlugin");
 
             configOptions.plugins.unshift(
                 new CLIPlugin({
@@ -1988,6 +1992,7 @@ class WebpackCLI {
 
             return configOptions;
         };
+
         config.options = Array.isArray(config.options)
             ? config.options.map((options) => addCLIPlugin(options))
             : addCLIPlugin(config.options);
@@ -2059,6 +2064,14 @@ class WebpackCLI {
     async buildCommand(options, isWatchCommand) {
         let compiler;
 
+        let createJsonStringifyStream;
+
+        if (options.json) {
+            const jsonExt = await this.tryRequireThenImport('@discoveryjs/json-ext');
+
+            createJsonStringifyStream = jsonExt.stringifyStream;
+        }
+
         const callback = (error, stats) => {
             if (error) {
                 this.logger.error(error);
@@ -2090,10 +2103,7 @@ class WebpackCLI {
                 statsOptions.colors = statsOptions.children.some((child) => child.colors);
             }
 
-            if (options.json) {
-                const {
-                    stringifyStream: createJsonStringifyStream,
-                } = require("@discoveryjs/json-ext");
+            if (options.json && createJsonStringifyStream) {
                 const handleWriteError = (error) => {
                     this.logger.error(error);
                     process.exit(2);

--- a/test/plugin/plugin.test.js
+++ b/test/plugin/plugin.test.js
@@ -21,8 +21,8 @@ const dataForTests = (rootAssetsPath) => ({
 describe("plugin command", () => {
     it("should ask the plugin name when invoked", async () => {
         const assetsPath = await uniqueDirectoryForTest();
-        const { stdout, stderr } = await runPromptWithAnswers(assetsPath, ['plugin']);
-        
+        const { stdout, stderr } = await runPromptWithAnswers(assetsPath, ["plugin"]);
+
         expect(stdout).toBeTruthy();
         expect(stderr).toBeFalsy();
         expect(normalizeStdout(stdout)).toContain(firstPrompt);

--- a/test/plugin/plugin.test.js
+++ b/test/plugin/plugin.test.js
@@ -20,7 +20,9 @@ const dataForTests = (rootAssetsPath) => ({
 
 describe("plugin command", () => {
     it("should ask the plugin name when invoked", async () => {
-        const { stdout, stderr } = await runPromptWithAnswers(__dirname, ["plugin"]);
+        const assetsPath = await uniqueDirectoryForTest();
+        const { stdout, stderr } = await runPromptWithAnswers(assetsPath, ['plugin']);
+        
         expect(stdout).toBeTruthy();
         expect(stderr).toBeFalsy();
         expect(normalizeStdout(stdout)).toContain(firstPrompt);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

refactor

**Did you add tests for your changes?**

Existing

**If relevant, did you update the documentation?**

No

**Summary**

Unify code, we should avoid using `require` for external packages due Node.js is out and we some modules can migrate on ES. Also reduce duplicate of code and error handling


**Does this PR introduce a breaking change?**

No

**Other information**

No