### PR TITLE
fix: multi compiler progress output

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "ts-loader": "^9.3.1",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.4",
-    "webpack": "^5.72.0",
+    "webpack": "^5.86.0",
     "webpack-bundle-analyzer": "^4.5.0",
     "webpack-dev-server": "^4.8.1"
   }

--- a/packages/webpack-cli/src/plugins/cli-plugin.ts
+++ b/packages/webpack-cli/src/plugins/cli-plugin.ts
@@ -1,4 +1,4 @@
-import { type Compiler } from "webpack";
+import { type Compiler, ProgressPlugin } from "webpack";
 import { type CLIPluginOptions } from "../types";
 
 export class CLIPlugin {
@@ -19,6 +19,54 @@ export class CLIPlugin {
     if (!bundleAnalyzerPlugin) {
       new BundleAnalyzerPlugin().apply(compiler);
     }
+  }
+
+  static #progressStates: [number, ...string[]][] = [];
+
+  setupProgressPlugin(compiler: Compiler) {
+    const { ProgressPlugin } = compiler.webpack || require("webpack");
+    const progressPlugin = Boolean(
+      compiler.options.plugins.find((plugin) => plugin instanceof ProgressPlugin),
+    );
+
+    if (progressPlugin) {
+      return;
+    }
+
+    const isProfile = this.options.progress === "profile";
+
+    const options: ConstructorParameters<typeof ProgressPlugin>[0] = {
+      profile: isProfile,
+    };
+
+    if (this.options.isMultiCompiler) {
+      // @ts-expect-error TODO
+      const handler = ProgressPlugin.createDefaultHandler(
+        isProfile,
+        compiler.getInfrastructureLogger("webpack.Progress"),
+      );
+      const idx = CLIPlugin.#progressStates.length;
+
+      CLIPlugin.#progressStates[idx] = [0];
+
+      options.handler = (p: number, msg: string, ...args: string[]) => {
+        CLIPlugin.#progressStates[idx] = [p, msg, ...args];
+
+        let sum = 0;
+
+        for (const [p] of CLIPlugin.#progressStates) {
+          sum += p;
+        }
+
+        handler(
+          sum / CLIPlugin.#progressStates.length,
+          `[${compiler.name ? compiler.name : idx}] ${msg}`,
+          ...args,
+        );
+      };
+    }
+
+    new ProgressPlugin(options).apply(compiler);
   }
 
   setupHelpfulOutput(compiler: Compiler) {
@@ -91,6 +139,10 @@ export class CLIPlugin {
 
   apply(compiler: Compiler) {
     this.logger = compiler.getInfrastructureLogger("webpack-cli");
+
+    if (this.options.progress) {
+      this.setupProgressPlugin(compiler);
+    }
 
     if (this.options.analyze) {
       this.setupBundleAnalyzerPlugin(compiler);

--- a/packages/webpack-cli/src/plugins/cli-plugin.ts
+++ b/packages/webpack-cli/src/plugins/cli-plugin.ts
@@ -21,19 +21,6 @@ export class CLIPlugin {
     }
   }
 
-  setupProgressPlugin(compiler: Compiler) {
-    const { ProgressPlugin } = compiler.webpack || require("webpack");
-    const progressPlugin = Boolean(
-      compiler.options.plugins.find((plugin) => plugin instanceof ProgressPlugin),
-    );
-
-    if (!progressPlugin) {
-      new ProgressPlugin({
-        profile: this.options.progress === "profile",
-      }).apply(compiler);
-    }
-  }
-
   setupHelpfulOutput(compiler: Compiler) {
     const pluginName = "webpack-cli";
     const getCompilationName = () => (compiler.name ? `'${compiler.name}'` : "");
@@ -104,10 +91,6 @@ export class CLIPlugin {
 
   apply(compiler: Compiler) {
     this.logger = compiler.getInfrastructureLogger("webpack-cli");
-
-    if (this.options.progress) {
-      this.setupProgressPlugin(compiler);
-    }
 
     if (this.options.analyze) {
       this.setupBundleAnalyzerPlugin(compiler);

--- a/packages/webpack-cli/src/plugins/cli-plugin.ts
+++ b/packages/webpack-cli/src/plugins/cli-plugin.ts
@@ -39,8 +39,10 @@ export class CLIPlugin {
       profile: isProfile,
     };
 
-    if (this.options.isMultiCompiler) {
-      // @ts-expect-error TODO
+    // TODO remove `ProgressPlugin.createDefaultHandler` when webpack v5 is dropped
+    // @ts-expect-error Fix me after release
+    if (this.options.isMultiCompiler && ProgressPlugin.createDefaultHandler) {
+      // @ts-expect-error Fix me after release
       const handler = ProgressPlugin.createDefaultHandler(
         isProfile,
         compiler.getInfrastructureLogger("webpack.Progress"),

--- a/packages/webpack-cli/src/types.ts
+++ b/packages/webpack-cli/src/types.ts
@@ -239,9 +239,11 @@ interface BasicPackageJsonContent {
  */
 
 interface CLIPluginOptions {
+  isMultiCompiler?: boolean;
   configPath?: string[];
   helpfulOutput: boolean;
   hot?: boolean | "only";
+  progress?: boolean | "profile";
   prefetch?: string;
   analyze?: boolean;
 }
@@ -320,7 +322,6 @@ export {
   WebpackRunOptions,
   WebpackCompiler,
   WebpackConfiguration,
-  WebpackPluginInstance,
   Argv,
   Argument,
   BasicPrimitive,

--- a/packages/webpack-cli/src/types.ts
+++ b/packages/webpack-cli/src/types.ts
@@ -11,6 +11,7 @@ import type {
   Argument,
   AssetEmittedInfo,
   FileCacheOptions,
+  WebpackPluginInstance,
 } from "webpack";
 import type webpack from "webpack";
 
@@ -210,6 +211,7 @@ type ProcessedArguments = Record<string, BasicPrimitive | RegExp | (BasicPrimiti
 type CommandAction = Parameters<WebpackCLICommand["action"]>[0];
 
 interface WebpackRunOptions extends WebpackOptionsNormalized {
+  progress?: boolean | "profile";
   json?: boolean;
   argv?: Argv;
   env: Env;
@@ -240,7 +242,6 @@ interface CLIPluginOptions {
   configPath?: string[];
   helpfulOutput: boolean;
   hot?: boolean | "only";
-  progress?: boolean | "profile";
   prefetch?: string;
   analyze?: boolean;
 }
@@ -319,6 +320,7 @@ export {
   WebpackRunOptions,
   WebpackCompiler,
   WebpackConfiguration,
+  WebpackPluginInstance,
   Argv,
   Argument,
   BasicPrimitive,

--- a/packages/webpack-cli/src/webpack-cli.ts
+++ b/packages/webpack-cli/src/webpack-cli.ts
@@ -17,6 +17,7 @@ import type {
   WebpackRunOptions,
   WebpackCompiler,
   WebpackConfiguration,
+  WebpackPluginInstance,
   Argv,
   BasicPrimitive,
   CallableOption,
@@ -2346,7 +2347,6 @@ class WebpackCLI implements IWebpackCLI {
         new CLIPlugin({
           configPath: config.path.get(item),
           helpfulOutput: !options.json,
-          progress: options.progress,
           analyze: options.analyze,
         }),
       );
@@ -2464,7 +2464,7 @@ class WebpackCLI implements IWebpackCLI {
           process.exit(2);
         };
 
-        if (options.json === true) {
+        if (options.json) {
           createJsonStringifyStream(stats.toJson(statsOptions as StatsOptions))
             .on("error", handleWriteError)
             .pipe(process.stdout)
@@ -2509,6 +2509,32 @@ class WebpackCLI implements IWebpackCLI {
 
     if (!compiler) {
       return;
+    }
+
+    if (options.progress) {
+      const isMultiCompiler = this.isMultipleCompiler(compiler);
+      const firstCompiler = isMultiCompiler ? (compiler as MultiCompiler).compilers[0] : compiler;
+      const { ProgressPlugin } = (firstCompiler as Compiler).webpack || require("webpack");
+
+      const progressPlugin = isMultiCompiler
+        ? Boolean(
+            (compiler as MultiCompiler).compilers.find((compiler: Compiler) =>
+              compiler.options.plugins.find(
+                (plugin: WebpackPluginInstance) => plugin instanceof ProgressPlugin,
+              ),
+            ),
+          )
+        : Boolean(
+            (compiler as Compiler).options.plugins.find(
+              (plugin: WebpackPluginInstance) => plugin instanceof ProgressPlugin,
+            ),
+          );
+
+      if (!progressPlugin) {
+        new ProgressPlugin({
+          profile: options.progress === "profile",
+        }).apply(compiler);
+      }
     }
 
     const isWatch = (compiler: WebpackCompiler): boolean =>

--- a/packages/webpack-cli/src/webpack-cli.ts
+++ b/packages/webpack-cli/src/webpack-cli.ts
@@ -17,7 +17,6 @@ import type {
   WebpackRunOptions,
   WebpackCompiler,
   WebpackConfiguration,
-  WebpackPluginInstance,
   Argv,
   BasicPrimitive,
   CallableOption,
@@ -2347,7 +2346,9 @@ class WebpackCLI implements IWebpackCLI {
         new CLIPlugin({
           configPath: config.path.get(item),
           helpfulOutput: !options.json,
+          progress: options.progress,
           analyze: options.analyze,
+          isMultiCompiler: Array.isArray(config.options),
         }),
       );
     };
@@ -2509,32 +2510,6 @@ class WebpackCLI implements IWebpackCLI {
 
     if (!compiler) {
       return;
-    }
-
-    if (options.progress) {
-      const isMultiCompiler = this.isMultipleCompiler(compiler);
-      const firstCompiler = isMultiCompiler ? (compiler as MultiCompiler).compilers[0] : compiler;
-      const { ProgressPlugin } = (firstCompiler as Compiler).webpack || require("webpack");
-
-      const progressPlugin = isMultiCompiler
-        ? Boolean(
-            (compiler as MultiCompiler).compilers.find((compiler: Compiler) =>
-              compiler.options.plugins.find(
-                (plugin: WebpackPluginInstance) => plugin instanceof ProgressPlugin,
-              ),
-            ),
-          )
-        : Boolean(
-            (compiler as Compiler).options.plugins.find(
-              (plugin: WebpackPluginInstance) => plugin instanceof ProgressPlugin,
-            ),
-          );
-
-      if (!progressPlugin) {
-        new ProgressPlugin({
-          profile: options.progress === "profile",
-        }).apply(compiler);
-      }
     }
 
     const isWatch = (compiler: WebpackCompiler): boolean =>

--- a/packages/webpack-cli/src/webpack-cli.ts
+++ b/packages/webpack-cli/src/webpack-cli.ts
@@ -2465,7 +2465,7 @@ class WebpackCLI implements IWebpackCLI {
           process.exit(2);
         };
 
-        if (options.json) {
+        if (options.json === true) {
           createJsonStringifyStream(stats.toJson(statsOptions as StatsOptions))
             .on("error", handleWriteError)
             .pipe(process.stdout)

--- a/yarn.lock
+++ b/yarn.lock
@@ -11129,10 +11129,10 @@ webpack-sources@^3.2.3:
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.3.tgz#2d4daab8451fd4b240cc27055ff6a0c2ccea0cde"
   integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==
 
-webpack@^5.72.0:
-  version "5.85.0"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.85.0.tgz#c14a6a3a91f84d67c450225661fda8da36bc7f49"
-  integrity sha512-7gazTiYqwo5OSqwH1tigLDL2r3qDeP2dOKYgd+LlXpsUMqDTklg6tOghexqky0/+6QY38kb/R/uRPUleuL43zg==
+webpack@^5.86.0:
+  version "5.86.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.86.0.tgz#b0eb81794b62aee0b7e7eb8c5073495217d9fc6d"
+  integrity sha512-3BOvworZ8SO/D4GVP+GoRC3fVeg5MO4vzmq8TJJEkdmopxyazGDxN8ClqN12uzrZW9Tv8EED8v5VSb6Sqyi0pg==
   dependencies:
     "@types/eslint-scope" "^3.7.3"
     "@types/estree" "^1.0.0"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

bug fix

**Did you add tests for your changes?**

No, but we need after we will fix a problem in webpack

**If relevant, did you update the documentation?**

No need

**Summary**

fixes https://github.com/webpack/webpack-cli/issues/3604

**Does this PR introduce a breaking change?**

No

**Other information**

There is a bug inside webpack:
```
TypeError: Cannot read properties of undefined (reading 'then')
    at /home/akait/IdeaProjects/webpack-cli/node_modules/webpack/lib/ProgressPlugin.js:358:27
    at Hook.eval [as callAsync] (eval at create (/home/akait/IdeaProjects/webpack-cli/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:8:17)
    at Hook.CALL_ASYNC_DELEGATE [as _callAsync] (/home/akait/IdeaProjects/webpack-cli/node_modules/tapable/lib/Hook.js:18:14)
    at /home/akait/IdeaProjects/webpack-cli/node_modules/webpack/lib/Compiler.js:1192:33
    at finalCallback (/home/akait/IdeaProjects/webpack-cli/node_modules/webpack/lib/Compilation.js:2787:11)
    at /home/akait/IdeaProjects/webpack-cli/node_modules/webpack/lib/Compilation.js:3092:11
    at Hook.eval [as callAsync] (eval at create (/home/akait/IdeaProjects/webpack-cli/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:6:1)
    at Hook.CALL_ASYNC_DELEGATE [as _callAsync] (/home/akait/IdeaProjects/webpack-cli/node_modules/tapable/lib/Hook.js:18:14)
    at /home/akait/IdeaProjects/webpack-cli/node_modules/webpack/lib/Compilation.js:3085:38
    at eval (eval at create (/home/akait/IdeaProjects/webpack-cli/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:17:1)

Node.js v18.12.0
```

looks like cache was not design for multi compiler mode, we need to fix it