### PR TITLE
ci: pin Node.js v23 to 23.5.0

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -58,7 +58,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: [18.x, 20.x, 22.x, 23.x]
+        node-version: [18.x, 20.x, 22.x, 23.5.0]
         shard: ["1/4", "2/4", "3/4", "4/4"]
         webpack-version: [latest]
         dev-server-version: [latest]


### PR DESCRIPTION
[CI is failing on Node.js v23.6.1](https://github.com/webpack/webpack-cli/actions/runs/12941121060/job/36096847885?pr=4380#step:7:76), let's fix that separately. Meanwhile, pin version to unblock PR merges.

<img width="1062" alt="Screenshot 2025-01-24 at 6 53 19 AM" src="https://github.com/user-attachments/assets/a9c142c9-b764-479a-80e0-192653e1f475" />
