### PR TITLE
chore(CLIPlugin): Remove unnecessary async keywords

### DIFF
--- a/packages/webpack-cli/lib/plugins/CLIPlugin.js
+++ b/packages/webpack-cli/lib/plugins/CLIPlugin.js
@@ -20,7 +20,7 @@ class CLIPlugin {
         new PrefetchPlugin(null, this.options.prefetch).apply(compiler);
     }
 
-    async setupBundleAnalyzerPlugin(compiler) {
+    setupBundleAnalyzerPlugin(compiler) {
         // eslint-disable-next-line node/no-extraneous-require
         const { BundleAnalyzerPlugin } = require("webpack-bundle-analyzer");
         const bundleAnalyzerPlugin = Boolean(


### PR DESCRIPTION
**What kind of change does this PR introduce?**
chore

**Did you add tests for your changes?**
no, because there is no new feature change,but `yarn test` pass

**If relevant, did you update the documentation?**
no
**Summary**
_motivation:_ I think the async keywords of the function is unnecessary, because the code has not found an asynchronous operation.

**Does this PR introduce a breaking change?**
no