### PR TITLE
feat: update-dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,5 @@
     "webpack": "^5.94.0",
     "webpack-bundle-analyzer": "^4.5.0",
     "webpack-dev-server": "^5.1.0"
-  },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -94,5 +94,6 @@
     "webpack": "^5.94.0",
     "webpack-bundle-analyzer": "^4.5.0",
     "webpack-dev-server": "^5.1.0"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/packages/create-webpack-app/package.json
+++ b/packages/create-webpack-app/package.json
@@ -46,7 +46,7 @@
     "@inquirer/select": "^4.0.3",
     "colorette": "^2.0.20",
     "commander": "^12.1.0",
-    "cross-spawn": "^7.0.3",
+    "cross-spawn": "^7.0.6",
     "ejs": "^3.1.10",
     "node-plop": "^0.32.0"
   },

--- a/packages/webpack-cli/package.json
+++ b/packages/webpack-cli/package.json
@@ -40,7 +40,7 @@
     "@webpack-cli/serve": "^3.0.1",
     "colorette": "^2.0.14",
     "commander": "^12.1.0",
-    "cross-spawn": "^7.0.3",
+    "cross-spawn": "^7.0.6",
     "envinfo": "^7.14.0",
     "fastest-levenshtein": "^1.0.12",
     "import-local": "^3.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4298,7 +4298,7 @@ create-require@^1.1.0:
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
-cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
+cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3, cross-spawn@^7.0.6:
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
   integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==


### PR DESCRIPTION
Update cross-pawn to avoid high-severity issue


**What kind of change does this PR introduce?**

Updating cross-spawn version on webpack-cli and create-webpack-app to 7.0.6.

**Summary**

We use trivy to analyze high security dependencies in our projects. Webpack-cli package contains cross-spawn 7.0.3:
<img width="582" alt="Screenshot 2025-02-10 at 12 22 50" src="https://github.com/user-attachments/assets/5631eff1-a13d-4418-be19-02a70b0a406e" />
Specific vulnerability: CVE-2024-21538 (https://avd.aquasec.com/nvd/cve-2024-21538)
