### PR TITLE
ci: add job to cancel previous runs

### DIFF
--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -1,0 +1,12 @@
+name: Cancel
+on: [push]
+jobs:
+  cancel:
+    name: Cancel Previous Runs
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: styfle/cancel-workflow-action@0.10.0
+        with:
+          workflow_id: nodejs.yml
+          access_token: ${{ github.token }}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
CI
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
No.

**If relevant, did you update the documentation?**
No.

**Summary**

[Related documentation](https://github.com/styfle/cancel-workflow-action#advanced-canceling-other-workflows)

This is a GitHub Action that will cancel any previous runs that are not completed for a given workflow. When we push a commit to PR the previous workflow keeps running and we have to make cancel them manually to make room for the latest workflow. This workflow takes care of this automatically.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
No