### PR TITLE
feat: new CLI options API for serve

### DIFF
--- a/test/serve/serve-variable/webpack.config.js
+++ b/test/serve/serve-variable/webpack.config.js
@@ -1,4 +1,4 @@
-const HAS_WEBPACK_SERVE = process.env.WEBPACK_SERVE;
+const HAS_WEBPACK_SERVE = process.env.WEBPACK_SERVE || process.env.WEBPACK_DEV_SERVER;
 
 class CustomTestPlugin {
     constructor(isInEnvironment) {

--- a/test/serve/serve-variable/webpack.config.js
+++ b/test/serve/serve-variable/webpack.config.js
@@ -1,4 +1,4 @@
-const isInProcess = process.env.WEBPACK_SERVE;
+const HAS_WEBPACK_SERVE = process.env.WEBPACK_SERVE;
 
 class CustomTestPlugin {
     constructor(isInEnvironment) {
@@ -6,7 +6,7 @@ class CustomTestPlugin {
     }
     apply(compiler) {
         compiler.hooks.done.tap("testPlugin", () => {
-            if (!isInProcess && this.isInEnvironment) {
+            if (this.isInEnvironment) {
                 console.log("PASS");
             } else {
                 console.log("FAIL");
@@ -19,6 +19,6 @@ module.exports = (env) => {
     return {
         mode: "development",
         devtool: false,
-        plugins: [new CustomTestPlugin(env.WEBPACK_SERVE)],
+        plugins: [new CustomTestPlugin(HAS_WEBPACK_SERVE && env.WEBPACK_SERVE)],
     };
 };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

feature

**Did you add tests for your changes?**

Exist, but only work after merge https://github.com/webpack/webpack-dev-server/pull/3325

**If relevant, did you update the documentation?**

No need

**Summary**

New API for CLI options

**Does this PR introduce a breaking change?**

No

**Other information**

I think we should refactor `serve` and put `startDevServer.ts` in `index.ts` to avoid extra `require` (but it is not problem, because `require` is cachable). Also we will avoid a lot of `for`/`reduce`/`forEach` after https://github.com/webpack/webpack-cli/pull/2626, but I want postpone it right now, focus on webpack-dev-server
