### PR TITLE
fix: not found module after ask installation

### DIFF
--- a/packages/webpack-cli/lib/utils/package-exists.js
+++ b/packages/webpack-cli/lib/utils/package-exists.js
@@ -1,9 +1,24 @@
+const fs = require("fs");
+const path = require("path");
+
 function packageExists(packageName) {
-    try {
-        return require.resolve(packageName);
-    } catch (error) {
-        return false;
+    if (process.versions.pnp) {
+        return true;
     }
+
+    let dir = __dirname;
+
+    do {
+        try {
+            if (fs.statSync(path.join(dir, "node_modules", packageName)).isDirectory()) {
+                return true;
+            }
+        } catch (_error) {
+            // Nothing
+        }
+    } while (dir !== (dir = path.dirname(dir)));
+
+    return false;
 }
 
 module.exports = packageExists;

--- a/packages/webpack-cli/lib/utils/prompt-installation.js
+++ b/packages/webpack-cli/lib/utils/prompt-installation.js
@@ -22,6 +22,7 @@ async function promptInstallation(packageName, preMessage) {
     const commandToBeRun = `${packageManager} ${[
         packageManager === "yarn" ? "add" : "install",
         "-D",
+        "--ignore-workspace-root-check",
         packageName,
     ].join(" ")}`;
     const { colors } = utils;
@@ -51,7 +52,7 @@ async function promptInstallation(packageName, preMessage) {
             process.exit(2);
         }
 
-        return utils.packageExists(packageName);
+        return packageName;
     }
 
     process.exit(2);

--- a/packages/webpack-cli/lib/utils/prompt-installation.js
+++ b/packages/webpack-cli/lib/utils/prompt-installation.js
@@ -22,7 +22,6 @@ async function promptInstallation(packageName, preMessage) {
     const commandToBeRun = `${packageManager} ${[
         packageManager === "yarn" ? "add" : "install",
         "-D",
-        "--ignore-workspace-root-check",
         packageName,
     ].join(" ")}`;
     const { colors } = utils;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**

Hard to add, manually tested

**If relevant, did you update the documentation?**

No need

**Summary**

fixes #2716

**Does this PR introduce a breaking change?**

No

**Other information**

@webpack/cli-team 

- we need backport this solution, in `webpack-dev-server` and `webpack` itself, just replace `require.resolve` on this function
- also we need small refactor, `promptInstallation` should not return something, only install package