### PR TITLE
fix: improve parsing of `--env` flag

### DIFF
--- a/test/build/config/type/function-with-env/function-with-env.test.js
+++ b/test/build/config/type/function-with-env/function-with-env.test.js
@@ -17,7 +17,7 @@ describe("function configuration", () => {
 
     expect(exitCode).toBe(0);
     expect(stderr).toBeFalsy();
-    expect(stdout).toBeTruthy();
+    expect(stdout).toContain("isProd: true");
     // Should generate the appropriate files
     expect(existsSync(resolve(__dirname, "./dist/prod.js"))).toBeTruthy();
   });
@@ -27,7 +27,7 @@ describe("function configuration", () => {
 
     expect(exitCode).toBe(0);
     expect(stderr).toBeFalsy();
-    expect(stdout).toBeTruthy();
+    expect(stdout).toContain("isDev: true");
     // Should generate the appropriate files
     expect(existsSync(resolve(__dirname, "./dist/dev.js"))).toBeTruthy();
   });
@@ -44,7 +44,8 @@ describe("function configuration", () => {
 
     expect(exitCode).toBe(0);
     expect(stderr).toBeFalsy();
-    expect(stdout).toBeTruthy();
+    expect(stdout).toContain("environment: 'production'");
+    expect(stdout).toContain("app: { title: 'Luffy' }");
     // Should generate the appropriate files
     expect(existsSync(resolve(__dirname, "./dist/Luffy.js"))).toBeTruthy();
   });
@@ -62,6 +63,7 @@ describe("function configuration", () => {
     expect(exitCode).toBe(0);
     expect(stderr).toBeFalsy();
     expect(stdout).toBeTruthy();
+    expect(stdout).toContain("environment: 'production'");
     // Should generate the appropriate files
     expect(existsSync(resolve(__dirname, "./dist/Atsumu.js"))).toBeTruthy();
   });
@@ -78,7 +80,8 @@ describe("function configuration", () => {
 
     expect(exitCode).toBe(0);
     expect(stderr).toBeFalsy();
-    expect(stdout).toBeTruthy();
+    expect(stdout).toContain("environment: 'multipleq'");
+    expect(stdout).toContain("file: 'name=is=Eren'");
     // Should generate the appropriate files
     expect(existsSync(resolve(__dirname, "./dist/name=is=Eren.js"))).toBeTruthy();
   });
@@ -95,7 +98,8 @@ describe("function configuration", () => {
 
     expect(exitCode).toBe(0);
     expect(stderr).toBeFalsy();
-    expect(stdout).toBeTruthy();
+    expect(stdout).toContain("environment: 'dot'");
+    expect(stdout).toContain("'name.': 'Hisoka'");
     // Should generate the appropriate files
     expect(existsSync(resolve(__dirname, "./dist/Hisoka.js"))).toBeTruthy();
   });
@@ -112,7 +116,8 @@ describe("function configuration", () => {
 
     expect(exitCode).toBe(0);
     expect(stderr).toBeFalsy();
-    expect(stdout).toBeTruthy();
+    expect(stdout).toContain("environment: 'dot'");
+    expect(stdout).toContain("'name.': true");
     // Should generate the appropriate files
     expect(existsSync(resolve(__dirname, "./dist/true.js"))).toBeTruthy();
   });
@@ -122,7 +127,7 @@ describe("function configuration", () => {
 
     expect(exitCode).toBe(0);
     expect(stderr).toBeFalsy();
-    expect(stdout).toBeTruthy();
+    expect(stdout).toContain(`foo: "''"`);
     // Should generate the appropriate files
     expect(existsSync(resolve(__dirname, "./dist/empty-string.js"))).toBeTruthy();
   });
@@ -132,7 +137,7 @@ describe("function configuration", () => {
 
     expect(exitCode).toBe(0);
     expect(stderr).toBeFalsy();
-    expect(stdout).toBeTruthy();
+    expect(stdout).toContain(`foo: "bar=''"`);
     // Should generate the appropriate files
     expect(existsSync(resolve(__dirname, "./dist/new-empty-string.js"))).toBeTruthy();
   });
@@ -146,28 +151,52 @@ describe("function configuration", () => {
     expect(stdout).toContain("foo: undefined");
   });
 
