### PR TITLE
ci: avoid multiple CI runs when pushed to next

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -4,15 +4,10 @@ on:
   push:
     branches:
       - master
-      - next
   pull_request:
     branches:
       - master
       - next
-  workflow_dispatch:
-    inputs:
-      tags:
-        description: "Test description"
 
 permissions:
   contents: read


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
CI
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
No
**If relevant, did you update the documentation?**
No
**Summary**

- Currently, if we push commit to `next` it triggers two CI runs, one for `pull request synchronization` event and one for `push` event to `next` branch

- Removed `workflow_dispatch`, we don't use it.

<img width="1118" alt="Screenshot 2024-10-22 at 10 11 51 AM" src="https://github.com/user-attachments/assets/59c2e4e2-eacb-4501-86b3-e538c1ce7d14">

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
No