### PR TITLE
fix: allow configuration freeze

### DIFF
--- a/packages/webpack-cli/src/webpack-cli.ts
+++ b/packages/webpack-cli/src/webpack-cli.ts
@@ -2237,6 +2237,10 @@ class WebpackCLI implements IWebpackCLI {
       }
 
       // Output warnings
+      if (!Object.isExtensible(item)) {
+        return;
+      }
+
       if (
         options.isWatchingLikeCommand &&
         options.argv &&
@@ -2263,7 +2267,7 @@ class WebpackCLI implements IWebpackCLI {
       };
 
       // Setup default cache options
-      if (isFileSystemCacheOptions(item)) {
+      if (isFileSystemCacheOptions(item) && Object.isExtensible(item.cache)) {
         const configPath = config.path.get(item);
 
         if (configPath) {
@@ -2321,22 +2325,26 @@ class WebpackCLI implements IWebpackCLI {
         colors = Boolean(this.colors.isColorSupported);
       }
 
-      item.stats.colors = colors;
+      if (Object.isExtensible(item.stats)) {
+        item.stats.colors = colors;
+      }
 
       // Apply CLI plugin
       if (!item.plugins) {
         item.plugins = [];
       }
 
-      item.plugins.unshift(
-        new CLIPlugin({
-          configPath: config.path.get(item),
-          helpfulOutput: !options.json,
-          progress: options.progress,
-          analyze: options.analyze,
-          isMultiCompiler: Array.isArray(config.options),
-        }),
-      );
+      if (Object.isExtensible(item.plugins)) {
+        item.plugins.unshift(
+          new CLIPlugin({
+            configPath: config.path.get(item),
+            helpfulOutput: !options.json,
+            progress: options.progress,
+            analyze: options.analyze,
+            isMultiCompiler: Array.isArray(config.options),
+          }),
+        );
+      }
     };
 
     if (Array.isArray(config.options)) {

--- a/test/build/config/object-freeze-partial/index.test.js
+++ b/test/build/config/object-freeze-partial/index.test.js
@@ -1,0 +1,16 @@
+"use strict";
+const { resolve } = require("path");
+const { run } = require("../../../utils/test-utils");
+
+describe("config with partial `Object.freeze({})`", () => {
+  it("should not throw error", async () => {
+    const { exitCode, stderr, stdout } = await run(__dirname, [
+      "-c",
+      resolve(__dirname, "webpack.config.js"),
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toBeFalsy();
+    expect(stdout).toBeTruthy();
+  });
+});

--- a/test/build/config/object-freeze-partial/src/index.js
+++ b/test/build/config/object-freeze-partial/src/index.js
@@ -1,0 +1,1 @@
+console.log("Percy Weasley");

--- a/test/build/config/object-freeze-partial/webpack.config.js
+++ b/test/build/config/object-freeze-partial/webpack.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  cache: Object.freeze({ type: "filesystem" }),
+  stats: Object.freeze({}),
+  plugins: Object.freeze([]),
+};

--- a/test/build/config/object-freeze/index.test.js
+++ b/test/build/config/object-freeze/index.test.js
@@ -1,0 +1,16 @@
+"use strict";
+const { resolve } = require("path");
+const { run } = require("../../../utils/test-utils");
+
+describe("config with `Object.freeze({})`", () => {
+  it("should not throw error", async () => {
+    const { exitCode, stderr, stdout } = await run(__dirname, [
+      "-c",
+      resolve(__dirname, "webpack.config.js"),
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toBeFalsy();
+    expect(stdout).toBeTruthy();
+  });
+});

--- a/test/build/config/object-freeze/src/index.js
+++ b/test/build/config/object-freeze/src/index.js
@@ -1,0 +1,1 @@
+console.log("Percy Weasley");

--- a/test/build/config/object-freeze/webpack.config.js
+++ b/test/build/config/object-freeze/webpack.config.js
@@ -1,0 +1,1 @@
+module.exports = Object.freeze({});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

fixes https://github.com/webpack/webpack-cli/issues/4427

**Did you add tests for your changes?**

Yes

**If relevant, did you update the documentation?**

No need

**Summary**

Allow to use `Object.freeze({})` as a configuration

**Does this PR introduce a breaking change?**

No

**Other information**

There is a small limitation, because we modify some default options in configuration for better DX, using `Object.freeze({})` prevent doing it, theoretically we can clone object, but it is has a bed perf and will don't work for all fields, also if you are using `Object.freeze({})` it means you really don't want to modify something, otherwise just don't use it