### PR TITLE
perf: simplify logic, reduce extra loops and perf

### DIFF
--- a/packages/serve/src/index.ts
+++ b/packages/serve/src/index.ts
@@ -193,7 +193,7 @@ class ServeCommand {
             for (const path in problemsByPath) {
               const problems = problemsByPath[path];
 
-              problems.forEach((problem: Problem) => {
+              for (const problem of problems) {
                 cli.logger.error(
                   `${cli.capitalizeFirstLetter(problem.type.replace(/-/g, " "))}${
                     problem.value ? ` '${problem.value}'` : ""
@@ -205,7 +205,7 @@ class ServeCommand {
                 if (problem.expected) {
                   cli.logger.error(`Expected: '${problem.expected}'`);
                 }
-              });
+              }
             }
 
             process.exit(2);

--- a/packages/webpack-cli/src/types.ts
+++ b/packages/webpack-cli/src/types.ts
@@ -7,8 +7,6 @@ import webpack, {
   WebpackOptionsNormalized,
   Compiler,
   MultiCompiler,
-  Problem,
-  Argument,
   AssetEmittedInfo,
   FileCacheOptions,
 } from "webpack";
@@ -187,10 +185,7 @@ type Callback<T extends unknown[]> = (...args: T) => void;
 /**
  * Webpack
  */
-type WebpackConfiguration = Configuration & {
-  // TODO add extends to webpack types
-  extends?: string | string[];
-};
+type WebpackConfiguration = Configuration;
 type ConfigOptions = PotentialPromise<WebpackConfiguration | CallableOption>;
 type CallableOption = (env: Env | undefined, argv: Argv) => WebpackConfiguration;
 type WebpackCompiler = Compiler | MultiCompiler;
@@ -207,9 +202,6 @@ type FileSystemCacheOptions = WebpackConfiguration & {
   cache: FileCacheOptions & { defaultConfig: string[] };
 };
 
-type ProcessedArguments = Record<string, BasicPrimitive | RegExp | (BasicPrimitive | RegExp)[]>;
-
-type MultipleCompilerStatsOptions = StatsOptions & { children: StatsOptions[] };
 type CommandAction = Parameters<WebpackCLICommand["action"]>[0];
 
 interface WebpackRunOptions extends WebpackOptionsNormalized {
@@ -322,7 +314,6 @@ export {
   WebpackCompiler,
   WebpackConfiguration,
   Argv,
-  Argument,
   BasicPrimitive,
   BasicPackageJsonContent,
   CallableOption,
@@ -339,13 +330,10 @@ export {
   Instantiable,
   JsonExt,
   ModuleName,
-  MultipleCompilerStatsOptions,
   PackageInstallOptions,
   PackageManager,
   Path,
-  ProcessedArguments,
   PromptOptions,
-  Problem,
   PotentialPromise,
   Rechoir,
   RechoirError,

--- a/packages/webpack-cli/src/types.ts
+++ b/packages/webpack-cli/src/types.ts
@@ -7,6 +7,8 @@ import webpack, {
   WebpackOptionsNormalized,
   Compiler,
   MultiCompiler,
+  Problem,
+  Argument,
   AssetEmittedInfo,
   FileCacheOptions,
 } from "webpack";
@@ -202,6 +204,8 @@ type FileSystemCacheOptions = WebpackConfiguration & {
   cache: FileCacheOptions & { defaultConfig: string[] };
 };
 
+type ProcessedArguments = Record<string, BasicPrimitive | RegExp | (BasicPrimitive | RegExp)[]>;
+
 type CommandAction = Parameters<WebpackCLICommand["action"]>[0];
 
 interface WebpackRunOptions extends WebpackOptionsNormalized {
@@ -314,6 +318,7 @@ export {
   WebpackCompiler,
   WebpackConfiguration,
   Argv,
+  Argument,
   BasicPrimitive,
   BasicPackageJsonContent,
   CallableOption,
@@ -333,7 +338,9 @@ export {
   PackageInstallOptions,
   PackageManager,
   Path,
+  ProcessedArguments,
   PromptOptions,
+  Problem,
   PotentialPromise,
   Rechoir,
   RechoirError,

--- a/packages/webpack-cli/src/types.ts
+++ b/packages/webpack-cli/src/types.ts
@@ -100,7 +100,6 @@ interface WebpackCLIConfig {
 interface WebpackCLICommand extends Command {
   pkg: string | undefined;
   forHelp: boolean | undefined;
-  options: WebpackCLICommandOption[];
   _args: WebpackCLICommandOption[];
 }
 

--- a/packages/webpack-cli/src/webpack-cli.ts
+++ b/packages/webpack-cli/src/webpack-cli.ts
@@ -34,13 +34,10 @@ import {
   PackageInstallOptions,
   PackageManager,
   Path,
-  ProcessedArguments,
   PromptOptions,
   PotentialPromise,
   Rechoir,
   RechoirError,
-  Argument,
-  Problem,
 } from "./types";
 
 import webpackMerge from "webpack-merge";
@@ -2122,67 +2119,6 @@ class WebpackCLI implements IWebpackCLI {
 
         if (options.argv.env["WEBPACK_SERVE"]) {
           item.watch = false;
-        }
-      }
-
-      // Apply options
-      const args: Record<string, Argument> = this.getBuiltInOptions()
-        .filter((flag) => flag.group === "core")
-        .reduce((accumulator: Record<string, Argument>, flag) => {
-          accumulator[flag.name] = flag as unknown as Argument;
-          return accumulator;
-        }, {});
-
-      const values: ProcessedArguments = Object.keys(options).reduce(
-        (accumulator: ProcessedArguments, name) => {
-          if (name === "argv") {
-            return accumulator;
-          }
-
-          const kebabName = this.toKebabCase(name);
-
-          if (args[kebabName]) {
-            accumulator[kebabName] = options[name as keyof typeof options as string];
-          }
-
-          return accumulator;
-        },
-        {},
-      );
-
-      if (Object.keys(values).length > 0) {
-        const problems: Problem[] | null = this.webpack.cli.processArguments(args, item, values);
-
-        if (problems) {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const groupBy = (xs: Record<string, any>[], key: string) => {
-            return xs.reduce((rv, x) => {
-              (rv[x[key]] = rv[x[key]] || []).push(x);
-
-              return rv;
-            }, {});
-          };
-          const problemsByPath = groupBy(problems, "path");
-
-          for (const path in problemsByPath) {
-            const problems = problemsByPath[path];
-
-            problems.forEach((problem: Problem) => {
-              this.logger.error(
-                `${this.capitalizeFirstLetter(problem.type.replace(/-/g, " "))}${
-                  problem.value ? ` '${problem.value}'` : ""
-                } for the '--${problem.argument}' option${
-                  problem.index ? ` by index '${problem.index}'` : ""
-                }`,
-              );
-
-              if (problem.expected) {
-                this.logger.error(`Expected: '${problem.expected}'`);
-              }
-            });
-          }
-
-          process.exit(2);
         }
       }
 

--- a/packages/webpack-cli/src/webpack-cli.ts
+++ b/packages/webpack-cli/src/webpack-cli.ts
@@ -2126,12 +2126,15 @@ class WebpackCLI implements IWebpackCLI {
       }
 
       // Apply options
-      const args: Record<string, Argument> = this.getBuiltInOptions()
-        .filter((flag) => flag.group === "core")
-        .reduce((accumulator: Record<string, Argument>, flag) => {
-          accumulator[flag.name] = flag as unknown as Argument;
+      const args: Record<string, Argument> = this.getBuiltInOptions().reduce(
+        (accumulator: Record<string, Argument>, flag) => {
+          if (flag.group === "core") {
+            accumulator[flag.name] = flag as unknown as Argument;
+          }
           return accumulator;
-        }, {});
+        },
+        {},
+      );
       const values: ProcessedArguments = Object.keys(options).reduce(
         (accumulator: ProcessedArguments, name) => {
           if (name === "argv") {

--- a/packages/webpack-cli/src/webpack-cli.ts
+++ b/packages/webpack-cli/src/webpack-cli.ts
@@ -50,6 +50,7 @@ import { stringifyStream } from "@discoveryjs/json-ext";
 import { Help, ParseOptions } from "commander";
 
 import { CLIPlugin as CLIPluginClass } from "./plugins/cli-plugin";
+import levenshtein from "fastest-levenshtein";
 
 const fs = require("fs");
 const path = require("path");
@@ -562,9 +563,9 @@ class WebpackCLI implements IWebpackCLI {
         }
       }
 
-      options.forEach((optionForCommand) => {
-        this.makeOption(command, optionForCommand);
-      });
+      for (const option of options) {
+        this.makeOption(command, option);
+      }
     }
 
     command.action(action);
@@ -586,7 +587,7 @@ class WebpackCLI implements IWebpackCLI {
       let negatedDescription;
       const mainOptionType: WebpackCLIMainOption["type"] = new Set();
 
-      option.configs.forEach((config) => {
+      for (const config of option.configs) {
         switch (config.type) {
           case "reset":
             mainOptionType.add(Boolean);
@@ -637,7 +638,7 @@ class WebpackCLI implements IWebpackCLI {
             return enumTypes;
           }
         }
-      });
+      }
 
       mainOption = {
         flags: option.alias ? `-${option.alias}, --${option.name}` : `--${option.name}`,
@@ -1268,11 +1269,11 @@ class WebpackCLI implements IWebpackCLI {
 
             const levenshtein = require("fastest-levenshtein");
 
-            (command as WebpackCLICommand).options.forEach((option) => {
+            for (const option of (command as WebpackCLICommand).options) {
               if (!option.hidden && levenshtein.distance(name, option.long?.slice(2)) < 3) {
                 this.logger.error(`Did you mean '--${option.name()}'?`);
               }
-            });
+            }
           }
         }
       }
@@ -1744,9 +1745,9 @@ class WebpackCLI implements IWebpackCLI {
           if ((error as RechoirError)?.failures) {
             this.logger.error(`Unable load '${configPath}'`);
             this.logger.error((error as RechoirError).message);
-            (error as RechoirError).failures.forEach((failure) => {
+            for (const failure of (error as RechoirError).failures) {
               this.logger.error(failure.error.message);
-            });
+            }
             this.logger.error("Please install one of them");
             process.exit(2);
           }
@@ -1854,18 +1855,18 @@ class WebpackCLI implements IWebpackCLI {
           }
 
           if (isArray) {
-            (loadedConfig.options as ConfigOptions[]).forEach((item) => {
+            for (const item of loadedConfig.options as ConfigOptions[]) {
               (config.options as ConfigOptions[]).push(item);
-            });
+            }
           } else {
             config.options.push(loadedConfig.options as WebpackConfiguration);
           }
         }
 
         if (isArray) {
-          (loadedConfig.options as ConfigOptions[]).forEach((options) => {
+          for (const options of loadedConfig.options as ConfigOptions[]) {
             config.path.set(options, [loadedConfig.path]);
-          });
+          }
         } else {
           config.path.set(loadedConfig.options, [loadedConfig.path]);
         }
@@ -1905,9 +1906,9 @@ class WebpackCLI implements IWebpackCLI {
         config.options = loadedConfig.options as WebpackConfiguration[];
 
         if (Array.isArray(config.options)) {
-          config.options.forEach((item) => {
+          for (const item of config.options) {
             config.path.set(item, [loadedConfig.path]);
-          });
+          }
         } else {
           config.path.set(loadedConfig.options, [loadedConfig.path]);
         }
@@ -2149,7 +2150,7 @@ class WebpackCLI implements IWebpackCLI {
           for (const path in problemsByPath) {
             const problems = problemsByPath[path];
 
-            problems.forEach((problem: Problem) => {
+            for (const problem of problems) {
               this.logger.error(
                 `${this.capitalizeFirstLetter(problem.type.replace(/-/g, " "))}${
                   problem.value ? ` '${problem.value}'` : ""
@@ -2161,7 +2162,7 @@ class WebpackCLI implements IWebpackCLI {
               if (problem.expected) {
                 this.logger.error(`Expected: '${problem.expected}'`);
               }
-            });
+            }
           }
 
           process.exit(2);
@@ -2208,13 +2209,13 @@ class WebpackCLI implements IWebpackCLI {
           }
 
           if (Array.isArray(configPath)) {
-            configPath.forEach((oneOfConfigPath) => {
+            for (const oneOfConfigPath of configPath) {
               (
                 item.cache.buildDependencies as NonNullable<
                   FileSystemCacheOptions["cache"]["buildDependencies"]
                 >
               ).defaultConfig.push(oneOfConfigPath);
-            });
+            }
           } else {
             item.cache.buildDependencies.defaultConfig.push(configPath);
           }

--- a/packages/webpack-cli/src/webpack-cli.ts
+++ b/packages/webpack-cli/src/webpack-cli.ts
@@ -34,10 +34,13 @@ import {
   PackageInstallOptions,
   PackageManager,
   Path,
+  ProcessedArguments,
   PromptOptions,
   PotentialPromise,
   Rechoir,
   RechoirError,
+  Argument,
+  Problem,
 } from "./types";
 
 import webpackMerge from "webpack-merge";
@@ -2119,6 +2122,66 @@ class WebpackCLI implements IWebpackCLI {
 
         if (options.argv.env["WEBPACK_SERVE"]) {
           item.watch = false;
+        }
+      }
+
+      // Apply options
+      const args: Record<string, Argument> = this.getBuiltInOptions()
+        .filter((flag) => flag.group === "core")
+        .reduce((accumulator: Record<string, Argument>, flag) => {
+          accumulator[flag.name] = flag as unknown as Argument;
+          return accumulator;
+        }, {});
+      const values: ProcessedArguments = Object.keys(options).reduce(
+        (accumulator: ProcessedArguments, name) => {
+          if (name === "argv") {
+            return accumulator;
+          }
+
+          const kebabName = this.toKebabCase(name);
+
+          if (args[kebabName]) {
+            accumulator[kebabName] = options[name as keyof typeof options as string];
+          }
+
+          return accumulator;
+        },
+        {},
+      );
+
+      if (Object.keys(values).length > 0) {
+        const problems: Problem[] | null = this.webpack.cli.processArguments(args, item, values);
+
+        if (problems) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const groupBy = (xs: Record<string, any>[], key: string) => {
+            return xs.reduce((rv, x) => {
+              (rv[x[key]] = rv[x[key]] || []).push(x);
+
+              return rv;
+            }, {});
+          };
+          const problemsByPath = groupBy(problems, "path");
+
+          for (const path in problemsByPath) {
+            const problems = problemsByPath[path];
+
+            problems.forEach((problem: Problem) => {
+              this.logger.error(
+                `${this.capitalizeFirstLetter(problem.type.replace(/-/g, " "))}${
+                  problem.value ? ` '${problem.value}'` : ""
+                } for the '--${problem.argument}' option${
+                  problem.index ? ` by index '${problem.index}'` : ""
+                }`,
+              );
+
+              if (problem.expected) {
+                this.logger.error(`Expected: '${problem.expected}'`);
+              }
+            });
+          }
+
+          process.exit(2);
         }
       }
 

--- a/packages/webpack-cli/src/webpack-cli.ts
+++ b/packages/webpack-cli/src/webpack-cli.ts
@@ -50,7 +50,6 @@ import { stringifyStream } from "@discoveryjs/json-ext";
 import { Help, ParseOptions } from "commander";
 
 import { CLIPlugin as CLIPluginClass } from "./plugins/cli-plugin";
-import interpret from "interpret";
 import * as console from "console";
 
 const fs = require("fs");
@@ -612,7 +611,7 @@ class WebpackCLI implements IWebpackCLI {
           case "enum": {
             let hasFalseEnum = false;
 
-            const enumTypes = (config.values || []).map((value) => {
+            for (const value of config.values || []) {
               switch (typeof value) {
                 case "string":
                   mainOptionType.add(String);
@@ -629,14 +628,12 @@ class WebpackCLI implements IWebpackCLI {
                   mainOptionType.add(Boolean);
                   break;
               }
-            });
+            }
 
             if (!needNegativeOption) {
               needNegativeOption = hasFalseEnum;
               negatedDescription = config.negatedDescription;
             }
-
-            return enumTypes;
           }
         }
       }

--- a/packages/webpack-cli/src/webpack-cli.ts
+++ b/packages/webpack-cli/src/webpack-cli.ts
@@ -50,7 +50,6 @@ import { stringifyStream } from "@discoveryjs/json-ext";
 import { Help, ParseOptions } from "commander";
 
 import { CLIPlugin as CLIPluginClass } from "./plugins/cli-plugin";
-import * as console from "console";
 
 const fs = require("fs");
 const path = require("path");

--- a/packages/webpack-cli/src/webpack-cli.ts
+++ b/packages/webpack-cli/src/webpack-cli.ts
@@ -2061,21 +2061,6 @@ class WebpackCLI implements IWebpackCLI {
     config: WebpackCLIConfig,
     options: Partial<WebpackDevServerOptions>,
   ): Promise<WebpackCLIConfig> {
-    const runFunctionOnEachConfig = (
-      options: ConfigOptions | ConfigOptions[],
-      fn: CallableFunction,
-    ) => {
-      if (Array.isArray(options)) {
-        for (let item of options) {
-          item = fn(item);
-        }
-      } else {
-        options = fn(options);
-      }
-
-      return options;
-    };
-
     if (options.analyze) {
       if (!this.checkPackageExists("webpack-bundle-analyzer")) {
         await this.doInstall("webpack-bundle-analyzer", {
@@ -2271,11 +2256,15 @@ class WebpackCLI implements IWebpackCLI {
           analyze: options.analyze,
         }),
       );
-
-      return options;
     };
 
-    runFunctionOnEachConfig(config.options, internalBuildConfig);
+    if (Array.isArray(config.options)) {
+      for (const item of config.options) {
+        internalBuildConfig(item);
+      }
+    } else {
+      internalBuildConfig(config.options);
+    }
 
     return config;
   }

--- a/packages/webpack-cli/src/webpack-cli.ts
+++ b/packages/webpack-cli/src/webpack-cli.ts
@@ -2096,7 +2096,7 @@ class WebpackCLI implements IWebpackCLI {
     >("./plugins/cli-plugin");
 
     const internalBuildConfig = (item: WebpackConfiguration) => {
-      const isWatchOption = item.watch || (options.argv || {}).watch;
+      const isWatchOption = item.watch;
 
       // Apply options
       const args: Record<string, Argument> = this.getBuiltInOptions().reduce(

--- a/packages/webpack-cli/src/webpack-cli.ts
+++ b/packages/webpack-cli/src/webpack-cli.ts
@@ -2150,38 +2150,40 @@ class WebpackCLI implements IWebpackCLI {
         {},
       );
 
-      const problems: Problem[] | null = this.webpack.cli.processArguments(args, item, values);
+      if (Object.keys(values).length > 0) {
+        const problems: Problem[] | null = this.webpack.cli.processArguments(args, item, values);
 
-      if (problems) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const groupBy = (xs: Record<string, any>[], key: string) => {
-          return xs.reduce((rv, x) => {
-            (rv[x[key]] = rv[x[key]] || []).push(x);
+        if (problems) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const groupBy = (xs: Record<string, any>[], key: string) => {
+            return xs.reduce((rv, x) => {
+              (rv[x[key]] = rv[x[key]] || []).push(x);
 
-            return rv;
-          }, {});
-        };
-        const problemsByPath = groupBy(problems, "path");
+              return rv;
+            }, {});
+          };
+          const problemsByPath = groupBy(problems, "path");
 
-        for (const path in problemsByPath) {
-          const problems = problemsByPath[path];
+          for (const path in problemsByPath) {
+            const problems = problemsByPath[path];
 
-          problems.forEach((problem: Problem) => {
-            this.logger.error(
-              `${this.capitalizeFirstLetter(problem.type.replace(/-/g, " "))}${
-                problem.value ? ` '${problem.value}'` : ""
-              } for the '--${problem.argument}' option${
-                problem.index ? ` by index '${problem.index}'` : ""
-              }`,
-            );
+            problems.forEach((problem: Problem) => {
+              this.logger.error(
+                `${this.capitalizeFirstLetter(problem.type.replace(/-/g, " "))}${
+                  problem.value ? ` '${problem.value}'` : ""
+                } for the '--${problem.argument}' option${
+                  problem.index ? ` by index '${problem.index}'` : ""
+                }`,
+              );
 
-            if (problem.expected) {
-              this.logger.error(`Expected: '${problem.expected}'`);
-            }
-          });
+              if (problem.expected) {
+                this.logger.error(`Expected: '${problem.expected}'`);
+              }
+            });
+          }
+
+          process.exit(2);
         }
-
-        process.exit(2);
       }
 
       const isFileSystemCacheOptions = (

--- a/packages/webpack-cli/src/webpack-cli.ts
+++ b/packages/webpack-cli/src/webpack-cli.ts
@@ -2096,7 +2096,7 @@ class WebpackCLI implements IWebpackCLI {
     >("./plugins/cli-plugin");
 
     const internalBuildConfig = (item: WebpackConfiguration) => {
-      const isWatchOption = item.watch;
+      const originalWatchValue = item.watch;
 
       // Apply options
       const args: Record<string, Argument> = this.getBuiltInOptions().reduce(
@@ -2163,7 +2163,8 @@ class WebpackCLI implements IWebpackCLI {
 
       // Output warnings
       if (
-        isWatchOption &&
+        (typeof originalWatchValue !== "undefined" ||
+          (options.argv && typeof options.argv.watch !== "undefined")) &&
         options.argv &&
         options.argv.env &&
         (options.argv.env["WEBPACK_WATCH"] || options.argv.env["WEBPACK_SERVE"])
@@ -2171,7 +2172,7 @@ class WebpackCLI implements IWebpackCLI {
         this.logger.warn(
           `No need to use the '${
             options.argv.env["WEBPACK_WATCH"] ? "watch" : "serve"
-          }' command together with '{ watch: true }' or '--watch' configuration, it does not make sense.`,
+          }' command together with '{ watch: true | false }' or '--watch'/'--no-watch' configuration, it does not make sense.`,
         );
 
         if (options.argv.env["WEBPACK_SERVE"]) {

--- a/packages/webpack-cli/src/webpack-cli.ts
+++ b/packages/webpack-cli/src/webpack-cli.ts
@@ -50,7 +50,6 @@ import { stringifyStream } from "@discoveryjs/json-ext";
 import { Help, ParseOptions } from "commander";
 
 import { CLIPlugin as CLIPluginClass } from "./plugins/cli-plugin";
-import levenshtein from "fastest-levenshtein";
 
 const fs = require("fs");
 const path = require("path");
@@ -1828,7 +1827,6 @@ class WebpackCLI implements IWebpackCLI {
       return { options, path: configPath };
     };
 
-    // TODO better name and better type
     const config: WebpackCLIConfig = {
       options: {} as WebpackConfiguration,
       path: new WeakMap(),

--- a/packages/webpack-cli/src/webpack-cli.ts
+++ b/packages/webpack-cli/src/webpack-cli.ts
@@ -1147,9 +1147,7 @@ class WebpackCLI implements IWebpackCLI {
           async () => {
             this.webpack = await this.loadWebpack();
 
-            return isWatchCommandUsed
-              ? this.getBuiltInOptions().filter((option) => option.name !== "watch")
-              : this.getBuiltInOptions();
+            return this.getBuiltInOptions();
           },
           async (entries, options) => {
             if (entries.length > 0) {
@@ -2107,24 +2105,6 @@ class WebpackCLI implements IWebpackCLI {
     >("./plugins/cli-plugin");
 
     const internalBuildConfig = (item: WebpackConfiguration) => {
-      // Output warnings
-      if (
-        item.watch &&
-        options.argv &&
-        options.argv.env &&
-        (options.argv.env["WEBPACK_WATCH"] || options.argv.env["WEBPACK_SERVE"])
-      ) {
-        this.logger.warn(
-          `No need to use the '${
-            options.argv.env["WEBPACK_WATCH"] ? "watch" : "serve"
-          }' command together with '{ watch: true }' configuration, it does not make sense.`,
-        );
-
-        if (options.argv.env["WEBPACK_SERVE"]) {
-          item.watch = false;
-        }
-      }
-
       // Apply options
       const args: Record<string, Argument> = this.getBuiltInOptions().reduce(
         (accumulator: Record<string, Argument>, flag) => {
@@ -2185,6 +2165,24 @@ class WebpackCLI implements IWebpackCLI {
           }
 
           process.exit(2);
+        }
+      }
+
+      // Output warnings
+      if (
+        item.watch &&
+        options.argv &&
+        options.argv.env &&
+        (options.argv.env["WEBPACK_WATCH"] || options.argv.env["WEBPACK_SERVE"])
+      ) {
+        this.logger.warn(
+          `No need to use the '${
+            options.argv.env["WEBPACK_WATCH"] ? "watch" : "serve"
+          }' command together with '{ watch: true }' or '--watch' configuration, it does not make sense.`,
+        );
+
+        if (options.argv.env["WEBPACK_SERVE"]) {
+          item.watch = false;
         }
       }
 

--- a/packages/webpack-cli/src/webpack-cli.ts
+++ b/packages/webpack-cli/src/webpack-cli.ts
@@ -50,6 +50,8 @@ import { stringifyStream } from "@discoveryjs/json-ext";
 import { Help, ParseOptions } from "commander";
 
 import { CLIPlugin as CLIPluginClass } from "./plugins/cli-plugin";
+import interpret from "interpret";
+import * as console from "console";
 
 const fs = require("fs");
 const path = require("path");
@@ -1872,20 +1874,22 @@ class WebpackCLI implements IWebpackCLI {
 
       config.options = config.options.length === 1 ? config.options[0] : config.options;
     } else {
+      // TODO ".mts" is not supported by `interpret`, need to add it
+      // Prioritize popular extensions first to avoid unnecessary fs calls
+      const extensions = [
+        ".js",
+        ".mjs",
+        ".cjs",
+        ".ts",
+        ".cts",
+        ...Object.keys(interpret.extensions),
+      ];
       // Order defines the priority, in decreasing order
       const defaultConfigFiles = [
         "webpack.config",
         ".webpack/webpack.config",
         ".webpack/webpackfile",
-      ]
-        .map((filename) =>
-          // Prioritize popular extensions first to avoid unnecessary fs calls
-          // TODO ".mts" is not supported by `interpret`, need to add it
-          [".js", ".mjs", ".cjs", ".ts", ".cts", ...Object.keys(interpret.extensions)].map((ext) =>
-            path.resolve(filename + ext),
-          ),
-        )
-        .reduce((accumulator, currentValue) => accumulator.concat(currentValue), []);
+      ].flatMap((filename) => extensions.map((ext) => path.resolve(filename + ext)));
 
       let foundDefaultConfigFile;
 

--- a/test/serve/basic/__snapshots__/serve-basic.test.js.snap.devServer4.webpack5
+++ b/test/serve/basic/__snapshots__/serve-basic.test.js.snap.devServer4.webpack5
@@ -79,7 +79,7 @@ exports[`basic serve usage should throw error when same ports in multicompiler: 
 exports[`basic serve usage should throw error when same ports in multicompiler: stdout 1`] = `""`;
 
 exports[`basic serve usage should work and log warning on the \`watch option in a configuration: stderr 1`] = `
-"[webpack-cli] No need to use the 'serve' command together with '{ watch: true }' or '--watch' configuration, it does not make sense.
+"[webpack-cli] No need to use the 'serve' command together with '{ watch: true | false }' or '--watch'/'--no-watch' configuration, it does not make sense.
 <i> [webpack-dev-server] Project is running at:
 <i> [webpack-dev-server] Loopback: http://localhost:<port>/
 <i> [webpack-dev-server] On Your Network (IPv4): http://<network-ip-v4>:<port>/

--- a/test/serve/basic/__snapshots__/serve-basic.test.js.snap.devServer4.webpack5
+++ b/test/serve/basic/__snapshots__/serve-basic.test.js.snap.devServer4.webpack5
@@ -22,7 +22,7 @@ exports[`basic serve usage should log error on using '-w' alias with serve: stde
 exports[`basic serve usage should log error on using '-w' alias with serve: stdout 1`] = `""`;
 
 exports[`basic serve usage should log used supplied config with serve: stderr 1`] = `
-"    [webpack-cli] Compiler starting... 
+"    [webpack-cli] Compiler starting...
     [webpack-cli] Compiler is using config: '<cwd>/test/serve/basic/log.config.js'
 <i> [webpack-dev-server] Project is running at:
 <i> [webpack-dev-server] Loopback: http://localhost:<port>/
@@ -79,7 +79,7 @@ exports[`basic serve usage should throw error when same ports in multicompiler: 
 exports[`basic serve usage should throw error when same ports in multicompiler: stdout 1`] = `""`;
 
 exports[`basic serve usage should work and log warning on the \`watch option in a configuration: stderr 1`] = `
-"[webpack-cli] No need to use the 'serve' command together with '{ watch: true }' configuration, it does not make sense.
+"[webpack-cli] No need to use the 'serve' command together with '{ watch: true }' or '--watch' configuration, it does not make sense.
 <i> [webpack-dev-server] Project is running at:
 <i> [webpack-dev-server] Loopback: http://localhost:<port>/
 <i> [webpack-dev-server] On Your Network (IPv4): http://<network-ip-v4>:<port>/

--- a/test/serve/basic/__snapshots__/serve-basic.test.js.snap.devServer4.webpack5
+++ b/test/serve/basic/__snapshots__/serve-basic.test.js.snap.devServer4.webpack5
@@ -22,7 +22,7 @@ exports[`basic serve usage should log error on using '-w' alias with serve: stde
 exports[`basic serve usage should log error on using '-w' alias with serve: stdout 1`] = `""`;
 
 exports[`basic serve usage should log used supplied config with serve: stderr 1`] = `
-"    [webpack-cli] Compiler starting...
+"    [webpack-cli] Compiler starting... 
     [webpack-cli] Compiler is using config: '<cwd>/test/serve/basic/log.config.js'
 <i> [webpack-dev-server] Project is running at:
 <i> [webpack-dev-server] Loopback: http://localhost:<port>/

--- a/test/watch/bail/bail.test.js
+++ b/test/watch/bail/bail.test.js
@@ -11,22 +11,14 @@ describe('"bail" option', () => {
   });
 
   it('should not log warning without the "bail" option', async () => {
-    const { stderr, stdout } = await runWatch(__dirname, [
-      "-c",
-      "no-bail-webpack.config.js",
-      "--watch",
-    ]);
+    const { stderr, stdout } = await runWatch(__dirname, ["-c", "no-bail-webpack.config.js"]);
 
     expect(stderr).toBeFalsy();
     expect(stdout).toBeTruthy();
   });
 
   it('should not log warning without the "bail" option', async () => {
-    const { stderr, stdout } = await runWatch(__dirname, [
-      "-c",
-      "no-bail-webpack.config.js",
-      "--watch",
-    ]);
+    const { stderr, stdout } = await runWatch(__dirname, ["-c", "no-bail-webpack.config.js"]);
 
     expect(stderr).toBeFalsy();
     expect(stdout).toBeTruthy();

--- a/test/watch/basic/basic.test.js
+++ b/test/watch/basic/basic.test.js
@@ -150,7 +150,51 @@ describe("basic", () => {
       const data = chunk.toString();
 
       expect(data).toContain(
-        "No need to use the 'watch' command together with '{ watch: true }' configuration, it does not make sense.",
+        " No need to use the 'watch' command together with '{ watch: true | false }' or '--watch'/'--no-watch' configuration, it does not make sense.",
+      );
+    });
+  });
+
+  it("should log warning about the `watch` option in the configuration and recompile upon file change using the `watch` command #2", (done) => {
+    const proc = runAndGetProcess(__dirname, [
+      "--watch",
+      "--mode",
+      "development",
+      "--config",
+      "./no-watch.config.js",
+    ]);
+
+    let modified = false;
+
+    proc.stdout.on("data", (chunk) => {
+      const data = chunk.toString();
+
+      if (data.includes("index.js")) {
+        for (const word of wordsInStatsv5) {
+          expect(data).toContain(word);
+        }
+
+        if (!modified) {
+          process.nextTick(() => {
+            writeFileSync(
+              resolve(__dirname, "./src/index.js"),
+              `console.log('watch flag test');\n`,
+            );
+          });
+
+          modified = true;
+        } else {
+          processKill(proc);
+          done();
+        }
+      }
+    });
+
+    proc.stderr.on("data", (chunk) => {
+      const data = chunk.toString();
+
+      expect(data).toContain(
+        "No need to use the 'watch' command together with '{ watch: true | false }' or '--watch'/'--no-watch' configuration, it does not make sense.",
       );
     });
   });
@@ -177,31 +221,79 @@ describe("basic", () => {
     });
   });
 
-  it("should recompile upon file change using the `command` option and the `--watch` option and log warning", async () => {
-    const { exitCode, stderr, stdout } = await run(__dirname, [
-      "watch",
-      "--watch",
-      "--mode",
-      "development",
-    ]);
+  it("should recompile upon file change using the `command` option and the `--watch` option and log warning", (done) => {
+    const proc = runAndGetProcess(__dirname, ["watch", "--watch", "--mode", "development"]);
 
-    expect(exitCode).toBe(2);
-    expect(stderr).toContain("Error: Unknown option '--watch'");
-    expect(stderr).toContain("Run 'webpack --help' to see available commands and options");
-    expect(stdout).toBeFalsy();
+    let modified = false;
+
+    proc.stdout.on("data", (chunk) => {
+      const data = chunk.toString();
+
+      if (data.includes("index.js")) {
+        for (const word of wordsInStatsv5) {
+          expect(data).toContain(word);
+        }
+
+        if (!modified) {
+          process.nextTick(() => {
+            writeFileSync(
+              resolve(__dirname, "./src/index.js"),
+              `console.log('watch flag test');\n`,
+            );
+          });
+
+          modified = true;
+        } else {
+          processKill(proc);
+          done();
+        }
+      }
+    });
+
+    proc.stderr.on("data", (chunk) => {
+      const data = chunk.toString();
+
+      expect(data).toContain(
+        "No need to use the 'watch' command together with '{ watch: true | false }' or '--watch'/'--no-watch' configuration, it does not make sense.",
+      );
+    });
   });
 
-  it("should recompile upon file change using the `command` option and the `--no-watch` option and log warning", async () => {
-    const { exitCode, stderr, stdout } = await run(__dirname, [
-      "watch",
-      "--no-watch",
-      "--mode",
-      "development",
-    ]);
+  it("should recompile upon file change using the `command` option and the `--watch` option and log warning", (done) => {
+    const proc = runAndGetProcess(__dirname, ["watch", "--no-watch", "--mode", "development"]);
 
-    expect(exitCode).toBe(2);
-    expect(stderr).toContain("Error: Unknown option '--no-watch'");
-    expect(stderr).toContain("Run 'webpack --help' to see available commands and options");
-    expect(stdout).toBeFalsy();
+    let modified = false;
+
+    proc.stdout.on("data", (chunk) => {
+      const data = chunk.toString();
+
+      if (data.includes("index.js")) {
+        for (const word of wordsInStatsv5) {
+          expect(data).toContain(word);
+        }
+
+        if (!modified) {
+          process.nextTick(() => {
+            writeFileSync(
+              resolve(__dirname, "./src/index.js"),
+              `console.log('watch flag test');\n`,
+            );
+          });
+
+          modified = true;
+        } else {
+          processKill(proc);
+          done();
+        }
+      }
+    });
+
+    proc.stderr.on("data", (chunk) => {
+      const data = chunk.toString();
+
+      expect(data).toContain(
+        "No need to use the 'watch' command together with '{ watch: true | false }' or '--watch'/'--no-watch' configuration, it does not make sense.",
+      );
+    });
   });
 });

--- a/test/watch/basic/no-watch.config.js
+++ b/test/watch/basic/no-watch.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  watch: false,
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

~~Avoid validation of our arguments from command line, i.e. when you have `webpack --stats invalid`~~

**Did you add tests for your changes?**

Update existing

**If relevant, did you update the documentation?**

No need

**Summary**

~~Webpack **always** validates provided configurations, when we have `webpack --stats invalid`, we just set `stats` to `"invalid"` value and now try to validate it, but I don't see any reasons to spend time on it, because when we pass it to `webpack` it will be validated again, so now we skip a one extra validation~~

We can't do it

**Does this PR introduce a breaking change?**

No

**Other information**

fixes https://github.com/webpack/webpack-cli/pull/2626/