### PR TITLE
fix: allow falsy values for "port" option

### DIFF
--- a/packages/serve/src/index.ts
+++ b/packages/serve/src/index.ts
@@ -296,7 +296,8 @@ class ServeCommand {
             };
 
             devServerOptions.host = devServerOptions.host || "localhost";
-            devServerOptions.port = devServerOptions.port || 8080;
+            devServerOptions.port =
+              typeof devServerOptions.port !== "undefined" ? devServerOptions.port : 8080;
             devServerOptions.stats = getStatsOption();
             devServerOptions.publicPath = getPublicPathOption();
           }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Fix

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

Open to suggestions for testing this.

**If relevant, did you update the documentation?**

N/A

**Summary**

This fixes a regression that we noticed when updating to `webpack-cli@4.7.2`. We are still on `webpack-dev-server@3.11.2` which allows using `null` or `0` to automatically use a free port. In our case we are setting `port: 0` and it was causing this error:

```
Error: listen EADDRINUSE: address already in use 127.0.0.1:8080
```

If `webpack-cli` still supports `webpack-dev-server@3.11.2` it seems like it shouldn't prevent passing `null` or `0` as an option to `port`. Our current workaround is using the string `'0'`, which is not falsy.

**Does this PR introduce a breaking change?**

No

**Other information**
