### PR TITLE
fix: show all CLI specific flags in the minimum help output

### DIFF
--- a/packages/webpack-cli/src/webpack-cli.ts
+++ b/packages/webpack-cli/src/webpack-cli.ts
@@ -698,28 +698,6 @@ class WebpackCLI implements IWebpackCLI {
       return this.builtInOptionsCache;
     }
 
-    const minimumHelpFlags = [
-      "analyze",
-      "config",
-      "config-name",
-      "merge",
-      "disable-interpret",
-      "env",
-      "mode",
-      "watch",
-      "watch-options-stdin",
-      "stats",
-      "devtool",
-      "entry",
-      "target",
-      "progress",
-      "json",
-      "name",
-      "output-path",
-      "node-env",
-      "fail-on-warnings",
-    ];
-
     const builtInFlags: WebpackCLIBuiltInFlag[] = [
       // For configs
       {
@@ -873,6 +851,19 @@ class WebpackCLI implements IWebpackCLI {
         ],
         description: "Stop webpack-cli process with non-zero exit code on warnings from webpack",
       },
+    ];
+
+    const minimumHelpFlags = [
+      ...builtInFlags.map((flag) => flag.name),
+      "mode",
+      "watch",
+      "watch-options-stdin",
+      "stats",
+      "devtool",
+      "entry",
+      "target",
+      "name",
+      "output-path",
     ];
 
     // Extract all the flags being exported from core.

