### PR TITLE
fix: consider using createroot instead of render

### DIFF
--- a/packages/generators/init-template/react/src/index.js.tpl
+++ b/packages/generators/init-template/react/src/index.js.tpl
@@ -1,5 +1,5 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import App from './App';
 <%  if (cssType == 'CSS only') { %>
 import "./styles/global.css";<% } if (cssType == 'SASS') { %>
@@ -7,7 +7,6 @@ import "./styles/global.scss";<% } if (cssType == 'LESS') { %>
 import "./styles/global.less";<% } if (cssType == 'Stylus') { %>
 import "./styles/global.styl";<% } %>
 
-ReactDOM.render(
-    <App />,
-    document.getElementById("root")
-);
+const container = document.getElementById('root');
+const root = createRoot(container);
+root.render(<App />);

--- a/packages/generators/init-template/react/src/index.tsx.tpl
+++ b/packages/generators/init-template/react/src/index.tsx.tpl
@@ -1,5 +1,5 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import App from './App';
 <%  if (cssType == 'CSS only') { %>
 import "./styles/global.css";<% } if (cssType == 'SASS') { %>
@@ -7,7 +7,6 @@ import "./styles/global.scss";<% } if (cssType == 'LESS') { %>
 import "./styles/global.less";<% } if (cssType == 'Stylus') { %>
 import "./styles/global.styl";<% } %>
 
-ReactDOM.render(
-    <App />,
-    document.getElementById("root")
-);
+const container = document.getElementById('root');
+const root = createRoot(container);
+root.render(<App />);

--- a/packages/generators/src/handlers/react.ts
+++ b/packages/generators/src/handlers/react.ts
@@ -25,7 +25,7 @@ export async function questions(
   });
 
   // Add react dependencies
-  self.dependencies.push("react@18.1.0", "react-dom@18.1.0");
+  self.dependencies.push("react@18", "react-dom@18");
 
   // Add webpack-dev-server always
   self.dependencies.push("webpack-dev-server");

--- a/packages/generators/src/handlers/react.ts
+++ b/packages/generators/src/handlers/react.ts
@@ -25,7 +25,7 @@ export async function questions(
   });
 
   // Add react dependencies
-  self.dependencies.push("react", "react-dom");
+  self.dependencies.push("react@18.1.0", "react-dom@18.1.0");
 
   // Add webpack-dev-server always
   self.dependencies.push("webpack-dev-server");


### PR DESCRIPTION
**What kind of change does this PR introduce?**

I see that there is a react template support being added so used `createRoot` instead of `render` as per React 18.

**Did you add tests for your changes?**
