### PR TITLE
Bugfix in calculation of modified time of files in watch mode

### DIFF
--- a/packages/webpack-cli/src/plugins/CLIPlugin.ts
+++ b/packages/webpack-cli/src/plugins/CLIPlugin.ts
@@ -93,7 +93,7 @@ export class CLIPlugin {
     });
 
     compiler.hooks.invalid.tap(pluginName, (filename, changeTime) => {
-      const date = new Date(changeTime * 1000);
+      const date = new Date(changeTime);
 
       this.logger.log(`File '${filename}' was modified`);
       this.logger.log(`Changed time is ${date} (timestamp is ${changeTime})`);


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix

**Did you add tests for your changes?**

No, seemed too niche for a test case but happy to add one with a bit of instruction (namely whether `test/plugin/plugin.test.js` is the correct spot)

**If relevant, did you update the documentation?**

Not relevant, updates a verbose log

**Summary**

Fixes https://github.com/webpack/webpack-cli/issues/3197

We need to pass the timestamp in milliseconds to the date constructor, this code was assuming that changeTime was in seconds and needed to be multiplied by 1000 to get milliseconds but it is already in milliseconds.

This led to the constructed date being incorrect.

|Before|After|
|---|---|
|<img src="https://user-images.githubusercontent.com/3004111/162455034-f94baef3-3468-41b4-82db-911351e08336.png">|<img alt="image" src="https://user-images.githubusercontent.com/3004111/162454932-32aa6f48-dcb7-4fba-8c73-1d0c47d0f3a4.png">|


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**

It appears that the `changeTime` value comes through the `WatchMethod` value of `WatchFileSystem` type, ultimately tracing back to the `watchpack` package. Watchpack uses `fs.lstat` to retrieve a `fs.Stat` object of the file and retuns the mtime by casting it to a number using the `+` operand. This might cause some platform-dependant behaviour, such as if `+new Date()` returns different levels of precision between Mac/Windows/Linux/etc. There's a `mtimeMs` on the Stat object that might be more appropriate in this case to ensure a certain level of precision is returned.

Ref: https://nodejs.org/api/fs.html#stat-time-values