--- a/packages/webpack-cli/src/webpack-cli.ts
+++ b/packages/webpack-cli/src/webpack-cli.ts
@@ -699,6 +699,7 @@ class WebpackCLI implements IWebpackCLI {
     }
 
     const minimumHelpFlags = [
+      "analyze",
       "config",
       "config-name",
       "merge",
@@ -716,6 +717,7 @@ class WebpackCLI implements IWebpackCLI {
       "name",
       "output-path",
       "node-env",
+      "fail-on-warnings",
     ];
 
     const builtInFlags: WebpackCLIBuiltInFlag[] = [

--- a/test/help/__snapshots__/help.test.js.snap.devServer4.webpack5
+++ b/test/help/__snapshots__/help.test.js.snap.devServer4.webpack5
@@ -100,8 +100,10 @@ Options:
   --disable-interpret                              Disable interpret a config file.
   --env <value...>                                 Environment passed to the configuration when it is a function.
   --node-env <value>                               Sets process.env.NODE_ENV to the specified value.
+  --analyze                                        It invokes webpack-bundle-analyzer plugin to get bundle information.
   --progress [value]                               Print compilation progress during build.
   -j, --json [value]                               Prints result as JSON or store it in a file.
+  --fail-on-warnings                               Stop webpack-cli process with non-zero exit code on warnings from webpack
   -d, --devtool <value>                            A developer tool to enhance debugging (false | eval | [inline-|hidden-|eval-][nosources-][cheap-[module-]]source-map).
   --no-devtool                                     Negative 'devtool' option.
   --entry <value...>                               A module that is loaded upon startup. Only the last one is exported.
@@ -157,8 +159,10 @@ Options:
   --disable-interpret                              Disable interpret a config file.
   --env <value...>                                 Environment passed to the configuration when it is a function.
   --node-env <value>                               Sets process.env.NODE_ENV to the specified value.
+  --analyze                                        It invokes webpack-bundle-analyzer plugin to get bundle information.
   --progress [value]                               Print compilation progress during build.
   -j, --json [value]                               Prints result as JSON or store it in a file.
+  --fail-on-warnings                               Stop webpack-cli process with non-zero exit code on warnings from webpack
   -d, --devtool <value>                            A developer tool to enhance debugging (false | eval | [inline-|hidden-|eval-][nosources-][cheap-[module-]]source-map).
   --no-devtool                                     Negative 'devtool' option.
   --entry <value...>                               A module that is loaded upon startup. Only the last one is exported.
@@ -214,8 +218,10 @@ Options:
   --disable-interpret                              Disable interpret a config file.
   --env <value...>                                 Environment passed to the configuration when it is a function.
   --node-env <value>                               Sets process.env.NODE_ENV to the specified value.
+  --analyze                                        It invokes webpack-bundle-analyzer plugin to get bundle information.
   --progress [value]                               Print compilation progress during build.
   -j, --json [value]                               Prints result as JSON or store it in a file.
+  --fail-on-warnings                               Stop webpack-cli process with non-zero exit code on warnings from webpack
   -d, --devtool <value>                            A developer tool to enhance debugging (false | eval | [inline-|hidden-|eval-][nosources-][cheap-[module-]]source-map).
   --no-devtool                                     Negative 'devtool' option.
   --entry <value...>                               A module that is loaded upon startup. Only the last one is exported.
@@ -270,8 +276,10 @@ Options:
   --disable-interpret        Disable interpret a config file.
   --env <value...>           Environment passed to the configuration when it is a function.
   --node-env <value>         Sets process.env.NODE_ENV to the specified value.
+  --analyze                  It invokes webpack-bundle-analyzer plugin to get bundle information.
   --progress [value]         Print compilation progress during build.
   -j, --json [value]         Prints result as JSON or store it in a file.
+  --fail-on-warnings         Stop webpack-cli process with non-zero exit code on warnings from webpack
   -d, --devtool <value>      A developer tool to enhance debugging (false | eval | [inline-|hidden-|eval-][nosources-][cheap-[module-]]source-map).
   --no-devtool               Negative 'devtool' option.
   --entry <value...>         A module that is loaded upon startup. Only the last one is exported.
@@ -314,8 +322,10 @@ Options:
   --disable-interpret        Disable interpret a config file.
   --env <value...>           Environment passed to the configuration when it is a function.
   --node-env <value>         Sets process.env.NODE_ENV to the specified value.
+  --analyze                  It invokes webpack-bundle-analyzer plugin to get bundle information.
   --progress [value]         Print compilation progress during build.
   -j, --json [value]         Prints result as JSON or store it in a file.
+  --fail-on-warnings         Stop webpack-cli process with non-zero exit code on warnings from webpack
   -d, --devtool <value>      A developer tool to enhance debugging (false | eval | [inline-|hidden-|eval-][nosources-][cheap-[module-]]source-map).
   --no-devtool               Negative 'devtool' option.
   --entry <value...>         A module that is loaded upon startup. Only the last one is exported.
@@ -361,8 +371,12 @@ Options:
   --env <value...>           Environment passed to the configuration when it is
                              a function.
   --node-env <value>         Sets process.env.NODE_ENV to the specified value.
+  --analyze                  It invokes webpack-bundle-analyzer plugin to get
+                             bundle information.
   --progress [value]         Print compilation progress during build.
   -j, --json [value]         Prints result as JSON or store it in a file.
+  --fail-on-warnings         Stop webpack-cli process with non-zero exit code
+                             on warnings from webpack
   -d, --devtool <value>      A developer tool to enhance debugging (false |
                              eval |
                              [inline-|hidden-|eval-][nosources-][cheap-[module-]]source-map).
@@ -418,8 +432,12 @@ Options:
   --env <value...>           Environment passed to the configuration when it is
                              a function.
   --node-env <value>         Sets process.env.NODE_ENV to the specified value.
+  --analyze                  It invokes webpack-bundle-analyzer plugin to get
+                             bundle information.
   --progress [value]         Print compilation progress during build.
   -j, --json [value]         Prints result as JSON or store it in a file.
+  --fail-on-warnings         Stop webpack-cli process with non-zero exit code
+                             on warnings from webpack
   -d, --devtool <value>      A developer tool to enhance debugging (false |
                              eval |
                              [inline-|hidden-|eval-][nosources-][cheap-[module-]]source-map).
@@ -472,8 +490,10 @@ Options:
   --disable-interpret        Disable interpret a config file.
   --env <value...>           Environment passed to the configuration when it is a function.
   --node-env <value>         Sets process.env.NODE_ENV to the specified value.
+  --analyze                  It invokes webpack-bundle-analyzer plugin to get bundle information.
   --progress [value]         Print compilation progress during build.
   -j, --json [value]         Prints result as JSON or store it in a file.
+  --fail-on-warnings         Stop webpack-cli process with non-zero exit code on warnings from webpack
   -d, --devtool <value>      A developer tool to enhance debugging (false | eval | [inline-|hidden-|eval-][nosources-][cheap-[module-]]source-map).
   --no-devtool               Negative 'devtool' option.
   --entry <value...>         A module that is loaded upon startup. Only the last one is exported.
@@ -516,8 +536,10 @@ Options:
   --disable-interpret        Disable interpret a config file.
   --env <value...>           Environment passed to the configuration when it is a function.
   --node-env <value>         Sets process.env.NODE_ENV to the specified value.
+  --analyze                  It invokes webpack-bundle-analyzer plugin to get bundle information.
   --progress [value]         Print compilation progress during build.
   -j, --json [value]         Prints result as JSON or store it in a file.
+  --fail-on-warnings         Stop webpack-cli process with non-zero exit code on warnings from webpack
   -d, --devtool <value>      A developer tool to enhance debugging (false | eval | [inline-|hidden-|eval-][nosources-][cheap-[module-]]source-map).
   --no-devtool               Negative 'devtool' option.
   --entry <value...>         A module that is loaded upon startup. Only the last one is exported.
@@ -1494,8 +1516,10 @@ Options:
   --disable-interpret        Disable interpret a config file.
   --env <value...>           Environment passed to the configuration when it is a function.
   --node-env <value>         Sets process.env.NODE_ENV to the specified value.
+  --analyze                  It invokes webpack-bundle-analyzer plugin to get bundle information.
   --progress [value]         Print compilation progress during build.
   -j, --json [value]         Prints result as JSON or store it in a file.
+  --fail-on-warnings         Stop webpack-cli process with non-zero exit code on warnings from webpack
   -d, --devtool <value>      A developer tool to enhance debugging (false | eval | [inline-|hidden-|eval-][nosources-][cheap-[module-]]source-map).
   --no-devtool               Negative 'devtool' option.
   --entry <value...>         A module that is loaded upon startup. Only the last one is exported.
@@ -1536,8 +1560,10 @@ Options:
   --disable-interpret        Disable interpret a config file.
   --env <value...>           Environment passed to the configuration when it is a function.
   --node-env <value>         Sets process.env.NODE_ENV to the specified value.
+  --analyze                  It invokes webpack-bundle-analyzer plugin to get bundle information.
   --progress [value]         Print compilation progress during build.
   -j, --json [value]         Prints result as JSON or store it in a file.
+  --fail-on-warnings         Stop webpack-cli process with non-zero exit code on warnings from webpack
   -d, --devtool <value>      A developer tool to enhance debugging (false | eval | [inline-|hidden-|eval-][nosources-][cheap-[module-]]source-map).
   --no-devtool               Negative 'devtool' option.
   --entry <value...>         A module that is loaded upon startup. Only the last one is exported.
@@ -1581,8 +1607,12 @@ Options:
   --env <value...>           Environment passed to the configuration when it is
                              a function.
   --node-env <value>         Sets process.env.NODE_ENV to the specified value.
+  --analyze                  It invokes webpack-bundle-analyzer plugin to get
+                             bundle information.
   --progress [value]         Print compilation progress during build.
   -j, --json [value]         Prints result as JSON or store it in a file.
+  --fail-on-warnings         Stop webpack-cli process with non-zero exit code
+                             on warnings from webpack
   -d, --devtool <value>      A developer tool to enhance debugging (false |
                              eval |
                              [inline-|hidden-|eval-][nosources-][cheap-[module-]]source-map).
@@ -1636,8 +1666,12 @@ Options:
   --env <value...>           Environment passed to the configuration when it is
                              a function.
   --node-env <value>         Sets process.env.NODE_ENV to the specified value.
+  --analyze                  It invokes webpack-bundle-analyzer plugin to get
+                             bundle information.
   --progress [value]         Print compilation progress during build.
   -j, --json [value]         Prints result as JSON or store it in a file.
+  --fail-on-warnings         Stop webpack-cli process with non-zero exit code
+                             on warnings from webpack
   -d, --devtool <value>      A developer tool to enhance debugging (false |
                              eval |
                              [inline-|hidden-|eval-][nosources-][cheap-[module-]]source-map).
@@ -1688,8 +1722,10 @@ Options:
   --disable-interpret        Disable interpret a config file.
   --env <value...>           Environment passed to the configuration when it is a function.
   --node-env <value>         Sets process.env.NODE_ENV to the specified value.
+  --analyze                  It invokes webpack-bundle-analyzer plugin to get bundle information.
   --progress [value]         Print compilation progress during build.
   -j, --json [value]         Prints result as JSON or store it in a file.
+  --fail-on-warnings         Stop webpack-cli process with non-zero exit code on warnings from webpack
   -d, --devtool <value>      A developer tool to enhance debugging (false | eval | [inline-|hidden-|eval-][nosources-][cheap-[module-]]source-map).
   --no-devtool               Negative 'devtool' option.
   --entry <value...>         A module that is loaded upon startup. Only the last one is exported.
@@ -1730,8 +1766,10 @@ Options:
   --disable-interpret        Disable interpret a config file.
   --env <value...>           Environment passed to the configuration when it is a function.
   --node-env <value>         Sets process.env.NODE_ENV to the specified value.
+  --analyze                  It invokes webpack-bundle-analyzer plugin to get bundle information.
   --progress [value]         Print compilation progress during build.
   -j, --json [value]         Prints result as JSON or store it in a file.
+  --fail-on-warnings         Stop webpack-cli process with non-zero exit code on warnings from webpack
   -d, --devtool <value>      A developer tool to enhance debugging (false | eval | [inline-|hidden-|eval-][nosources-][cheap-[module-]]source-map).
   --no-devtool               Negative 'devtool' option.
   --entry <value...>         A module that is loaded upon startup. Only the last one is exported.
@@ -1773,8 +1811,10 @@ Options:
   --disable-interpret                              Disable interpret a config file.
   --env <value...>                                 Environment passed to the configuration when it is a function.
   --node-env <value>                               Sets process.env.NODE_ENV to the specified value.
+  --analyze                                        It invokes webpack-bundle-analyzer plugin to get bundle information.
   --progress [value]                               Print compilation progress during build.
   -j, --json [value]                               Prints result as JSON or store it in a file.
+  --fail-on-warnings                               Stop webpack-cli process with non-zero exit code on warnings from webpack
   -d, --devtool <value>                            A developer tool to enhance debugging (false | eval | [inline-|hidden-|eval-][nosources-][cheap-[module-]]source-map).
   --no-devtool                                     Negative 'devtool' option.
   --entry <value...>                               A module that is loaded upon startup. Only the last one is exported.
@@ -1830,8 +1870,10 @@ Options:
   --disable-interpret                              Disable interpret a config file.
   --env <value...>                                 Environment passed to the configuration when it is a function.
   --node-env <value>                               Sets process.env.NODE_ENV to the specified value.
+  --analyze                                        It invokes webpack-bundle-analyzer plugin to get bundle information.
   --progress [value]                               Print compilation progress during build.
   -j, --json [value]                               Prints result as JSON or store it in a file.
+  --fail-on-warnings                               Stop webpack-cli process with non-zero exit code on warnings from webpack
   -d, --devtool <value>                            A developer tool to enhance debugging (false | eval | [inline-|hidden-|eval-][nosources-][cheap-[module-]]source-map).
   --no-devtool                                     Negative 'devtool' option.
   --entry <value...>                               A module that is loaded upon startup. Only the last one is exported.
@@ -2077,8 +2119,10 @@ Options:
   --disable-interpret                              Disable interpret a config file.
   --env <value...>                                 Environment passed to the configuration when it is a function.
   --node-env <value>                               Sets process.env.NODE_ENV to the specified value.
+  --analyze                                        It invokes webpack-bundle-analyzer plugin to get bundle information.
   --progress [value]                               Print compilation progress during build.
   -j, --json [value]                               Prints result as JSON or store it in a file.
+  --fail-on-warnings                               Stop webpack-cli process with non-zero exit code on warnings from webpack
   -d, --devtool <value>                            A developer tool to enhance debugging (false | eval | [inline-|hidden-|eval-][nosources-][cheap-[module-]]source-map).
   --no-devtool                                     Negative 'devtool' option.
   --entry <value...>                               A module that is loaded upon startup. Only the last one is exported.
@@ -2132,8 +2176,10 @@ Options:
   --disable-interpret                              Disable interpret a config file.
   --env <value...>                                 Environment passed to the configuration when it is a function.
   --node-env <value>                               Sets process.env.NODE_ENV to the specified value.
+  --analyze                                        It invokes webpack-bundle-analyzer plugin to get bundle information.
   --progress [value]                               Print compilation progress during build.
   -j, --json [value]                               Prints result as JSON or store it in a file.
+  --fail-on-warnings                               Stop webpack-cli process with non-zero exit code on warnings from webpack
   -d, --devtool <value>                            A developer tool to enhance debugging (false | eval | [inline-|hidden-|eval-][nosources-][cheap-[module-]]source-map).
   --no-devtool                                     Negative 'devtool' option.
   --entry <value...>                               A module that is loaded upon startup. Only the last one is exported.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
bugfix
<!-- E.g. a bugfix, feature, refactoring, build-related change, etc… -->

**Did you add tests for your changes?**
Yes. Updated snapshots.

**If relevant, did you update the documentation?**
No.

**Summary**

webpack-cli offers many additional flags like (`--analyze`, `--json`, `--env`, etc) than pure configuration option (like `--stats`, `--target`).

The minimum help output should contain all the additional feature flags webpack-cli offers for better visibility, It's easy to miss these flags in the verbose help output.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
NO