### PR TITLE
feat: Interactive Plugin

### DIFF
--- a/packages/webpack-cli/src/plugins/InteractivePlugin.ts
+++ b/packages/webpack-cli/src/plugins/InteractivePlugin.ts
@@ -1,3 +1,71 @@
-class InteractivePlugin {}
+import { type Compiler } from "webpack";
+// eslint-disable-next-line node/no-extraneous-import
+import { SyncHook } from "tapable";
+
+type TKeys = {
+  quit: string;
+  stop: string;
+  start: string;
+};
+
+type THandler = (compilers: Compiler[]) => Promise<void>;
+
+type THandlers = {
+  quit: THandler;
+  stop: THandler;
+  start: THandler;
+};
+
+const compilerHooksMap = new WeakMap<Compiler, Record<string, SyncHook<unknown>>>();
+
+class InteractivePlugin {
+  public name = "webpack-interactive-cli";
+  private keys: TKeys;
+  private verbose: boolean;
+  private handlers: THandlers;
+
+  static getCompilerHooks(compiler: Compiler) {
+    let hooks = compilerHooksMap.get(compiler);
+    if (hooks === undefined) {
+      hooks = {
+        beforeInteractiveOutput: new SyncHook(),
+      };
+      compilerHooksMap.set(compiler, hooks);
+    }
+    return hooks;
+  }
+
+  constructor(options = { mode: "verbose" }) {
+    this.keys = {
+      quit: "q",
+      stop: "s",
+      start: "w",
+    };
+
+    this.verbose = options.mode === "verbose";
+
+    this.handlers = {
+      quit: this.quit.bind(this),
+      stop: this.stop.bind(this),
+      start: this.start.bind(this),
+    };
+  }
+
+  apply(compiler: Compiler) {
+    return;
+  }
+
+  async quit(compilers: Compiler[]) {
+    return;
+  }
+
+  async stop(compilers: Compiler[]) {
+    return;
+  }
+
+  async start(compilers: Compiler[]) {
+    return;
+  }
+}
 
 export default InteractivePlugin;

--- a/packages/webpack-cli/src/plugins/InteractivePlugin.ts
+++ b/packages/webpack-cli/src/plugins/InteractivePlugin.ts
@@ -147,7 +147,23 @@ class InteractivePlugin {
   }
 
   async start(compilers: Compiler[]) {
-    return;
+    const allWatching = compilers.reduce((result, childCompiler) => {
+      return result && !childCompiler.watching.suspended;
+    }, true);
+
+    if (allWatching) {
+      //TODO: spawn interface
+      return;
+    }
+
+    for (const childCompiler of compilers) {
+      if (childCompiler.watching && childCompiler.watching.suspended) {
+        childCompiler.watching.resume();
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        childCompiler.compile(() => {});
+      }
+    }
+    // TODO: spawn interface
   }
 }
 

--- a/packages/webpack-cli/src/plugins/InteractivePlugin.ts
+++ b/packages/webpack-cli/src/plugins/InteractivePlugin.ts
@@ -52,7 +52,14 @@ class InteractivePlugin {
   }
 
   apply(compiler: Compiler) {
-    return;
+    this.hideCursor();
+  }
+
+  hideCursor() {
+    process.stdout.write("\u001B[?25l");
+    process.on("beforeExit", () => {
+      process.stdout.write("\u001B[?25h");
+    });
   }
 
   async quit(compilers: Compiler[]) {

--- a/packages/webpack-cli/src/plugins/InteractivePlugin.ts
+++ b/packages/webpack-cli/src/plugins/InteractivePlugin.ts
@@ -1,0 +1,3 @@
+class InteractivePlugin {}
+
+export default InteractivePlugin;

--- a/packages/webpack-cli/src/plugins/InteractivePlugin.ts
+++ b/packages/webpack-cli/src/plugins/InteractivePlugin.ts
@@ -110,7 +110,12 @@ class InteractivePlugin {
 
   hideCursor() {
     process.stdout.write("\u001B[?25l");
+
     process.on("beforeExit", () => {
+      process.stdout.write("\u001B[?25h");
+    });
+
+    process.on("exit", () => {
       process.stdout.write("\u001B[?25h");
     });
   }

--- a/packages/webpack-cli/src/plugins/InteractivePlugin.ts
+++ b/packages/webpack-cli/src/plugins/InteractivePlugin.ts
@@ -125,7 +125,21 @@ class InteractivePlugin {
   }
 
   async quit(compilers: Compiler[]) {
-    return;
+    const allExits: Promise<void>[] = [];
+    for (const compiler of compilers) {
+      allExits.push(
+        new Promise<void>((resolve) => {
+          compiler.close(() => {
+            resolve();
+          });
+        }),
+      );
+    }
+
+    Promise.all(allExits).then(() => {
+      // TODO: remove interface
+      process.exit(0);
+    });
   }
 
   async stop(compilers: Compiler[]) {

--- a/packages/webpack-cli/src/webpack-cli.ts
+++ b/packages/webpack-cli/src/webpack-cli.ts
@@ -972,6 +972,21 @@ class WebpackCLI implements IWebpackCLI {
         description: "Stop watching when stdin stream has ended.",
         negatedDescription: "Do not stop watching when stdin stream has ended.",
       },
+
+      {
+        name: "interactive",
+        configs: [
+          {
+            type: "string",
+          },
+          {
+            type: "boolean",
+          },
+        ],
+        alias: "i",
+        multiple: false,
+        description: "Enable webpack interactive mode",
+      },
     ];
 
     // Extract all the flags being exported from core.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Different from `interactive` at #586**: This PR just adds support for interactive output mode.

**What kind of change does this PR introduce?**
Feature

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**


**If relevant, did you update the documentation?**
Not applicable

**Summary**
There are two output modes for `--watch` and `webpack serve`, standard and interactive.
Standard is already supported. This PR aims to implement that.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
/cc @alexander-akait  