### PR TITLE
(Draft): Feature/remove lerna

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -93,7 +93,8 @@
     "wagoid",
     "Nitin",
     "dbaeumer",
-    "esbenp"
+    "esbenp",
+    "quickstart"
   ],
   "dictionaries": ["npm", "software-terms"],
   "ignorePaths": [

--- a/.cspell.json
+++ b/.cspell.json
@@ -91,7 +91,9 @@
     "Zenitsu",
     "eslintcache",
     "wagoid",
-    "Nitin"
+    "Nitin",
+    "dbaeumer",
+    "esbenp"
   ],
   "dictionaries": ["npm", "software-terms"],
   "ignorePaths": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,6 +5,6 @@
   "settings": {
     "terminal.integrated.shell.linux": "/bin/bash"
   },
-  "postCreateCommand": "yarn install && yarn lerna bootstrap && yarn build",
+  "postCreateCommand": "yarn install && yarn build",
   "extensions": ["dbaeumer.vscode-eslint", "esbenp.prettier-vscode"]
 }

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -72,7 +72,6 @@ In case you are suggesting a new feature, we will match your idea with our curre
 - Bootstrap all the submodules before building for the first time
 
   ```bash
-  yarn lerna bootstrap
   yarn build
   ```
 

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -38,9 +38,6 @@ jobs:
       - name: Install dependencies
         run: yarn --frozen-lockfile
 
-      - name: Bootstrap
-        run: yarn install
-
       - name: Build
         run: yarn build
 

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -39,7 +39,7 @@ jobs:
         run: yarn --frozen-lockfile
 
       - name: Bootstrap
-        run: yarn lerna bootstrap
+        run: yarn install
 
       - name: Build
         run: yarn build

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -40,7 +40,7 @@ jobs:
         run: yarn add -W webpack-dev-server@latest webpack@latest
 
       - name: Bootstrap
-        run: yarn lerna bootstrap
+        run: yarn install
 
       - name: Build
         run: yarn build

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -39,9 +39,6 @@ jobs:
       - name: Install latest webpack and webpack-dev-server version
         run: yarn add -W webpack-dev-server@latest webpack@latest
 
-      - name: Bootstrap
-        run: yarn install
-
       - name: Build
         run: yarn build
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "./packages/*"
   ],
   "scripts": {
+    "prune:deps": "find . -name 'node_modules' -type d -prune -exec rm -rf '{}' +",
     "clean": "del-cli \"*.tsbuildinfo\" \"packages/**/*.tsbuildinfo\" \"packages/*/lib/!(*.tpl)\" \"**/.yo-rc.json\"",
     "prebuild": "yarn clean",
     "prebuild:ci": "yarn clean && node ./scripts/setupBuild.js",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

The intention is to remove `lerna` from dependencies list and use yarn workspaces instead. I started with removing `lerna bootsrap` command to see if `yarn install` would suffice for pipelines to succeed. 

After replacing `lerna bootstrap`, I'll have a look on other lerna usages (versioning and publishing) to see how we can replace those.

**Did you add tests for your changes?**

No

**If relevant, did you update the documentation?**

Not yet, I'd like to run a few CI pipelines on my branch to see how it goes.

**Summary**

[Related to feature request #3227](https://github.com/webpack/webpack-cli/issues/3227)

**Does this PR introduce a breaking change?**

No

**Other information**

This is a draft PR, as migration from `lerna` is not ready yet.
