### PR TITLE
Migrate to colorette 2.0.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@typescript-eslint/parser": "^4.14.1",
     "@webpack-cli/migrate": "^1.1.2",
     "coffeescript": "^2.5.1",
-    "colorette": "^1.2.1",
+    "colorette": "^2.0.2",
     "concat-stream": "^2.0.0",
     "cz-customizable": "^6.3.0",
     "del-cli": "^3.0.1",

--- a/packages/generators/package.json
+++ b/packages/generators/package.json
@@ -22,7 +22,7 @@
     "plugin-template"
   ],
   "dependencies": {
-    "colorette": "^1.2.1",
+    "colorette": "^2.0.2",
     "yeoman-environment": "^2.10.3",
     "yeoman-generator": "^4.12.0"
   },

--- a/packages/generators/src/init-generator.ts
+++ b/packages/generators/src/init-generator.ts
@@ -1,4 +1,4 @@
-import { blue, yellow } from "colorette";
+import { createColors } from "colorette";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import path from "path";
 
@@ -6,6 +6,8 @@ import { CustomGenerator } from "./types";
 import { getInstaller, getTemplate } from "./utils/helpers";
 import * as Question from "./utils/scaffold-utils";
 import handlers from "./handlers";
+
+const { blue, yellow } = createColors();
 
 /**
  *

--- a/packages/webpack-cli/lib/utils/index.js
+++ b/packages/webpack-cli/lib/utils/index.js
@@ -1,6 +1,22 @@
+let colorette = null;
+
 module.exports = {
+
   get colors() {
-    return require("colorette");
+    if (!colorette || colorette.options.changed) {
+      const col = require('colorette');
+      const options = {
+        changed: false,
+        enabled: colorette? colorette.options.enabled : true,
+      }
+
+      colorette = {
+        ...col.createColors({ useColor: options.enabled }),
+        options,
+      }
+    }
+
+    return colorette;
   },
 
   get levenshtein() {

--- a/packages/webpack-cli/package.json
+++ b/packages/webpack-cli/package.json
@@ -33,7 +33,7 @@
     "@webpack-cli/configtest": "^1.0.4",
     "@webpack-cli/info": "^1.3.0",
     "@webpack-cli/serve": "^1.5.2",
-    "colorette": "^1.2.1",
+    "colorette": "^2.0.2",
     "commander": "^7.0.0",
     "execa": "^5.0.0",
     "fastest-levenshtein": "^1.0.12",

--- a/scripts/prepareSuite.js
+++ b/scripts/prepareSuite.js
@@ -1,9 +1,10 @@
 // eslint-disable-next-line node/no-unpublished-require
 const execa = require("execa");
 // eslint-disable-next-line node/no-unpublished-require
-const { red, green } = require("colorette");
+const { createColors } = require("colorette");
 const collectTestFolders = require("./utils");
 
+const { red, green } = createColors();
 const PACKAGE = "package.json";
 
 const getFoldersWithPackage = (stats, file) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3361,6 +3361,11 @@ colorette@^1.2.1, colorette@^1.2.2:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.4.0.tgz#5190fbb87276259a86ad700bff2c6d6faa3fca40"
   integrity sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==
 
+colorette@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.2.tgz#f04cbc7f59ffc4f33ba4da0702dd4c8a68885d91"
+  integrity sha512-iO5Ycn8HKVhTGGKpwJtyzrrvOGI9YC4u4dppP5yKSGP47ApaZNwX7ne4PtgpTzq+JBwQh6FrdAfCSYTBQe1+FA==
+
 colors@1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"


### PR DESCRIPTION
fixes #2955

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

Update colorette to a new semver major version.

**Did you add tests for your changes?**

Not relevant.

**If relevant, did you update the documentation?**

Not relevant.

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This ensures webpack-cli is staying on up-to-date dependency version, and also removes reliance on global state, which is never a good idea.

**Does this PR introduce a breaking change?**

It shouldn't, although there was a change in colorette behavior: it no longer generates colouring for empty strings, which is unlikely to be an issue for majority of users.