### PR TITLE
chore: replace deprecated String.prototype.substr()

### DIFF
--- a/packages/webpack-cli/src/webpack-cli.ts
+++ b/packages/webpack-cli/src/webpack-cli.ts
@@ -1234,7 +1234,7 @@ class WebpackCLI implements IWebpackCLI {
         let name = error.message.match(/'(.+)'/) as string | null;
 
         if (name) {
-          name = name[1].substr(2);
+          name = name[1].slice(2);
 
           if (name.includes("=")) {
             name = name.split("=")[0];

--- a/smoketests/helpers.js
+++ b/smoketests/helpers.js
@@ -17,7 +17,7 @@ const getPkgPath = (pkg, isSubPackage) => {
 
 const swapPkgName = (current, isSubPackage = false) => {
   // info -> .info and vice-versa
-  const next = current.startsWith(".") ? current.substr(1) : `.${current}`;
+  const next = current.startsWith(".") ? current.slice(1) : `.${current}`;
 
   console.log(`  swapping ${current} with ${next}`);
 


### PR DESCRIPTION
This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

### Breaking Changes

None

### Additional Info
