### PR TITLE
fix: #4419 removed plugin-syntax-dynamic-import

### DIFF
--- a/packages/create-webpack-app/templates/init/default/babel.config.json.tpl
+++ b/packages/create-webpack-app/templates/init/default/babel.config.json.tpl
@@ -1,5 +1,4 @@
 {
-  "plugins": ["@babel/syntax-dynamic-import"],
   "presets": [
     [
       "@babel/preset-env",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
Bug fix

**Did you add tests for your changes?**
Yes

**If relevant, did you update the documentation?**
No

**Summary**
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
This PR solves the issue #4419 

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No

**Other information**
[Babel docs for plugin-syntax-dynamic-import mentions this plugin no longer needs to be used for @babel/core 7.8.0 and above](https://babeljs.io/docs/babel-plugin-syntax-DYNAMIC-Import), webpack-cli uses 7.25.2 as of now