### PR TITLE
Refactor(cli): Migrate from CJS to ESM 

### DIFF
--- a/.changeset/migrate-cjs-to-esm.md
+++ b/.changeset/migrate-cjs-to-esm.md
@@ -1,0 +1,5 @@
+---
+"webpack-cli": major
+---
+
+Migrate webpack-cli from CommonJS to ES Modules. The package now sets `"type": "module"` and uses native ESM `import`/`export`. The `import-local` dependency has been removed.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -28,7 +28,7 @@ export default defineConfig([
     },
   },
   {
-    files: ["./packages/create-webpack-app/**/*"],
+    files: ["./packages/create-webpack-app/**/*", "./packages/webpack-cli/bin/**/*"],
     extends: [configs["recommended-module"]],
     rules: {
       // We are CLI, so using `console.log` is normal

--- a/package-lock.json
+++ b/package-lock.json
@@ -89,7 +89,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2306,7 +2305,6 @@
       "integrity": "sha512-Tdfx4eH2uS+gv9V9NCr3Rz+c7RSS6ntXp3Blliud18ibRUlRxO9dTaOjG4iv4x0nAmMeedP1ORkEpeXSkh2QiQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20"
       }
@@ -2388,8 +2386,7 @@
       "resolved": "https://registry.npmjs.org/@cspell/dict-css/-/dict-css-4.1.1.tgz",
       "integrity": "sha512-y/Vgo6qY08e1t9OqR56qjoFLBCpi4QfWMf2qzD1l9omRZwvSMQGRPz4x0bxkkkU4oocMAeztjzCsmLew//c/8w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-dart": {
       "version": "2.3.2",
@@ -2529,16 +2526,14 @@
       "resolved": "https://registry.npmjs.org/@cspell/dict-html/-/dict-html-4.0.15.tgz",
       "integrity": "sha512-GJYnYKoD9fmo2OI0aySEGZOjThnx3upSUvV7mmqUu8oG+mGgzqm82P/f7OqsuvTaInZZwZbo+PwJQd/yHcyFIw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-html-symbol-entities": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@cspell/dict-html-symbol-entities/-/dict-html-symbol-entities-4.0.5.tgz",
       "integrity": "sha512-429alTD4cE0FIwpMucvSN35Ld87HCyuM8mF731KU5Rm4Je2SG6hmVx7nkBsLyrmH3sQukTcr1GaiZsiEg8svPA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-java": {
       "version": "5.0.12",
@@ -2736,8 +2731,7 @@
       "resolved": "https://registry.npmjs.org/@cspell/dict-typescript/-/dict-typescript-3.2.3.tgz",
       "integrity": "sha512-zXh1wYsNljQZfWWdSPYwQhpwiuW0KPW1dSd8idjMRvSD0aSvWWHoWlrMsmZeRl4qM4QCEAjua8+cjflm41cQBg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-vue": {
       "version": "3.0.5",
@@ -5346,7 +5340,6 @@
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -5528,7 +5521,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
       "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -5679,7 +5671,6 @@
       "integrity": "sha512-RLkVSiNuUP1C2ROIWfqX+YcUfLaSnxGE/8M+Y57lopVwg9VTYYfhuz15Yf1IzCKgZj6/rIbYTmJCUSqr76r0Wg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
         "@typescript-eslint/scope-manager": "8.58.0",
@@ -5719,7 +5710,6 @@
       "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.0",
         "@typescript-eslint/types": "8.58.0",
@@ -6446,7 +6436,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7336,7 +7325,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -9372,7 +9360,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -9462,7 +9449,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -10618,6 +10604,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
       "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^5.0.0",
@@ -10779,7 +10766,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -11662,6 +11648,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
       "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pkg-dir": "^4.2.0",
@@ -11681,6 +11668,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
       "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "find-up": "^4.0.0"
@@ -12710,7 +12698,6 @@
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -14298,6 +14285,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
       "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^4.1.0"
@@ -16382,6 +16370,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
       "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^2.2.0"
@@ -16394,6 +16383,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-try": "^2.0.0"
@@ -16440,6 +16430,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -16538,6 +16529,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -16784,7 +16776,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -16907,7 +16898,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -17444,6 +17434,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
       "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "resolve-from": "^5.0.0"
@@ -17456,6 +17447,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -17658,7 +17650,6 @@
       "integrity": "sha512-kgW13M54DUB7IsIRM5LvJkNlpH+WhMpooUcaWGFARkF1Tc82v9mIWkCbCYf+MBvpIUBSeSOTilpZjEPr2VYE6Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.1.5",
@@ -17739,7 +17730,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -19337,7 +19327,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -19416,8 +19405,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tsyringe": {
       "version": "4.10.0",
@@ -19579,7 +19567,6 @@
       "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -20002,7 +19989,6 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.4.tgz",
       "integrity": "sha512-jTywjboN9aHxFlToqb0K0Zs9SbBoW4zRUlGzI2tYNxVYcEi/IPpn+Xi4ye5jTLvX2YeLuic/IvxNot+Q1jMoOw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -20052,7 +20038,6 @@
       "integrity": "sha512-PEhAoqiJ+47d0uLMx/+zo5XOvaU+Vk6N2ZLht7H3n09QLy/fhyvqGNwjdRUHJDgMN8crBR2ZwVHkIswT3Xuawg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.6.3",
         "acorn": "^8.0.4",
@@ -20159,7 +20144,6 @@
       "integrity": "sha512-9Gyu2F7+bg4Vv+pjbovuYDhHX+mqdqITykfzdM9UyKqKHlsE5aAjRhR+oOEfXW5vBeu8tarzlJFIZva4ZjAdrQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.13",
         "@types/connect-history-api-fallback": "^1.5.4",
@@ -20817,7 +20801,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -20882,7 +20865,6 @@
         "cross-spawn": "^7.0.6",
         "envinfo": "^7.14.0",
         "fastest-levenshtein": "^1.0.12",
-        "import-local": "^3.0.2",
         "interpret": "^3.1.1",
         "rechoir": "^0.8.0",
         "webpack-merge": "^6.0.1"

--- a/packages/webpack-cli/bin/cli.js
+++ b/packages/webpack-cli/bin/cli.js
@@ -1,29 +1,14 @@
 #!/usr/bin/env node
 
-"use strict";
-
-const importLocal = require("import-local");
-const WebpackCLI = require("../lib/webpack-cli").default;
-
-const runCLI = async (args) => {
-  const cli = new WebpackCLI();
-
-  try {
-    await cli.run(args);
-  } catch (error) {
-    cli.logger.error(error);
-    process.exit(2);
-  }
-};
-
-if (
-  !process.env.WEBPACK_CLI_SKIP_IMPORT_LOCAL && // Prefer the local installation of `webpack-cli`
-  importLocal(__filename)
-) {
-  return;
-}
+import WebpackCLI from "../lib/webpack-cli.js";
 
 process.title = "webpack";
 
-// eslint-disable-next-line unicorn/prefer-top-level-await
-runCLI(process.argv);
+const cli = new WebpackCLI();
+
+try {
+  await cli.run(process.argv);
+} catch (error) {
+  cli.logger.error(error);
+  process.exit(2);
+}

--- a/packages/webpack-cli/package.json
+++ b/packages/webpack-cli/package.json
@@ -21,6 +21,11 @@
     "url": "https://opencollective.com/webpack"
   },
   "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": "./lib/index.js",
+    "./package.json": "./package.json"
+  },
   "main": "./lib/index.js",
   "bin": {
     "webpack-cli": "./bin/cli.js"
@@ -36,7 +41,6 @@
     "cross-spawn": "^7.0.6",
     "envinfo": "^7.14.0",
     "fastest-levenshtein": "^1.0.12",
-    "import-local": "^3.0.2",
     "interpret": "^3.1.1",
     "rechoir": "^0.8.0",
     "webpack-merge": "^6.0.1"

--- a/packages/webpack-cli/src/webpack-cli.ts
+++ b/packages/webpack-cli/src/webpack-cli.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import { createRequire } from "node:module";
 import path from "node:path";
 import { type Readable as ReadableType } from "node:stream";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -31,6 +32,8 @@ import {
   default as webpack,
 } from "webpack";
 import { type Configuration as DevServerConfiguration } from "webpack-dev-server";
+
+const require = createRequire(import.meta.url);
 
 const WEBPACK_PACKAGE_IS_CUSTOM = Boolean(process.env.WEBPACK_PACKAGE);
 const WEBPACK_PACKAGE = WEBPACK_PACKAGE_IS_CUSTOM
@@ -410,7 +413,7 @@ class WebpackCLI {
     }
 
     // Fallback using fs
-    let dir = __dirname;
+    let dir = path.dirname(fileURLToPath(import.meta.url));
 
     do {
       try {
@@ -1953,7 +1956,7 @@ class WebpackCLI {
 
   async run(args: readonly string[], parseOptions: ParseOptions) {
     // Default `--color` and `--no-color` options
-    // eslint-disable-next-line @typescript-eslint/no-this-alias
+
     const self: WebpackCLI = this;
 
     // Register own exit
@@ -2169,8 +2172,7 @@ class WebpackCLI {
         let loadingError;
 
         try {
-          options = // eslint-disable-next-line no-eval
-            (await eval(`import("${isFileURL ? configPath : pathToFileURL(configPath)}")`)).default;
+          options = (await import(isFileURL ? configPath : pathToFileURL(configPath).href)).default;
         } catch (err) {
           if (this.isValidationError(err) || process.env?.WEBPACK_CLI_FORCE_LOAD_ESM_CONFIG) {
             throw err;
@@ -2528,7 +2530,7 @@ class WebpackCLI {
       process.exit(2);
     }
 
-    const { default: CLIPlugin } = (await import("./plugins/cli-plugin.js")).default;
+    const { default: CLIPlugin } = await import("./plugins/cli-plugin.js");
 
     const builtInOptions = this.schemaToOptions(options.webpack);
     const internalBuildConfig = (configuration: Configuration) => {

--- a/test/api/CLI.test.js
+++ b/test/api/CLI.test.js
@@ -1,6 +1,10 @@
-const CLI = require("../../packages/webpack-cli/lib/webpack-cli").default;
+let CLI;
 
 describe("CLI API", () => {
+  beforeAll(async () => {
+    ({ default: CLI } = await import("../../packages/webpack-cli/lib/webpack-cli"));
+  });
+
   let cli;
 
   beforeEach(() => {

--- a/test/api/capitalizeFirstLetter.test.js
+++ b/test/api/capitalizeFirstLetter.test.js
@@ -1,6 +1,10 @@
-const CLI = require("../../packages/webpack-cli/lib/webpack-cli").default;
+let CLI;
 
 describe("capitalizeFirstLetter", () => {
+  beforeAll(async () => {
+    ({ default: CLI } = await import("../../packages/webpack-cli/lib/webpack-cli"));
+  });
+
   it("should capitalize first letter", () => {
     const cli = new CLI();
 

--- a/test/api/get-default-package-manager.test.js
+++ b/test/api/get-default-package-manager.test.js
@@ -1,6 +1,7 @@
 const fs = require("node:fs");
 const path = require("node:path");
-const CLI = require("../../packages/webpack-cli/lib/webpack-cli").default;
+
+let CLI;
 
 const syncMock = jest.fn(() => ({
   stdout: "1.0.0",
@@ -23,7 +24,9 @@ describe("getPackageManager", () => {
 
   const cwdSpy = jest.spyOn(process, "cwd");
 
-  beforeAll(() => {
+  beforeAll(async () => {
+    ({ default: CLI } = await import("../../packages/webpack-cli/lib/webpack-cli"));
+
     // package-lock.json is ignored by .gitignore, so we simply
     // write a lockfile here for testing
     if (!fs.existsSync(testNpmLockPath)) {

--- a/test/api/install-package.test.js
+++ b/test/api/install-package.test.js
@@ -1,7 +1,8 @@
 "use strict";
 
 const { stripVTControlCharacters } = require("node:util");
-const CLI = require("../../packages/webpack-cli/lib/webpack-cli").default;
+
+let CLI;
 
 const readlineQuestionMock = jest.fn();
 
@@ -17,6 +18,10 @@ const spawnMock = jest.fn();
 jest.mock("cross-spawn", () => ({ sync: spawnMock }));
 
 describe("installPackage", () => {
+  beforeAll(async () => {
+    ({ default: CLI } = await import("../../packages/webpack-cli/lib/webpack-cli"));
+  });
+
   let cli;
   let getDefaultPackageManagerSpy;
 

--- a/test/api/is-package-installed.test.js
+++ b/test/api/is-package-installed.test.js
@@ -1,6 +1,10 @@
-const CLI = require("../../packages/webpack-cli/lib/webpack-cli").default;
+let CLI;
 
 describe("isPackageInstalled", () => {
+  beforeAll(async () => {
+    ({ default: CLI } = await import("../../packages/webpack-cli/lib/webpack-cli"));
+  });
+
   let cli;
 
   beforeEach(() => {


### PR DESCRIPTION
refactor(cli): migrate webpack-cli from CJS to ESM ( Solves the issue #3436 )

- Add "type": "module" and "exports" to webpack-cli package.json
- Rewrite bin/cli.js as ESM, drop import-local dependency
- Replace eval('import()') with native import() for config loading
- Use createRequire for sync require() calls (webpack colors, CJS config fallback)
- Replace __dirname with path.dirname(fileURLToPath(import.meta.url))
- Fix double .default unwrap on cli-plugin dynamic import
- Update ESLint config to recognize bin/ as ESM
- Update API tests to use async import() instead of require()
