### PR TITLE
fix: attempts custom package require without path exists check

### DIFF
--- a/packages/webpack-cli/src/webpack-cli.ts
+++ b/packages/webpack-cli/src/webpack-cli.ts
@@ -62,8 +62,10 @@ const util = require("util");
 
 const { program, Option } = require("commander");
 
-const WEBPACK_PACKAGE = process.env.WEBPACK_PACKAGE || "webpack";
-const WEBPACK_DEV_SERVER_PACKAGE = process.env.WEBPACK_DEV_SERVER_PACKAGE || "webpack-dev-server";
+const WEBPACK_PACKAGE_IS_CUSTOM = !!process.env.WEBPACK_PACKAGE;
+const WEBPACK_PACKAGE = WEBPACK_PACKAGE_IS_CUSTOM ? process.env.WEBPACK_PACKAGE as string : "webpack";
+const WEBPACK_DEV_SERVER_PACKAGE_IS_CUSTOM = !!process.env.WEBPACK_DEV_SERVER_PACKAGE;
+const WEBPACK_DEV_SERVER_PACKAGE = WEBPACK_DEV_SERVER_PACKAGE_IS_CUSTOM ? process.env.WEBPACK_DEV_SERVER_PACKAGE as string : "webpack-dev-server";
 
 class WebpackCLI implements IWebpackCLI {
   colors: WebpackCLIColors;
@@ -421,12 +423,12 @@ class WebpackCLI implements IWebpackCLI {
         let skipInstallation = false;
 
         // Allow to use `./path/to/webpack.js` outside `node_modules`
-        if (dependency === WEBPACK_PACKAGE && fs.existsSync(WEBPACK_PACKAGE)) {
+        if (dependency === WEBPACK_PACKAGE && WEBPACK_PACKAGE_IS_CUSTOM) {
           skipInstallation = true;
         }
 
         // Allow to use `./path/to/webpack-dev-server.js` outside `node_modules`
-        if (dependency === WEBPACK_DEV_SERVER_PACKAGE && fs.existsSync(WEBPACK_PACKAGE)) {
+        if (dependency === WEBPACK_DEV_SERVER_PACKAGE && WEBPACK_DEV_SERVER_PACKAGE_IS_CUSTOM) {
           skipInstallation = true;
         }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Bugfix

**Did you add tests for your changes?**

No

**If relevant, did you update the documentation?**

Yes

**Summary**

Firstly this change fixes an issue that looks like a copy-paste error: Custom WEBPACK_DEV_SERVER_PACKAGE would be conditioned on WEBPACK_PACKAGE to exist.

The next change, using require.resolve, widens the usefulness of the override. With plain `existsSync` you basically need an absolute path, unless you know what the current working directory will be when using the override.

**Does this PR introduce a breaking change?**

I don't think so. Existing WEBPACK_PACKAGE or WEBPACK_DEV_SERVER_PACKAGE would have satisfied `fs.existsSync(require.resolve(path)))` if they worked.

**Other information**
