### PR TITLE
.gitattributes updated to ignore `png.tpl` files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 * text eol=lf
+*png.tpl -text


### PR DESCRIPTION
### What kind of change does this PR introduce?

Currently, the `.gitattributes` file canonicalizes line endings for all files since all repository files are text files. So, that's a perfect fit.

With #2862, however, a binary file was added to the repository: `webpack.png.tpl`. On Windows development machines, that file becomes inadvertently altered at checkout time due to `.gitattributes` configuration.

Now, with this pull request, the `.gitattributes` file is amended to exclude that particular file (and similar future `*.png.tpl` files) from line ending canonicalization.

### Did you add tests for your changes?

No. Not necessary as this is a build environment change.

### Does this PR introduce a breaking change?

No.