### PR TITLE
fix: remove unnecessary vue runtime-dom alias from webpack config

### DIFF
--- a/packages/create-webpack-app/templates/init/vue/webpack.config.js.tpl
+++ b/packages/create-webpack-app/templates/init/vue/webpack.config.js.tpl
@@ -93,8 +93,7 @@ const config = {
     },
     resolve: {
         alias: {
-            "@": path.resolve(__dirname, "./src/"),
-            'vue': '@vue/runtime-dom'
+            "@": path.resolve(__dirname, "./src/")
         },<% if (langType == "Typescript") {%>
         extensions: ['.tsx', '.ts', '.js', '.vue', '.json'],<% } %>
     },

--- a/test/create-webpack-app/init/__snapshots__/init.test.js.snap.webpack5
+++ b/test/create-webpack-app/init/__snapshots__/init.test.js.snap.webpack5
@@ -1144,8 +1144,7 @@ const config = {
     },
     resolve: {
         alias: {
-            "@": path.resolve(__dirname, "./src/"),
-            'vue': '@vue/runtime-dom'
+            "@": path.resolve(__dirname, "./src/")
         },
     },
 };
@@ -1266,8 +1265,7 @@ const config = {
     },
     resolve: {
         alias: {
-            "@": path.resolve(__dirname, "./src/"),
-            'vue': '@vue/runtime-dom'
+            "@": path.resolve(__dirname, "./src/")
         },
     },
 };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

Fix 
- https://github.com/webpack/webpack/issues/19889

**Did you add tests for your changes?**

**If relevant, did you update the documentation?**

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

The `'vue': '@vue/runtime-dom'` alias is no longer necessary in modern Vue setups(I guess)

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
