### PR TITLE
test: build defineConfig-wrapped configs of every shape through the CLI

### DIFF
--- a/test/build/config/define-config/define-config-array-functions.config.js
+++ b/test/build/config/define-config/define-config-array-functions.config.js
@@ -1,0 +1,18 @@
+const { defineConfig } = require("webpack");
+
+module.exports = defineConfig([
+  () => ({
+    output: { filename: "./define-config-array-first.js" },
+    name: "first",
+    entry: "./src/first.js",
+    mode: "development",
+    stats: "minimal",
+  }),
+  async () => ({
+    output: { filename: "./define-config-array-second.js" },
+    name: "second",
+    entry: "./src/second.js",
+    mode: "development",
+    stats: "minimal",
+  }),
+]);

--- a/test/build/config/define-config/define-config-async-function.config.js
+++ b/test/build/config/define-config/define-config-async-function.config.js
@@ -1,0 +1,7 @@
+const { defineConfig } = require("webpack");
+
+module.exports = defineConfig(async () => ({
+  output: { filename: "./define-config-async-function.js" },
+  name: "async-function",
+  mode: "development",
+}));

--- a/test/build/config/define-config/define-config-function-multi.config.js
+++ b/test/build/config/define-config/define-config-function-multi.config.js
@@ -1,0 +1,18 @@
+const { defineConfig } = require("webpack");
+
+module.exports = defineConfig(() => [
+  {
+    output: { filename: "./define-config-function-multi-first.js" },
+    name: "first",
+    entry: "./src/first.js",
+    mode: "development",
+    stats: "minimal",
+  },
+  {
+    output: { filename: "./define-config-function-multi-second.js" },
+    name: "second",
+    entry: "./src/second.js",
+    mode: "development",
+    stats: "minimal",
+  },
+]);

--- a/test/build/config/define-config/define-config-function.config.js
+++ b/test/build/config/define-config/define-config-function.config.js
@@ -1,0 +1,7 @@
+const { defineConfig } = require("webpack");
+
+module.exports = defineConfig(() => ({
+  output: { filename: "./define-config-function.js" },
+  name: "function",
+  mode: "development",
+}));

--- a/test/build/config/define-config/define-config-multi.config.js
+++ b/test/build/config/define-config/define-config-multi.config.js
@@ -1,0 +1,18 @@
+const { defineConfig } = require("webpack");
+
+module.exports = defineConfig([
+  {
+    output: { filename: "./define-config-multi-first.js" },
+    name: "first",
+    entry: "./src/first.js",
+    mode: "development",
+    stats: "minimal",
+  },
+  {
+    output: { filename: "./define-config-multi-second.js" },
+    name: "second",
+    entry: "./src/second.js",
+    mode: "development",
+    stats: "minimal",
+  },
+]);

--- a/test/build/config/define-config/define-config-object.config.js
+++ b/test/build/config/define-config/define-config-object.config.js
@@ -1,0 +1,7 @@
+const { defineConfig } = require("webpack");
+
+module.exports = defineConfig({
+  output: { filename: "./define-config-object.js" },
+  name: "object",
+  mode: "development",
+});

--- a/test/build/config/define-config/define-config-promise-multi.config.js
+++ b/test/build/config/define-config/define-config-promise-multi.config.js
@@ -1,0 +1,20 @@
+const { defineConfig } = require("webpack");
+
+module.exports = defineConfig(
+  Promise.resolve([
+    {
+      output: { filename: "./define-config-promise-multi-first.js" },
+      name: "first",
+      entry: "./src/first.js",
+      mode: "development",
+      stats: "minimal",
+    },
+    {
+      output: { filename: "./define-config-promise-multi-second.js" },
+      name: "second",
+      entry: "./src/second.js",
+      mode: "development",
+      stats: "minimal",
+    },
+  ]),
+);

--- a/test/build/config/define-config/define-config-promise.config.js
+++ b/test/build/config/define-config/define-config-promise.config.js
@@ -1,0 +1,9 @@
+const { defineConfig } = require("webpack");
+
+module.exports = defineConfig(
+  Promise.resolve({
+    output: { filename: "./define-config-promise.js" },
+    name: "promise",
+    mode: "development",
+  }),
+);

