### PR TITLE
fix: handle undefined configuration export

### DIFF
--- a/packages/webpack-cli/lib/webpack-cli.js
+++ b/packages/webpack-cli/lib/webpack-cli.js
@@ -71,12 +71,7 @@ class WebpackCLI {
       result = result.default;
     }
 
-    // Treat undefined configuration for zero-config
-    if (!result) {
-      result = {};
-    }
-
-    return result;
+    return result || {};
   }
 
   loadJSONFile(pathToFile, handleError = true) {

--- a/packages/webpack-cli/lib/webpack-cli.js
+++ b/packages/webpack-cli/lib/webpack-cli.js
@@ -67,8 +67,16 @@ class WebpackCLI {
     }
 
     // For babel/typescript
-    if (result.default) {
+    if (result && result.default) {
       result = result.default;
+    }
+
+    // Treat undefined configuration for zero-config
+    if (!result) {
+      this.logger.info(
+        "Configuration file provided didn't export any configuration, using defaults to build.",
+      );
+      result = {};
     }
 
     return result;

--- a/packages/webpack-cli/lib/webpack-cli.js
+++ b/packages/webpack-cli/lib/webpack-cli.js
@@ -67,7 +67,7 @@ class WebpackCLI {
     }
 
     // For babel/typescript
-    if (result && "default" in result) {
+    if (result && typeof result === "object" && "default" in result) {
       result = result.default || {};
     }
 

--- a/packages/webpack-cli/lib/webpack-cli.js
+++ b/packages/webpack-cli/lib/webpack-cli.js
@@ -73,9 +73,6 @@ class WebpackCLI {
 
     // Treat undefined configuration for zero-config
     if (!result) {
-      this.logger.info(
-        "Configuration file provided didn't export any configuration, using defaults to build.",
-      );
       result = {};
     }
 

--- a/packages/webpack-cli/lib/webpack-cli.js
+++ b/packages/webpack-cli/lib/webpack-cli.js
@@ -67,8 +67,8 @@ class WebpackCLI {
     }
 
     // For babel/typescript
-    if (result && result.default) {
-      result = result.default;
+    if (result && "default" in result) {
+      result = result.default || {};
     }
 
     return result || {};

--- a/test/build/config/no-code/no-code.test.js
+++ b/test/build/config/no-code/no-code.test.js
@@ -3,7 +3,7 @@ const { resolve } = require("path");
 const { run } = require("../../../utils/test-utils");
 
 describe("config flag with no code", () => {
-  it("should throw error with no configuration or index file", async () => {
+  it("should not throw error with no configuration or index file", async () => {
     const { exitCode, stderr, stdout } = await run(__dirname, [
       "-c",
       resolve(__dirname, "webpack.config.js"),

--- a/test/build/config/no-code/no-code.test.js
+++ b/test/build/config/no-code/no-code.test.js
@@ -1,0 +1,16 @@
+"use strict";
+const { resolve } = require("path");
+const { run } = require("../../../utils/test-utils");
+
+describe("config flag with no code", () => {
+  it("should throw error with no configuration or index file", async () => {
+    const { exitCode, stderr, stdout } = await run(__dirname, [
+      "-c",
+      resolve(__dirname, "webpack.config.js"),
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toBeFalsy();
+    expect(stdout).toBeTruthy();
+  });
+});

--- a/test/build/config/no-code/src/index.js
+++ b/test/build/config/no-code/src/index.js
@@ -1,0 +1,1 @@
+console.log("Peeves");

--- a/test/build/config/undefined-default/src/index.js
+++ b/test/build/config/undefined-default/src/index.js
@@ -1,0 +1,1 @@
+console.log("Tom Riddle");

--- a/test/build/config/undefined-default/undefined-default.test.js
+++ b/test/build/config/undefined-default/undefined-default.test.js
@@ -3,7 +3,7 @@ const { resolve } = require("path");
 const { run } = require("../../../utils/test-utils");
 
 describe("config flag with undefined default export config file", () => {
-  it("should throw error with no configuration or index file", async () => {
+  it("should not throw error with no configuration or index file", async () => {
     const { exitCode, stderr, stdout } = await run(__dirname, [
       "-c",
       resolve(__dirname, "webpack.config.js"),

--- a/test/build/config/undefined-default/undefined-default.test.js
+++ b/test/build/config/undefined-default/undefined-default.test.js
@@ -1,0 +1,16 @@
+"use strict";
+const { resolve } = require("path");
+const { run } = require("../../../utils/test-utils");
+
+describe("config flag with undefined default export config file", () => {
+  it("should throw error with no configuration or index file", async () => {
+    const { exitCode, stderr, stdout } = await run(__dirname, [
+      "-c",
+      resolve(__dirname, "webpack.config.js"),
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toBeFalsy();
+    expect(stdout).toBeTruthy();
+  });
+});

--- a/test/build/config/undefined-default/webpack.config.js
+++ b/test/build/config/undefined-default/webpack.config.js
@@ -1,0 +1,1 @@
+module.exports.default = undefined;

--- a/test/build/config/undefined/src/index.js
+++ b/test/build/config/undefined/src/index.js
@@ -1,1 +1,1 @@
-console.log("Percy Weasley")
+console.log("Percy Weasley");

--- a/test/build/config/undefined/src/index.js
+++ b/test/build/config/undefined/src/index.js
@@ -1,0 +1,1 @@
+console.log("Percy Weasley")

--- a/test/build/config/undefined/undefined.test.js
+++ b/test/build/config/undefined/undefined.test.js
@@ -9,8 +9,6 @@ describe("config flag with undefined export config file", () => {
       resolve(__dirname, "webpack.config.js"),
     ]);
 
-    console.log({ stdout, stderr, exitCode });
-
     expect(exitCode).toBe(0);
     expect(stderr).toBeFalsy();
     expect(stdout).toBeTruthy();

--- a/test/build/config/undefined/undefined.test.js
+++ b/test/build/config/undefined/undefined.test.js
@@ -3,7 +3,7 @@ const { resolve } = require("path");
 const { run } = require("../../../utils/test-utils");
 
 describe("config flag with undefined export config file", () => {
-  it("should throw error with no configuration or index file", async () => {
+  it("should not throw error with no configuration or index file", async () => {
     const { exitCode, stderr, stdout } = await run(__dirname, [
       "-c",
       resolve(__dirname, "webpack.config.js"),

--- a/test/build/config/undefined/undefined.test.js
+++ b/test/build/config/undefined/undefined.test.js
@@ -1,0 +1,18 @@
+"use strict";
+const { resolve } = require("path");
+const { run } = require("../../../utils/test-utils");
+
+describe("config flag with undefined export config file", () => {
+  it("should throw error with no configuration or index file", async () => {
+    const { exitCode, stderr, stdout } = await run(__dirname, [
+      "-c",
+      resolve(__dirname, "webpack.config.js"),
+    ]);
+
+    console.log({ stdout, stderr, exitCode });
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toBeFalsy();
+    expect(stdout).toBeTruthy();
+  });
+});

--- a/test/build/config/undefined/webpack.config.js
+++ b/test/build/config/undefined/webpack.config.js
@@ -1,0 +1,1 @@
+module.exports = undefined;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
fix and test
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
Yup, did in TDD fashion.

**If relevant, did you update the documentation?**
Not required.

**Summary**
Treat `undefined` configuration as a case for `zero-config`
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
Nope.
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
/cc @alexander-akait 
> when we have `webpack.config.js`  without `module.exports`  or `export`  we don't work, but no exports means zero configuration and should work