### PR TITLE
test: enable skipped test assertions

### DIFF
--- a/test/loader/loader.test.js
+++ b/test/loader/loader.test.js
@@ -37,7 +37,7 @@ describe("loader command", () => {
         expect(normalizeStdout(stdout)).toContain(firstPrompt);
 
         // Skip test in case installation fails
-        if (!existsSync(resolve(defaultLoaderPath, "./yarn.lock"))) {
+        if (!existsSync(resolve(defaultLoaderPath, "./package-lock.json"))) {
             return;
         }
 
@@ -59,7 +59,7 @@ describe("loader command", () => {
         });
 
         // Check if the the generated loader works successfully
-        const path = resolve(__dirname, "./my-loader/examples/simple/");
+        const path = resolve(defaultLoaderPath, "./examples/simple/");
 
         ({ stdout } = await run(path, []));
 
@@ -78,7 +78,7 @@ describe("loader command", () => {
         expect(normalizeStdout(stdout)).toContain(firstPrompt);
 
         // Skip test in case installation fails
-        if (!existsSync(resolve(loaderPath, "./yarn.lock"))) {
+        if (!existsSync(resolve(loaderPath, "./package-lock.json"))) {
             return;
         }
 
@@ -100,7 +100,7 @@ describe("loader command", () => {
         });
 
         // Check if the the generated loader works successfully
-        const path = resolve(__dirname, "./test-loader/examples/simple/");
+        const path = resolve(loaderPath, "./examples/simple/");
 
         ({ stdout } = await run(path, []));
 
@@ -119,7 +119,7 @@ describe("loader command", () => {
         expect(normalizeStdout(stdout)).toContain(firstPrompt);
 
         // Skip test in case installation fails
-        if (!existsSync(resolve(customLoaderPath, "./yarn.lock"))) {
+        if (!existsSync(resolve(customLoaderPath, "./package-lock.json"))) {
             return;
         }
 
@@ -161,7 +161,7 @@ describe("loader command", () => {
         expect(normalizeStdout(stdout)).toContain(firstPrompt);
 
         // Skip test in case installation fails
-        if (!existsSync(resolve(customLoaderPath, "./yarn.lock"))) {
+        if (!existsSync(resolve(customLoaderPath, "./package-lock.json"))) {
             return;
         }
 
@@ -209,7 +209,7 @@ describe("loader command", () => {
         expect(normalizeStdout(stdout)).toContain(firstPrompt);
 
         // Skip test in case installation fails
-        if (!existsSync(resolve(defaultLoaderPath, "./yarn.lock"))) {
+        if (!existsSync(resolve(defaultLoaderPath, "./package-lock.json"))) {
             return;
         }
 
@@ -231,7 +231,7 @@ describe("loader command", () => {
         });
 
         // Check if the the generated loader works successfully
-        const path = resolve(__dirname, "./my-loader/examples/simple/");
+        const path = resolve(assetsPath, "./my-loader/examples/simple/");
 
         ({ stdout } = await run(path, []));
 

--- a/test/plugin/plugin.test.js
+++ b/test/plugin/plugin.test.js
@@ -39,7 +39,7 @@ describe("plugin command", () => {
         expect(existsSync(defaultPluginPath)).toBeTruthy();
 
         // Skip test in case installation fails
-        if (!existsSync(resolve(defaultPluginPath, "./yarn.lock"))) {
+        if (!existsSync(resolve(defaultPluginPath, "./package-lock.json"))) {
             return;
         }
 
@@ -58,9 +58,9 @@ describe("plugin command", () => {
         });
 
         // Check if the the generated plugin works successfully
-        const { stdout: stdout2 } = await run(__dirname, [
+        const { stdout: stdout2 } = await run(defaultPluginPath, [
             "--config",
-            "./my-webpack-plugin/examples/simple/webpack.config.js",
+            "./examples/simple/webpack.config.js",
         ]);
         expect(normalizeStdout(stdout2)).toContain("Hello World!");
     });
@@ -80,7 +80,7 @@ describe("plugin command", () => {
         expect(existsSync(pluginPath)).toBeTruthy();
 
         // Skip test in case installation fails
-        if (!existsSync(resolve(pluginPath, "./yarn.lock"))) {
+        if (!existsSync(resolve(pluginPath, "./package-lock.json"))) {
             return;
         }
 
@@ -99,9 +99,9 @@ describe("plugin command", () => {
         });
 
         // Check if the the generated plugin works successfully
-        const { stdout: stdout2 } = await run(__dirname, [
+        const { stdout: stdout2 } = await run(pluginPath, [
             "--config",
-            "./test-plugin/examples/simple/webpack.config.js",
+            "./examples/simple/webpack.config.js",
         ]);
         expect(normalizeStdout(stdout2)).toContain("Hello World!");
     });
@@ -121,7 +121,7 @@ describe("plugin command", () => {
         expect(existsSync(customPluginPath)).toBeTruthy();
 
         // Skip test in case installation fails
-        if (!existsSync(resolve(customPluginPath, "./yarn.lock"))) {
+        if (!existsSync(resolve(customPluginPath, "./package-lock.json"))) {
             return;
         }
 
@@ -167,7 +167,7 @@ describe("plugin command", () => {
         expect(existsSync(customPluginPath)).toBeTruthy();
 
         // Skip test in case installation fails
-        if (!existsSync(resolve(customPluginPath, "./yarn.lock"))) {
+        if (!existsSync(resolve(customPluginPath, "./package-lock.json"))) {
             return;
         }
 
@@ -208,13 +208,17 @@ describe("plugin command", () => {
             ["plugin", "-t", "default"],
             [`${ENTER}`, ENTER],
         );
+
         expect(normalizeStdout(stdout)).toContain(firstPrompt);
+
         // Check if the output directory exists with the appropriate plugin name
         expect(existsSync(defaultPluginPath)).toBeTruthy();
+
         // Skip test in case installation fails
-        if (!existsSync(resolve(defaultPluginPath, "./yarn.lock"))) {
+        if (!existsSync(resolve(defaultPluginPath, "./package-lock.json"))) {
             return;
         }
+
         // Test regressively files are scaffolded
         const files = [
             "package.json",
@@ -227,10 +231,11 @@ describe("plugin command", () => {
         files.forEach((file) => {
             expect(existsSync(join(defaultPluginPath, file))).toBeTruthy();
         });
+
         // Check if the the generated plugin works successfully
-        const { stdout: stdout2 } = await run(__dirname, [
+        const { stdout: stdout2 } = await run(defaultPluginPath, [
             "--config",
-            "./my-webpack-plugin/examples/simple/webpack.config.js",
+            "./examples/simple/webpack.config.js",
         ]);
         expect(normalizeStdout(stdout2)).toContain("Hello World!");
     });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Test update

**Did you add tests for your changes?**
This PR aims at updating the test suite.

**If relevant, did you update the documentation?**
N/A

**Summary**
Currently, a couple of integration test assertions associated with the `loader` and `plugin` commands get skipped.
https://github.com/webpack/webpack-cli/blob/9c6b341fd84e03606c9a9558711238f0863bd56f/test/loader/loader.test.js#L39-L42
This PR aims at fixing up this behavior.

**Does this PR introduce a breaking change?**
No

**Other information**
N/A