### PR TITLE
fix: npx init

### DIFF
--- a/packages/generators/package.json
+++ b/packages/generators/package.json
@@ -23,11 +23,11 @@
   ],
   "dependencies": {
     "yeoman-environment": "^2.10.3",
-    "yeoman-generator": "^4.12.0"
+    "yeoman-generator": "^4.12.0",
+    "webpack-cli": "4.x.x"
   },
   "peerDependencies": {
-    "webpack": "4.x.x || 5.x.x",
-    "webpack-cli": "4.x.x"
+    "webpack": "4.x.x || 5.x.x"
   },
   "peerDependenciesMeta": {
     "prettier": {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

bugfix

**Did you add tests for your changes?**

manually tests

**If relevant, did you update the documentation?**

yes

/cc @webpack/cli-team we need update our docs, for `init` we should always use `npx webpack-cli init`

**Summary**

It is fast fix, in future we should create rename `init` to `create-webpack-app` and use `npx create-webpack-app`

**Does this PR introduce a breaking change?**

No

**Other information**

Partial fix https://github.com/webpack/webpack-cli/issues/2944