### PR TITLE
refactor(webpack-cli): don't spawn needless shells and replace execa with cross-spawn

### DIFF
--- a/packages/webpack-cli/package.json
+++ b/packages/webpack-cli/package.json
@@ -35,7 +35,7 @@
     "@webpack-cli/serve": "^1.6.1",
     "colorette": "^2.0.14",
     "commander": "^7.0.0",
-    "execa": "^5.0.0",
+    "cross-spawn": "^7.0.3",
     "fastest-levenshtein": "^1.0.12",
     "import-local": "^3.0.2",
     "interpret": "^2.2.0",

--- a/packages/webpack-cli/src/webpack-cli.ts
+++ b/packages/webpack-cli/src/webpack-cli.ts
@@ -154,7 +154,7 @@ class WebpackCLI implements IWebpackCLI {
   }
 
   getAvailablePackageManagers(): PackageManager[] {
-    const { sync } = require("execa");
+    const { sync } = require("cross-spawn");
     const installers: PackageManager[] = ["npm", "yarn", "pnpm"];
     const hasPackageManagerInstalled = (packageManager: PackageManager) => {
       try {
@@ -179,7 +179,7 @@ class WebpackCLI implements IWebpackCLI {
   }
 
   getDefaultPackageManager(): PackageManager | undefined {
-    const { sync } = require("execa");
+    const { sync } = require("cross-spawn");
     const hasLocalNpm = fs.existsSync(path.resolve(process.cwd(), "package-lock.json"));
 
     if (hasLocalNpm) {
@@ -294,10 +294,10 @@ class WebpackCLI implements IWebpackCLI {
     }
 
     if (needInstall) {
-      const execa = require("execa");
+      const spawn = require("cross-spawn");
 
       try {
-        await execa(commandToBeRun, [], { stdio: "inherit", shell: true });
+        spawn(commandToBeRun, [], { stdio: "inherit", shell: true });
       } catch (error) {
         this.logger.error(error);
 

--- a/packages/webpack-cli/src/webpack-cli.ts
+++ b/packages/webpack-cli/src/webpack-cli.ts
@@ -244,13 +244,6 @@ class WebpackCLI implements IWebpackCLI {
       options.preMessage();
     }
 
-    // yarn uses 'add' command, rest npm and pnpm both use 'install'
-    const commandToBeRun = `${packageManager} ${[
-      packageManager === "yarn" ? "add" : "install",
-      "-D",
-      packageName,
-    ].join(" ")}`;
-
     const prompt = ({ message, defaultResponse, stream }: PromptOptions) => {
       const readline = require("readline");
       const rl = readline.createInterface({
@@ -275,6 +268,10 @@ class WebpackCLI implements IWebpackCLI {
       });
     };
 
+    // yarn uses 'add' command, rest npm and pnpm both use 'install'
+    const commandArguments = [packageManager === "yarn" ? "add" : "install", "-D", packageName];
+    const commandToBeRun = `${packageManager} ${commandArguments.join(" ")}`;
+
     let needInstall;
 
     try {
@@ -294,10 +291,10 @@ class WebpackCLI implements IWebpackCLI {
     }
 
     if (needInstall) {
-      const spawn = require("cross-spawn");
+      const { sync } = require("cross-spawn");
 
       try {
-        spawn(commandToBeRun, [], { stdio: "inherit", shell: true });
+        sync(packageManager, commandArguments, { stdio: "inherit" });
       } catch (error) {
         this.logger.error(error);
 

--- a/smoketests/helpers.js
+++ b/smoketests/helpers.js
@@ -44,7 +44,7 @@ const runTest = (pkg, cliArgs = [], logMessage, isSubPackage = false) => {
     const timeout = setTimeout(() => {
       console.log("  timeout: killing process");
       proc.kill();
-    }, 30000);
+    }, 60000);
 
     const prompt = "Would you like to install";
     let hasLogMessage = false,

--- a/test/api/do-install.test.js
+++ b/test/api/do-install.test.js
@@ -17,9 +17,9 @@ jest.mock("readline", () => {
   };
 });
 
-const execaMock = jest.fn();
+const spawnMock = jest.fn();
 
-jest.mock("execa", () => execaMock);
+jest.mock("cross-spawn", () => spawnMock);
 
 describe("doInstall", () => {
   let cli;
@@ -45,13 +45,13 @@ describe("doInstall", () => {
 
     expect(installResult).toBe("test-package");
     expect(readlineQuestionMock.mock.calls.length).toEqual(1);
-    expect(execaMock.mock.calls.length).toEqual(1);
+    expect(spawnMock.mock.calls.length).toEqual(1);
     expect(stripAnsi(readlineQuestionMock.mock.calls[0][0])).toContain(
       "Would you like to install 'test-package' package? (That will run 'npm install -D test-package')",
     );
 
     // install the package using npm
-    expect(execaMock.mock.calls[0][0]).toEqual("npm install -D test-package");
+    expect(spawnMock.mock.calls[0][0]).toEqual("npm install -D test-package");
   });
 
   it("should prompt to install using yarn if yarn is package manager", async () => {
@@ -62,13 +62,13 @@ describe("doInstall", () => {
 
     expect(installResult).toBe("test-package");
     expect(readlineQuestionMock.mock.calls.length).toEqual(1);
-    expect(execaMock.mock.calls.length).toEqual(1);
+    expect(spawnMock.mock.calls.length).toEqual(1);
     expect(stripAnsi(readlineQuestionMock.mock.calls[0][0])).toContain(
       "Would you like to install 'test-package' package? (That will run 'yarn add -D test-package')",
     );
 
     // install the package using yarn
-    expect(execaMock.mock.calls[0][0]).toEqual("yarn add -D test-package");
+    expect(spawnMock.mock.calls[0][0]).toEqual("yarn add -D test-package");
   });
 
   it("should prompt to install using pnpm if pnpm is package manager", async () => {
@@ -79,13 +79,13 @@ describe("doInstall", () => {
 
     expect(installResult).toBe("test-package");
     expect(readlineQuestionMock.mock.calls.length).toEqual(1);
-    expect(execaMock.mock.calls.length).toEqual(1);
+    expect(spawnMock.mock.calls.length).toEqual(1);
     expect(stripAnsi(readlineQuestionMock.mock.calls[0][0])).toContain(
       "Would you like to install 'test-package' package? (That will run 'pnpm install -D test-package')",
     );
 
     // install the package using npm
-    expect(execaMock.mock.calls[0][0]).toEqual("pnpm install -D test-package");
+    expect(spawnMock.mock.calls[0][0]).toEqual("pnpm install -D test-package");
   });
 
   it("should support pre message", async () => {
@@ -98,13 +98,13 @@ describe("doInstall", () => {
     expect(installResult).toBe("test-package");
     expect(preMessage.mock.calls.length).toEqual(1);
     expect(readlineQuestionMock.mock.calls.length).toEqual(1);
-    expect(execaMock.mock.calls.length).toEqual(1);
+    expect(spawnMock.mock.calls.length).toEqual(1);
     expect(stripAnsi(readlineQuestionMock.mock.calls[0][0])).toContain(
       "Would you like to install 'test-package' package? (That will run 'npm install -D test-package')",
     );
 
     // install the package using npm
-    expect(execaMock.mock.calls[0][0]).toEqual("npm install -D test-package");
+    expect(spawnMock.mock.calls[0][0]).toEqual("npm install -D test-package");
   });
 
   it("should prompt to install and install using 'y'", async () => {
@@ -115,13 +115,13 @@ describe("doInstall", () => {
 
     expect(installResult).toBe("test-package");
     expect(readlineQuestionMock.mock.calls.length).toEqual(1);
-    expect(execaMock.mock.calls.length).toEqual(1);
+    expect(spawnMock.mock.calls.length).toEqual(1);
     expect(stripAnsi(readlineQuestionMock.mock.calls[0][0])).toContain(
       "Would you like to install 'test-package' package? (That will run 'npm install -D test-package')",
     );
 
     // install the package using npm
-    expect(execaMock.mock.calls[0][0]).toEqual("npm install -D test-package");
+    expect(spawnMock.mock.calls[0][0]).toEqual("npm install -D test-package");
   });
 
   it("should prompt to install and install using 'yes'", async () => {
@@ -132,13 +132,13 @@ describe("doInstall", () => {
 
     expect(installResult).toBe("test-package");
     expect(readlineQuestionMock.mock.calls.length).toEqual(1);
-    expect(execaMock.mock.calls.length).toEqual(1);
+    expect(spawnMock.mock.calls.length).toEqual(1);
     expect(stripAnsi(readlineQuestionMock.mock.calls[0][0])).toContain(
       "Would you like to install 'test-package' package? (That will run 'npm install -D test-package')",
     );
 
     // install the package using npm
-    expect(execaMock.mock.calls[0][0]).toEqual("npm install -D test-package");
+    expect(spawnMock.mock.calls[0][0]).toEqual("npm install -D test-package");
   });
 
   it("should prompt to install and install using 'yEs'", async () => {
@@ -149,13 +149,13 @@ describe("doInstall", () => {
 
     expect(installResult).toBe("test-package");
     expect(readlineQuestionMock.mock.calls.length).toEqual(1);
-    expect(execaMock.mock.calls.length).toEqual(1);
+    expect(spawnMock.mock.calls.length).toEqual(1);
     expect(stripAnsi(readlineQuestionMock.mock.calls[0][0])).toContain(
       "Would you like to install 'test-package' package? (That will run 'npm install -D test-package')",
     );
 
     // install the package using npm
-    expect(execaMock.mock.calls[0][0]).toEqual("npm install -D test-package");
+    expect(spawnMock.mock.calls[0][0]).toEqual("npm install -D test-package");
   });
 
   it("should not install if install is not confirmed", async () => {
@@ -167,7 +167,7 @@ describe("doInstall", () => {
     expect(installResult).toBeUndefined();
     expect(readlineQuestionMock.mock.calls.length).toEqual(1);
     // runCommand should not be called, because the installation is not confirmed
-    expect(execaMock.mock.calls.length).toEqual(0);
+    expect(spawnMock.mock.calls.length).toEqual(0);
     expect(mockExit.mock.calls[0][0]).toEqual(2);
 
     mockExit.mockRestore();
@@ -182,7 +182,7 @@ describe("doInstall", () => {
     expect(installResult).toBeUndefined();
     expect(readlineQuestionMock.mock.calls.length).toEqual(1);
     // runCommand should not be called, because the installation is not confirmed
-    expect(execaMock.mock.calls.length).toEqual(0);
+    expect(spawnMock.mock.calls.length).toEqual(0);
     expect(mockExit.mock.calls[0][0]).toEqual(2);
 
     mockExit.mockRestore();
@@ -197,7 +197,7 @@ describe("doInstall", () => {
     expect(installResult).toBeUndefined();
     expect(readlineQuestionMock.mock.calls.length).toEqual(1);
     // runCommand should not be called, because the installation is not confirmed
-    expect(execaMock.mock.calls.length).toEqual(0);
+    expect(spawnMock.mock.calls.length).toEqual(0);
     expect(mockExit.mock.calls[0][0]).toEqual(2);
 
     mockExit.mockRestore();
@@ -212,7 +212,7 @@ describe("doInstall", () => {
     expect(installResult).toBeUndefined();
     expect(readlineQuestionMock.mock.calls.length).toEqual(1);
     // runCommand should not be called, because the installation is not confirmed
-    expect(execaMock.mock.calls.length).toEqual(0);
+    expect(spawnMock.mock.calls.length).toEqual(0);
     expect(mockExit.mock.calls[0][0]).toEqual(2);
 
     mockExit.mockRestore();

--- a/test/api/do-install.test.js
+++ b/test/api/do-install.test.js
@@ -19,7 +19,7 @@ jest.mock("readline", () => {
 
 const spawnMock = jest.fn();
 
-jest.mock("cross-spawn", () => spawnMock);
+jest.mock("cross-spawn", () => ({ sync: spawnMock }));
 
 describe("doInstall", () => {
   let cli;
@@ -51,7 +51,8 @@ describe("doInstall", () => {
     );
 
     // install the package using npm
-    expect(spawnMock.mock.calls[0][0]).toEqual("npm install -D test-package");
+    expect(spawnMock.mock.calls[0][0]).toEqual("npm");
+    expect(spawnMock.mock.calls[0][1]).toEqual(["install", "-D", "test-package"]);
   });
 
   it("should prompt to install using yarn if yarn is package manager", async () => {
@@ -68,7 +69,8 @@ describe("doInstall", () => {
     );
 
     // install the package using yarn
-    expect(spawnMock.mock.calls[0][0]).toEqual("yarn add -D test-package");
+    expect(spawnMock.mock.calls[0][0]).toEqual("yarn");
+    expect(spawnMock.mock.calls[0][1]).toEqual(["add", "-D", "test-package"]);
   });
 
   it("should prompt to install using pnpm if pnpm is package manager", async () => {
@@ -85,7 +87,8 @@ describe("doInstall", () => {
     );
 
     // install the package using npm
-    expect(spawnMock.mock.calls[0][0]).toEqual("pnpm install -D test-package");
+    expect(spawnMock.mock.calls[0][0]).toEqual("pnpm");
+    expect(spawnMock.mock.calls[0][1]).toEqual(["install", "-D", "test-package"]);
   });
 
   it("should support pre message", async () => {
@@ -104,7 +107,8 @@ describe("doInstall", () => {
     );
 
     // install the package using npm
-    expect(spawnMock.mock.calls[0][0]).toEqual("npm install -D test-package");
+    expect(spawnMock.mock.calls[0][0]).toEqual("npm");
+    expect(spawnMock.mock.calls[0][1]).toEqual(["install", "-D", "test-package"]);
   });
 
   it("should prompt to install and install using 'y'", async () => {
@@ -121,7 +125,8 @@ describe("doInstall", () => {
     );
 
     // install the package using npm
-    expect(spawnMock.mock.calls[0][0]).toEqual("npm install -D test-package");
+    expect(spawnMock.mock.calls[0][0]).toEqual("npm");
+    expect(spawnMock.mock.calls[0][1]).toEqual(["install", "-D", "test-package"]);
   });
 
   it("should prompt to install and install using 'yes'", async () => {
@@ -138,7 +143,8 @@ describe("doInstall", () => {
     );
 
     // install the package using npm
-    expect(spawnMock.mock.calls[0][0]).toEqual("npm install -D test-package");
+    expect(spawnMock.mock.calls[0][0]).toEqual("npm");
+    expect(spawnMock.mock.calls[0][1]).toEqual(["install", "-D", "test-package"]);
   });
 
   it("should prompt to install and install using 'yEs'", async () => {
@@ -155,7 +161,8 @@ describe("doInstall", () => {
     );
 
     // install the package using npm
-    expect(spawnMock.mock.calls[0][0]).toEqual("npm install -D test-package");
+    expect(spawnMock.mock.calls[0][0]).toEqual("npm");
+    expect(spawnMock.mock.calls[0][1]).toEqual(["install", "-D", "test-package"]);
   });
 
   it("should not install if install is not confirmed", async () => {

--- a/test/api/get-default-package-manager.test.js
+++ b/test/api/get-default-package-manager.test.js
@@ -8,7 +8,7 @@ const syncMock = jest.fn(() => {
     stdout: "1.0.0",
   };
 });
-jest.setMock("execa", {
+jest.setMock("cross-spawn", {
   sync: syncMock,
 });
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Refactor: use a simple child process instead of a shell and replace `execa` with `cross-spawn`.

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
No, I only replaced the `execa` mocks with `cross-spawn` mocks, as the functionality should be identical as before.
I've tested `webpack init` on my local machine.


**Summary**
Executing a shell is less performant, less secure and less cross-platform, according to both the [execa](https://github.com/sindresorhus/execa#shell) and [cross-spawn](https://github.com/moxystudio/node-cross-spawn#using-optionsshell-as-an-alternative-to-cross-spawn) documentation.

Replacing `execa` with `cross-spawn` removes 9 dependencies on a production install:
- execa
- get-stream
- human-signals
- is-stream
- mimic-fn
- npm-run-path
- onetime
- signal-exit
- strip-final-newline
 
I can't  find any options unique to execa in the codebase and cross-spawn should take care of the [Windows compatibility issues](https://github.com/moxystudio/node-cross-spawn#why).

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No.
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
 execa uses `cross-spawn` under the hood to parse the command arguments, so nothing should change in that regard: https://github.com/sindresorhus/execa/blob/main/index.js