-  it('Supports env variable with "=$NON_EXISTENT_VAR" at the end', async () => {
-    const { exitCode, stderr, stdout } = await run(__dirname, ["--env", `foo=$NON_EXISTENT_VAR`], {
-      shell: true,
-    });
+  it('Supports env variable with "foo=undefined" at the end', async () => {
+    const { exitCode, stderr, stdout } = await run(__dirname, ["--env", `foo=undefined`]);
 
     expect(exitCode).toBe(0);
     expect(stderr).toBeFalsy();
-    // should log foo: undefined
-    expect(stdout).toContain("foo: undefined");
+    // should log foo: 'undefined'
+    expect(stdout).toContain("foo: 'undefined'");
+    // Should generate the appropriate files
+    expect(existsSync(resolve(__dirname, "./dist/undefined-foo.js"))).toBeTruthy();
   });
 
   // macOS/Linux specific syntax
   if (!isWindows) {
-    it('Supports env variable with "foo=undefined" at the end', async () => {
-      const { exitCode, stderr, stdout } = await run(__dirname, ["--env", `foo=undefined`]);
+    it("Supports empty string in shell environment", async () => {
+      const { exitCode, stderr, stdout } = await run(__dirname, ["--env", "foo=\\'\\'"], {
+        shell: true,
+      });
 
       expect(exitCode).toBe(0);
       expect(stderr).toBeFalsy();
-      // should log foo: 'undefined'
-      expect(stdout).toContain("foo: 'undefined'");
+      expect(stdout).toContain(`foo: "''"`);
       // Should generate the appropriate files
-      expect(existsSync(resolve(__dirname, "./dist/undefined-foo.js"))).toBeTruthy();
+      expect(existsSync(resolve(__dirname, "./dist/empty-string.js"))).toBeTruthy();
+    });
+    it("should set the variable to undefined if empty string is not escaped in shell environment", async () => {
+      const { exitCode, stderr, stdout } = await run(__dirname, ["--env", "foo=''"], {
+        shell: true,
+      });
+
+      expect(exitCode).toBe(0);
+      expect(stderr).toBeFalsy();
+      expect(stdout).toContain(`foo: undefined`);
+    });
+    it('Supports env variable with "=$NON_EXISTENT_VAR" at the end', async () => {
+      const { exitCode, stderr, stdout } = await run(
+        __dirname,
+        ["--env", `foo=$NON_EXISTENT_VAR`],
+        {
+          shell: true,
+        },
+      );
+
+      expect(exitCode).toBe(0);
+      expect(stderr).toBeFalsy();
+      // should log foo: undefined
+      expect(stdout).toContain("foo: undefined");
     });
   }
 
@@ -183,7 +212,8 @@ describe("function configuration", () => {
 
     expect(exitCode).toBe(0);
     expect(stderr).toBeFalsy();
-    expect(stdout).toBeTruthy();
+    expect(stdout).toContain("verboseStats: true");
+    expect(stdout).toContain("envMessage: true");
     // check that the verbose env is respected
     expect(stdout).toContain("LOG from webpack");
 
@@ -213,7 +243,7 @@ describe("function configuration", () => {
 
     expect(exitCode).toBe(0);
     expect(stderr).toBeFalsy();
-    expect(stdout).toBeTruthy();
+    expect(stdout).toContain("'name.': 'baz'");
     // Should generate the appropriate files
     expect(existsSync(resolve(__dirname, "./dist/baz.js"))).toBeTruthy();
   });

--- a/test/build/config/type/function-with-env/function-with-env.test.js
+++ b/test/build/config/type/function-with-env/function-with-env.test.js
@@ -142,9 +142,19 @@ describe("function configuration", () => {
 
     expect(exitCode).toBe(0);
     expect(stderr).toBeFalsy();
-    expect(stdout).toBeTruthy();
-    // Should generate the appropriate files
-    expect(existsSync(resolve(__dirname, "./dist/equal-at-the-end.js"))).toBeTruthy();
+    // should log foo: undefined
+    expect(stdout).toContain("foo: undefined");
+  });
+
+  it('Supports env variable with "=$NON_EXISTENT_VAR" at the end', async () => {
+    const { exitCode, stderr, stdout } = await run(__dirname, ["--env", `foo=$NON_EXISTENT_VAR`], {
+      shell: true,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toBeFalsy();
+    // should log foo: undefined
+    expect(stdout).toContain("foo: undefined");
   });
 
   it("is able to understand multiple env flags", async () => {

--- a/test/build/config/type/function-with-env/function-with-env.test.js
+++ b/test/build/config/type/function-with-env/function-with-env.test.js
@@ -62,7 +62,6 @@ describe("function configuration", () => {
 
     expect(exitCode).toBe(0);
     expect(stderr).toBeFalsy();
-    expect(stdout).toBeTruthy();
     expect(stdout).toContain("environment: 'production'");
     // Should generate the appropriate files
     expect(existsSync(resolve(__dirname, "./dist/Atsumu.js"))).toBeTruthy();

--- a/test/build/config/type/function-with-env/function-with-env.test.js
+++ b/test/build/config/type/function-with-env/function-with-env.test.js
@@ -1,7 +1,7 @@
 "use strict";
 const { existsSync } = require("fs");
 const { resolve } = require("path");
-const { run, readFile } = require("../../../../utils/test-utils");
+const { run, readFile, isWindows } = require("../../../../utils/test-utils");
 
 describe("function configuration", () => {
   it("should throw when env is not supplied", async () => {
@@ -156,6 +156,20 @@ describe("function configuration", () => {
     // should log foo: undefined
     expect(stdout).toContain("foo: undefined");
   });
+
+  // macOS/Linux specific syntax
+  if (!isWindows) {
+    it('Supports env variable with "foo=undefined" at the end', async () => {
+      const { exitCode, stderr, stdout } = await run(__dirname, ["--env", `foo=undefined`]);
+
+      expect(exitCode).toBe(0);
+      expect(stderr).toBeFalsy();
+      // should log foo: 'undefined'
+      expect(stdout).toContain("foo: 'undefined'");
+      // Should generate the appropriate files
+      expect(existsSync(resolve(__dirname, "./dist/undefined-foo.js"))).toBeTruthy();
+    });
+  }
 
   it("is able to understand multiple env flags", async () => {
     const { exitCode, stderr, stdout } = await run(__dirname, [

--- a/test/build/config/type/function-with-env/webpack.config.js
+++ b/test/build/config/type/function-with-env/webpack.config.js
@@ -1,6 +1,7 @@
 const { DefinePlugin } = require("webpack");
 
 module.exports = (env) => {
+  console.log(env);
   if (env.isProd) {
     return {
       entry: "./a.js",
@@ -22,14 +23,6 @@ module.exports = (env) => {
       entry: "./a.js",
       output: {
         filename: "new-empty-string.js",
-      },
-    };
-  }
-  if (env["foo="]) {
-    return {
-      entry: "./a.js",
-      output: {
-        filename: "equal-at-the-end.js",
       },
     };
   }

--- a/test/build/config/type/function-with-env/webpack.config.js
+++ b/test/build/config/type/function-with-env/webpack.config.js
@@ -26,6 +26,14 @@ module.exports = (env) => {
       },
     };
   }
+  if (env.foo === "undefined") {
+    return {
+      entry: "./a.js",
+      output: {
+        filename: "undefined-foo.js",
+      },
+    };
+  }
   return {
     entry: "./a.js",
     mode: "development",

--- a/test/build/config/type/function-with-env/webpack.env.config.js
+++ b/test/build/config/type/function-with-env/webpack.env.config.js
@@ -1,4 +1,5 @@
 module.exports = (env) => {
+  console.log(env);
   const { environment, app, file } = env;
   const customName = file && file.name && file.name.is && file.name.is.this;
   const appTitle = app && app.title;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

bugfix.

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**

Yes

**If relevant, did you update the documentation?**

I will add a note on webpack.js.org

**Summary**

Fix https://github.com/webpack/webpack-cli/issues/3284

Set the variable to `undefined` instead of setting it to `true`.

```
$ npx webpack --env TEST1="" --env TEST2=$NON_EXISTENT_ENVVAR --env TEST3=
{
  WEBPACK_BUNDLE: true,
  WEBPACK_BUILD: true,
  'TEST1': '',
  'TEST2': undefined,
  'TEST3': undefined
}
asset main.bundle.js 50 bytes [compared for emit] [minimized] (name: main)
./main.js 28 bytes [built] [code generated]
webpack 5.73.0 compiled successfully in 82 ms
```
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
No