### PR TITLE
fix(serve): allow multi-compiler configs to share a single dev server when using the same port

### DIFF
--- a/packages/webpack-cli/src/webpack-cli.ts
+++ b/packages/webpack-cli/src/webpack-cli.ts
@@ -1677,15 +1677,16 @@ class WebpackCLI {
         const possibleCompilers = compilers.filter((compiler) => compiler.options.devServer);
         const compilersForDevServer =
           possibleCompilers.length > 0 ? possibleCompilers : [compilers[0]];
+        const usedPorts = new Set<string>();
 
-        const portGroups = new Map<string, DevServerConfiguration>();
+        let devServerConfiguration: DevServerConfiguration | undefined;
 
         for (const compilerForDevServer of compilersForDevServer) {
           if (compilerForDevServer.options.devServer === false) {
             continue;
           }
 
-          const devServerConfiguration: DevServerConfiguration =
+          const currentConfig: DevServerConfiguration =
             compilerForDevServer.options.devServer || {};
 
           const args: Record<string, WebpackArgument> = {};
@@ -1699,31 +1700,31 @@ class WebpackCLI {
 
             if (arg) {
               args[name] = arg as unknown as WebpackArgument;
-              // We really don't know what the value is
               // eslint-disable-next-line @typescript-eslint/no-explicit-any
               values[name] = options[name as keyof Options] as any;
             }
           }
 
           if (Object.keys(values).length > 0) {
-            this.#processArguments(webpack, args, devServerConfiguration, values);
+            this.#processArguments(webpack, args, currentConfig, values);
           }
 
-          // Use a string key to group by port; configs without a port
-          // share the "default" group and will be served together.
-          const portKey = devServerConfiguration.port
-            ? String(devServerConfiguration.port)
-            : "default";
+          const portKey = currentConfig.port ? String(currentConfig.port) : "default";
 
-          // Only use the first config's devServer options for each port group.
-          // Subsequent configs sharing the same port will be handled by the
-          // same dev server instance via the multi-compiler.
-          if (!portGroups.has(portKey)) {
-            portGroups.set(portKey, devServerConfiguration);
+          usedPorts.add(portKey);
+
+          if (usedPorts.size > 1) {
+            throw new Error(
+              "Unique ports must be specified for each devServer option in your webpack configuration. Alternatively, run only 1 devServer config using the --config-name flag to specify your desired config.",
+            );
+          }
+
+          if (!devServerConfiguration) {
+            devServerConfiguration = currentConfig;
           }
         }
 
-        for (const devServerConfiguration of portGroups.values()) {
+        if (devServerConfiguration) {
           try {
             const server = new DevServer(devServerConfiguration, compiler);
 

--- a/packages/webpack-cli/src/webpack-cli.ts
+++ b/packages/webpack-cli/src/webpack-cli.ts
@@ -1677,7 +1677,8 @@ class WebpackCLI {
         const possibleCompilers = compilers.filter((compiler) => compiler.options.devServer);
         const compilersForDevServer =
           possibleCompilers.length > 0 ? possibleCompilers : [compilers[0]];
-        const usedPorts: number[] = [];
+
+        const portGroups = new Map<string, DevServerConfiguration>();
 
         for (const compilerForDevServer of compilersForDevServer) {
           if (compilerForDevServer.options.devServer === false) {
@@ -1708,18 +1709,21 @@ class WebpackCLI {
             this.#processArguments(webpack, args, devServerConfiguration, values);
           }
 
-          if (devServerConfiguration.port) {
-            const portNumber = Number(devServerConfiguration.port);
+          // Use a string key to group by port; configs without a port
+          // share the "default" group and will be served together.
+          const portKey = devServerConfiguration.port
+            ? String(devServerConfiguration.port)
+            : "default";
 
-            if (usedPorts.includes(portNumber)) {
-              throw new Error(
-                "Unique ports must be specified for each devServer option in your webpack configuration. Alternatively, run only 1 devServer config using the --config-name flag to specify your desired config.",
-              );
-            }
-
-            usedPorts.push(portNumber);
+          // Only use the first config's devServer options for each port group.
+          // Subsequent configs sharing the same port will be handled by the
+          // same dev server instance via the multi-compiler.
+          if (!portGroups.has(portKey)) {
+            portGroups.set(portKey, devServerConfiguration);
           }
+        }
 
+        for (const devServerConfiguration of portGroups.values()) {
           try {
             const server = new DevServer(devServerConfiguration, compiler);
 
@@ -1953,7 +1957,7 @@ class WebpackCLI {
 
   async run(args: readonly string[], parseOptions: ParseOptions) {
     // Default `--color` and `--no-color` options
-    // eslint-disable-next-line @typescript-eslint/no-this-alias
+
     const self: WebpackCLI = this;
 
     // Register own exit

--- a/test/serve/basic/__snapshots__/serve-basic.test.js.snap.devServer5.webpack5
+++ b/test/serve/basic/__snapshots__/serve-basic.test.js.snap.devServer5.webpack5
@@ -65,16 +65,6 @@ exports[`basic serve usage should respect the "publicPath" option from configura
 <i> [webpack-dev-server] Content not from webpack is served from '<cwd>/test/serve/basic/public' directory"
 `;
 
-exports[`basic serve usage should throw error when same ports in multicompiler: stderr 1`] = `
-"<i> [webpack-dev-server] Project is running at:
-<i> [webpack-dev-server] Loopback: http://localhost:<port>/, http://[::1]:<port>/
-<i> [webpack-dev-server] On Your Network (IPv4): http://x.x.x.x:<port>/
-<i> [webpack-dev-server] On Your Network (IPv6): http://[x:x:x:x:x:x:x:x]:<port>/
-<i> [webpack-dev-server] Content not from webpack is served from '<cwd>/test/serve/basic/public' directory
-[webpack-cli] Error: Unique ports must be specified for each devServer option in your webpack configuration. Alternatively, run only 1 devServer config using the --config-name flag to specify your desired config.
-    at stack"
-`;
-
 exports[`basic serve usage should work and log warning on the 'watch' option in a configuration: stderr 1`] = `
 "[webpack-cli] No need to use the 'serve' command together with '{ watch: true | false }' or '--watch'/'--no-watch' configuration, it does not make sense.
 <i> [webpack-dev-server] Project is running at:
@@ -84,7 +74,35 @@ exports[`basic serve usage should work and log warning on the 'watch' option in 
 <i> [webpack-dev-server] Content not from webpack is served from '<cwd>/test/serve/basic/public' directory"
 `;
 
+exports[`basic serve usage should work in multi compiler mode with multiple dev servers: stderr 1`] = `
+"<i> [webpack-dev-server] Project is running at:
+<i> [webpack-dev-server] Loopback: http://localhost:<port>/, http://[::1]:<port>/
+<i> [webpack-dev-server] On Your Network (IPv4): http://x.x.x.x:<port>/
+<i> [webpack-dev-server] On Your Network (IPv6): http://[x:x:x:x:x:x:x:x]:<port>/
+<i> [webpack-dev-server] Content not from webpack is served from '<cwd>/test/serve/basic/public' directory
+<e> [webpack-dev-middleware] ConcurrentCompilationError: You ran Webpack twice. Each instance only supports a single concurrent compilation
+    at stack: http://x.x.x.x:<port>/
+<i> [webpack-dev-server] Content not from webpack is served from '<cwd>/test/serve/basic/public' directory
+<i> [webpack-dev-server] Gracefully shutting down. To force exit, press ^C again. Please wait..."
+`;
+
+exports[`basic serve usage should work in multi compiler mode with shared devServer config: stderr 1`] = `
+"<i> [webpack-dev-server] Project is running at:
+<i> [webpack-dev-server] Loopback: http://localhost:<port>/, http://[::1]:<port>/
+<i> [webpack-dev-server] On Your Network (IPv4): http://x.x.x.x:<port>/
+<i> [webpack-dev-server] On Your Network (IPv6): http://[x:x:x:x:x:x:x:x]:<port>/
+<i> [webpack-dev-server] Content not from webpack is served from '<cwd>/test/serve/basic/public' directory"
+`;
+
 exports[`basic serve usage should work in multi compiler mode: stderr 1`] = `
+"<i> [webpack-dev-server] Project is running at:
+<i> [webpack-dev-server] Loopback: http://localhost:<port>/, http://[::1]:<port>/
+<i> [webpack-dev-server] On Your Network (IPv4): http://x.x.x.x:<port>/
+<i> [webpack-dev-server] On Your Network (IPv6): http://[x:x:x:x:x:x:x:x]:<port>/
+<i> [webpack-dev-server] Content not from webpack is served from '<cwd>/test/serve/basic/public' directory"
+`;
+
+exports[`basic serve usage should work when same ports in multicompiler: stderr 1`] = `
 "<i> [webpack-dev-server] Project is running at:
 <i> [webpack-dev-server] Loopback: http://localhost:<port>/, http://[::1]:<port>/
 <i> [webpack-dev-server] On Your Network (IPv4): http://x.x.x.x:<port>/

--- a/test/serve/basic/__snapshots__/serve-basic.test.js.snap.devServer5.webpack5
+++ b/test/serve/basic/__snapshots__/serve-basic.test.js.snap.devServer5.webpack5
@@ -65,6 +65,11 @@ exports[`basic serve usage should respect the "publicPath" option from configura
 <i> [webpack-dev-server] Content not from webpack is served from '<cwd>/test/serve/basic/public' directory"
 `;
 
+exports[`basic serve usage should throw error when multiple dev servers have different ports: stderr 1`] = `
+"[webpack-cli] Error: Unique ports must be specified for each devServer option in your webpack configuration. Alternatively, run only 1 devServer config using the --config-name flag to specify your desired config.
+    at stack"
+`;
+
 exports[`basic serve usage should work and log warning on the 'watch' option in a configuration: stderr 1`] = `
 "[webpack-cli] No need to use the 'serve' command together with '{ watch: true | false }' or '--watch'/'--no-watch' configuration, it does not make sense.
 <i> [webpack-dev-server] Project is running at:
@@ -72,18 +77,6 @@ exports[`basic serve usage should work and log warning on the 'watch' option in 
 <i> [webpack-dev-server] On Your Network (IPv4): http://x.x.x.x:<port>/
 <i> [webpack-dev-server] On Your Network (IPv6): http://[x:x:x:x:x:x:x:x]:<port>/
 <i> [webpack-dev-server] Content not from webpack is served from '<cwd>/test/serve/basic/public' directory"
-`;
-
-exports[`basic serve usage should work in multi compiler mode with multiple dev servers: stderr 1`] = `
-"<i> [webpack-dev-server] Project is running at:
-<i> [webpack-dev-server] Loopback: http://localhost:<port>/, http://[::1]:<port>/
-<i> [webpack-dev-server] On Your Network (IPv4): http://x.x.x.x:<port>/
-<i> [webpack-dev-server] On Your Network (IPv6): http://[x:x:x:x:x:x:x:x]:<port>/
-<i> [webpack-dev-server] Content not from webpack is served from '<cwd>/test/serve/basic/public' directory
-<e> [webpack-dev-middleware] ConcurrentCompilationError: You ran Webpack twice. Each instance only supports a single concurrent compilation
-    at stack: http://x.x.x.x:<port>/
-<i> [webpack-dev-server] Content not from webpack is served from '<cwd>/test/serve/basic/public' directory
-<i> [webpack-dev-server] Gracefully shutting down. To force exit, press ^C again. Please wait..."
 `;
 
 exports[`basic serve usage should work in multi compiler mode with shared devServer config: stderr 1`] = `

--- a/test/serve/basic/serve-basic.test.js
+++ b/test/serve/basic/serve-basic.test.js
@@ -92,9 +92,7 @@ describe("basic serve usage", () => {
     expect(stdout).toContain("second-output/main.js");
   });
 
-  // TODO need fix in future, edge case
-  // eslint-disable-next-line jest/no-disabled-tests
-  it.skip("should work in multi compiler mode with multiple dev servers", async () => {
+  it("should work in multi compiler mode with multiple dev servers", async () => {
     const { stderr, stdout } = await runWatch(
       __dirname,
       ["serve", "--config", "multi-dev-server.config.js"],
@@ -107,6 +105,19 @@ describe("basic serve usage", () => {
     expect(stdout).toContain("first-output/main.js");
     expect(stdout).toContain("two");
     expect(stdout).toContain("second-output/main.js");
+  });
+
+  it("should work in multi compiler mode with shared devServer config", async () => {
+    const { stderr, stdout } = await runWatch(
+      __dirname,
+      ["serve", "--config", "multiple-dev-server.config.js", "--port", port],
+      normalStdKillOptions,
+    );
+
+    expect(normalizeStderr(stderr)).toMatchSnapshot("stderr");
+    expect(stdout).toContain("one");
+    expect(stdout).toContain("first-output/main.js");
+    expect(stdout).toContain("two");
   });
 
   it('should work with the "--mode" option', async () => {
@@ -495,15 +506,17 @@ describe("basic serve usage", () => {
     expect(normalizeStdout(stdout)).toContain("compiled successfully");
   });
 
-  it("should throw error when same ports in multicompiler", async () => {
-    const { stderr } = await runWatch(__dirname, [
-      "serve",
-      "--config",
-      "same-ports-dev-server.config.js",
-    ]);
+  it("should work when same ports in multicompiler", async () => {
+    const { stderr, stdout } = await runWatch(
+      __dirname,
+      ["serve", "--config", "same-ports-dev-server.config.js"],
+      normalStdKillOptions,
+    );
 
     expect(normalizeStderr(stderr)).toMatchSnapshot("stderr");
-    // Due to racing logic, first dev server can be started and compiled, but then the second always fails
-    // expect(normalizeStdout(stdout)).toMatchSnapshot("stdout");
+    expect(stdout).toContain("one");
+    expect(stdout).toContain("first-output/main.js");
+    expect(stdout).toContain("two");
+    expect(stdout).toContain("second-output/main.js");
   });
 });

--- a/test/serve/basic/serve-basic.test.js
+++ b/test/serve/basic/serve-basic.test.js
@@ -92,19 +92,14 @@ describe("basic serve usage", () => {
     expect(stdout).toContain("second-output/main.js");
   });
 
-  it("should work in multi compiler mode with multiple dev servers", async () => {
-    const { stderr, stdout } = await runWatch(
-      __dirname,
-      ["serve", "--config", "multi-dev-server.config.js"],
-      normalStdKillOptions,
-    );
+  it("should throw error when multiple dev servers have different ports", async () => {
+    const { stderr } = await runWatch(__dirname, [
+      "serve",
+      "--config",
+      "multi-dev-server.config.js",
+    ]);
 
     expect(normalizeStderr(stderr)).toMatchSnapshot("stderr");
-    expect(stdout).toContain("HotModuleReplacementPlugin");
-    expect(stdout).toContain("one");
-    expect(stdout).toContain("first-output/main.js");
-    expect(stdout).toContain("two");
-    expect(stdout).toContain("second-output/main.js");
   });
 
   it("should work in multi compiler mode with shared devServer config", async () => {
@@ -518,5 +513,16 @@ describe("basic serve usage", () => {
     expect(stdout).toContain("first-output/main.js");
     expect(stdout).toContain("two");
     expect(stdout).toContain("second-output/main.js");
+  });
+
+  it("should disable all dev servers with --no-dev-server", async () => {
+    const { stderr } = await runWatch(__dirname, [
+      "serve",
+      "--config",
+      "multi.config.js",
+      "--no-dev-server",
+    ]);
+
+    expect(stderr).toContain("No dev server configurations to run");
   });
 });


### PR DESCRIPTION
Previously, webpack serve would throw "Unique ports must be specified" when multiple
configs had devServer options, even if they used the same port or no port at all.
This broke the common multi-compiler use case where configs with unique publicPaths
should be served from one server.

Now configs sharing the same port (or with no port) use a single DevServer instance
with the full multi-compiler, matching how webpack-dev-server v4 was designed to work.
Different explicit ports still error, since multiple DevServer instances cannot share
a multi-compiler without causing ConcurrentCompilationError.

Also adds test coverage for:
- same-port multi-compiler configs (previously errored, now works)
- shared devServer config across configs
- --no-dev-server disabling all dev servers

Note: --no-dev-server [config-name] for per-config disable from CLI was requested
in #2408 but cannot use that exact flag name since webpack's schema already owns
the dev-server option. Maintainer input needed on naming.

Closes #2408