--- a/test/build/config/define-config/define-config.test.js
+++ b/test/build/config/define-config/define-config.test.js
@@ -1,0 +1,119 @@
+"use strict";
+
+const { existsSync } = require("node:fs");
+const { resolve } = require("node:path");
+const { run } = require("../../../utils/test-utils");
+
+describe("defineConfig", () => {
+  it("should build and not throw error with an object configuration", async () => {
+    const { exitCode, stderr, stdout } = await run(__dirname, [
+      "--config",
+      resolve(__dirname, "define-config-object.config.js"),
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toBeFalsy();
+    expect(stdout).toContain("./src/index.js");
+    expect(existsSync(resolve(__dirname, "./dist/define-config-object.js"))).toBeTruthy();
+  });
+
+  it("should build and not throw error with a multi-compiler configuration", async () => {
+    const { exitCode, stderr, stdout } = await run(__dirname, [
+      "--config",
+      resolve(__dirname, "define-config-multi.config.js"),
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toBeFalsy();
+    expect(stdout).toContain("first");
+    expect(stdout).toContain("second");
+    expect(existsSync(resolve(__dirname, "./dist/define-config-multi-first.js"))).toBeTruthy();
+    expect(existsSync(resolve(__dirname, "./dist/define-config-multi-second.js"))).toBeTruthy();
+  });
+
+  it("should build and not throw error with a function configuration", async () => {
+    const { exitCode, stderr, stdout } = await run(__dirname, [
+      "--config",
+      resolve(__dirname, "define-config-function.config.js"),
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toBeFalsy();
+    expect(stdout).toContain("./src/index.js");
+    expect(existsSync(resolve(__dirname, "./dist/define-config-function.js"))).toBeTruthy();
+  });
+
+  it("should build and not throw error with a function configuration returning an array", async () => {
+    const { exitCode, stderr, stdout } = await run(__dirname, [
+      "--config",
+      resolve(__dirname, "define-config-function-multi.config.js"),
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toBeFalsy();
+    expect(stdout).toContain("first");
+    expect(stdout).toContain("second");
+    expect(
+      existsSync(resolve(__dirname, "./dist/define-config-function-multi-first.js")),
+    ).toBeTruthy();
+    expect(
+      existsSync(resolve(__dirname, "./dist/define-config-function-multi-second.js")),
+    ).toBeTruthy();
+  });
+
+  it("should build and not throw error with an async function configuration", async () => {
+    const { exitCode, stderr, stdout } = await run(__dirname, [
+      "--config",
+      resolve(__dirname, "define-config-async-function.config.js"),
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toBeFalsy();
+    expect(stdout).toContain("./src/index.js");
+    expect(existsSync(resolve(__dirname, "./dist/define-config-async-function.js"))).toBeTruthy();
+  });
+
+  it("should build and not throw error with an array of functions configuration", async () => {
+    const { exitCode, stderr, stdout } = await run(__dirname, [
+      "--config",
+      resolve(__dirname, "define-config-array-functions.config.js"),
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toBeFalsy();
+    expect(stdout).toContain("first");
+    expect(stdout).toContain("second");
+    expect(existsSync(resolve(__dirname, "./dist/define-config-array-first.js"))).toBeTruthy();
+    expect(existsSync(resolve(__dirname, "./dist/define-config-array-second.js"))).toBeTruthy();
+  });
+
+  it("should build and not throw error with a promise configuration", async () => {
+    const { exitCode, stderr, stdout } = await run(__dirname, [
+      "--config",
+      resolve(__dirname, "define-config-promise.config.js"),
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toBeFalsy();
+    expect(stdout).toContain("./src/index.js");
+    expect(existsSync(resolve(__dirname, "./dist/define-config-promise.js"))).toBeTruthy();
+  });
+
+  it("should build and not throw error with a promise configuration returning an array", async () => {
+    const { exitCode, stderr, stdout } = await run(__dirname, [
+      "--config",
+      resolve(__dirname, "define-config-promise-multi.config.js"),
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toBeFalsy();
+    expect(stdout).toContain("first");
+    expect(stdout).toContain("second");
+    expect(
+      existsSync(resolve(__dirname, "./dist/define-config-promise-multi-first.js")),
+    ).toBeTruthy();
+    expect(
+      existsSync(resolve(__dirname, "./dist/define-config-promise-multi-second.js")),
+    ).toBeTruthy();
+  });
+});

--- a/test/build/config/define-config/src/first.js
+++ b/test/build/config/define-config/src/first.js
@@ -1,0 +1,1 @@
+console.log("first");

--- a/test/build/config/define-config/src/index.js
+++ b/test/build/config/define-config/src/index.js
@@ -1,0 +1,1 @@
+console.log("define-config");

--- a/test/build/config/define-config/src/second.js
+++ b/test/build/config/define-config/src/second.js
@@ -1,0 +1,1 @@
+console.log("second");


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Adds end-to-end CLI build tests verifying that configs wrapped in webpack's new `defineConfig` helper (webpack/webpack#21169) load and build correctly through webpack-cli in every supported shape. Ensures the CLI's config-loading chain (function/promise/array handling, env/argv) works with `defineConfig`, which is a runtime identity passthrough. Depends on a webpack that exports `defineConfig`, so these go green once that ships (or against `webpack@next`).

**What kind of change does this PR introduce?**

test

**Did you add tests for your changes?**

Yes — `test/build/config/define-config/` (one spec, 8 cases) covering object, multi-compiler array, function, function-returning-array, async function, array-of-functions, promise, and promise-returning-array; each runs the real CLI and asserts exit code 0 and emitted bundles.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

This PR was implemented with Claude Code under my direction and review; I specified the test matrix (every `defineConfig` input shape, exercised end-to-end through the CLI).

---
_Generated by [Claude Code](https://claude.ai/code/session_01YMzDH3ktTFRaGeATwQxqaY)_