### PR TITLE
refactor(cli): hierarchical indentation for styled CLI output

### DIFF
--- a/.changeset/hierarchical-cli-indent.md
+++ b/.changeset/hierarchical-cli-indent.md
@@ -1,5 +1,0 @@
----
-"webpack-cli": patch
----
-
-refactor(cli): make the styled help/info/version/configtest output use hierarchical indentation — branded headers, dividers, descriptions, status messages and the footer now sit at column 0, and the two-space indent is reserved for content nested inside a section (envinfo rows, option/command lists). This keeps the padding meaningful and leaves output that never went through the renderer (e.g. webpack/dev-server errors) untouched.

--- a/.changeset/hierarchical-cli-indent.md
+++ b/.changeset/hierarchical-cli-indent.md
@@ -1,0 +1,5 @@
+---
+"webpack-cli": patch
+---
+
+refactor(cli): make the styled help/info/version/configtest output use hierarchical indentation — branded headers, dividers, descriptions, status messages and the footer now sit at column 0, and the two-space indent is reserved for content nested inside a section (envinfo rows, option/command lists). This keeps the padding meaningful and leaves output that never went through the renderer (e.g. webpack/dev-server errors) untouched.

--- a/packages/webpack-cli/src/webpack-cli.ts
+++ b/packages/webpack-cli/src/webpack-cli.ts
@@ -1492,11 +1492,11 @@ class WebpackCLI {
             : helper.commandDescription(command);
 
           if (commandDescription.length > 0) {
-            output = [...output, `${INDENT}${commandDescription}`, ""];
+            output = [...output, commandDescription, ""];
           }
 
           // Usage
-          output = [...output, `${INDENT}${bold("Usage:")} ${helper.commandUsage(command)}`, ""];
+          output = [...output, `${bold("Usage:")} ${helper.commandUsage(command)}`, ""];
 
           // Arguments
           output = addSection(
@@ -1689,26 +1689,26 @@ class WebpackCLI {
 
   /** A horizontal rule used to separate sections. */
   #uiDivider(): string {
-    return `${UI_INDENT}${this.colors.blue("─".repeat(UI_DIVIDER_WIDTH))}`;
+    return this.colors.blue("─".repeat(UI_DIVIDER_WIDTH));
   }
 
   /** A branded title, e.g. `⬡ webpack build`. */
   #uiHeader(title: string): string {
     const { bold, cyan } = this.colors;
-    return `${UI_INDENT}${bold(cyan("⬡"))} ${bold(cyan(title))}`;
+    return `${bold(cyan("⬡"))} ${bold(cyan(title))}`;
   }
 
   /** A section heading with an underline, e.g. `Options` followed by a divider. */
   #uiSectionTitle(title: string): string {
     const { bold, cyan } = this.colors;
-    return `${UI_INDENT}${bold(cyan(title))}\n${this.#uiDivider()}`;
+    return `${bold(cyan(title))}\n${this.#uiDivider()}`;
   }
 
   /** A single status message prefixed with an icon (`✔`/`✖`/`⚠`/`ℹ`). */
   #uiStatusLine(kind: StatusKind, message: string): string {
     const { green, red, yellow, cyan } = this.colors;
     const color = { success: green, error: red, warning: yellow, info: cyan }[kind];
-    return `${UI_INDENT}${color(UI_STATUS_ICONS[kind])} ${message}`;
+    return `${color(UI_STATUS_ICONS[kind])} ${message}`;
   }
 
   /** The header block printed at the top of a framed command (`info`, `version`, …). */
@@ -1716,7 +1716,7 @@ class WebpackCLI {
     const lines = ["", this.#uiHeader(`webpack ${name}`), this.#uiDivider()];
 
     if (description) {
-      lines.push(`${UI_INDENT}${description}`, "");
+      lines.push(description, "");
     }
 
     return lines.join("\n");
@@ -1729,15 +1729,15 @@ class WebpackCLI {
 
     if (!options.verbose) {
       lines.push(
-        `${UI_INDENT}${cyan("ℹ")} Run ${bold("'webpack --help=verbose'")} to see all available commands and options.`,
+        `${cyan("ℹ")} Run ${bold("'webpack --help=verbose'")} to see all available commands and options.`,
       );
     }
 
     lines.push(
       "",
-      `${UI_INDENT}${bold("Webpack documentation:")}  ${cyan("https://webpack.js.org/")}`,
-      `${UI_INDENT}${bold("CLI documentation:")}      ${cyan("https://webpack.js.org/api/cli/")}`,
-      `${UI_INDENT}${bold("Made with")} ${red("♥")} ${bold("by the webpack team")}`,
+      `${bold("Webpack documentation:")}  ${cyan("https://webpack.js.org/")}`,
+      `${bold("CLI documentation:")}      ${cyan("https://webpack.js.org/api/cli/")}`,
+      `${bold("Made with")} ${red("♥")} ${bold("by the webpack team")}`,
     );
 
     return lines.join("\n");

--- a/packages/webpack-cli/src/webpack-cli.ts
+++ b/packages/webpack-cli/src/webpack-cli.ts
@@ -1377,7 +1377,7 @@ class WebpackCLI {
       value === "--version" ||
       value === "-h" ||
       value === "--help";
-    const { bold, cyan } = this.colors;
+    const { bold } = this.colors;
     // Shared "chrome" used to render the help screens. These are purely visual:
     // colors collapse to plain strings when colors are disabled (e.g. piped output
     // or `--no-color`), so the textual structure stays stable for scripts.
@@ -1414,9 +1414,8 @@ class WebpackCLI {
           }
 
           if (isGlobalHelp) {
-            return `${parentCmdNames}${command.usage()}\n${INDENT}${bold(
-              "Alternative usage to run commands:",
-            )} ${parentCmdNames}[command] [options]`;
+            // Show both supported invocation syntaxes on a single line.
+            return `${parentCmdNames}${command.usage()} | ${parentCmdNames}[command] [options]`;
           }
 
           return `${parentCmdNames}${command.name()}|${command
@@ -1464,14 +1463,14 @@ class WebpackCLI {
           const formatItem = (term: string, description: string) => {
             if (description) {
               return helper.formatItem(
-                cyan(term),
+                bold(term),
                 helper.padWidth(command, helper),
                 description,
                 helper,
               );
             }
 
-            return `${INDENT}${cyan(term)}`;
+            return `${INDENT}${bold(term)}`;
           };
 
           const formatList = (textArray: string[]) => textArray.join("\n");

--- a/packages/webpack-cli/src/webpack-cli.ts
+++ b/packages/webpack-cli/src/webpack-cli.ts
@@ -1688,7 +1688,9 @@ class WebpackCLI {
 
   /** A horizontal rule used to separate sections. */
   #uiDivider(): string {
-    return this.colors.blue("─".repeat(UI_DIVIDER_WIDTH));
+    // Separators should recede behind content, so render them faint rather than
+    // in a saturated color (default-blue is the least readable hue on dark terminals).
+    return this.colors.dim("─".repeat(UI_DIVIDER_WIDTH));
   }
 
   /** A branded title, e.g. `⬡ webpack build`. */

--- a/test/api/__snapshots__/CLI.test.js.snap.webpack5
+++ b/test/api/__snapshots__/CLI.test.js.snap.webpack5
@@ -6,10 +6,10 @@ exports[`CLI API custom help output should display help information 1`] = `
     "",
   ],
   [
-    "  ⬡ --mode",
+    "⬡ --mode",
   ],
   [
-    "  ────────────────────────────────────────────────────────────────────────",
+    "────────────────────────────────────────────────────────────────────────",
   ],
   [
     "  Usage: webpack --mode <value>",
@@ -21,17 +21,17 @@ exports[`CLI API custom help output should display help information 1`] = `
     "  Possible values: 'development' | 'production' | 'none'",
   ],
   [
-    "  ────────────────────────────────────────────────────────────────────────",
+    "────────────────────────────────────────────────────────────────────────",
   ],
   [
     "",
   ],
   [
-    "  ℹ Run 'webpack --help=verbose' to see all available commands and options.
+    "ℹ Run 'webpack --help=verbose' to see all available commands and options.
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team",
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team",
   ],
 ]
 `;

--- a/test/configtest/with-config-path/__snapshots__/with-config-path.test.js.snap.webpack5
+++ b/test/configtest/with-config-path/__snapshots__/with-config-path.test.js.snap.webpack5
@@ -18,7 +18,7 @@ exports[`'configtest' command with the configuration path option should throw sy
 exports[`'configtest' command with the configuration path option should throw syntax error: stdout 1`] = `""`;
 
 exports[`'configtest' command with the configuration path option should throw validation error: stderr 1`] = `
-"  ✖ Invalid configuration object. Webpack has been initialized using a configuration object that does not match the API schema.
+"✖ Invalid configuration object. Webpack has been initialized using a configuration object that does not match the API schema.
  - configuration.mode should be one of these:
    "development" | "production" | "none"
    -> Enable production optimizations or development hints."
@@ -26,15 +26,15 @@ exports[`'configtest' command with the configuration path option should throw va
 
 exports[`'configtest' command with the configuration path option should throw validation error: stdout 1`] = `
 "
-  ⬡ webpack configtest
-  ────────────────────────────────────────────────────────────────────────
-  Validating your webpack configuration.
+⬡ webpack configtest
+────────────────────────────────────────────────────────────────────────
+Validating your webpack configuration.
 
-  ℹ Validating: ./error.config.js"
+ℹ Validating: ./error.config.js"
 `;
 
 exports[`'configtest' command with the configuration path option should validate the config with alias 't': stderr 1`] = `
-"  ✖ Invalid configuration object. Webpack has been initialized using a configuration object that does not match the API schema.
+"✖ Invalid configuration object. Webpack has been initialized using a configuration object that does not match the API schema.
  - configuration.mode should be one of these:
    "development" | "production" | "none"
    -> Enable production optimizations or development hints."
@@ -42,26 +42,26 @@ exports[`'configtest' command with the configuration path option should validate
 
 exports[`'configtest' command with the configuration path option should validate the config with alias 't': stdout 1`] = `
 "
-  ⬡ webpack configtest
-  ────────────────────────────────────────────────────────────────────────
-  Validating your webpack configuration.
+⬡ webpack configtest
+────────────────────────────────────────────────────────────────────────
+Validating your webpack configuration.
 
-  ℹ Validating: ./error.config.js"
+ℹ Validating: ./error.config.js"
 `;
 
 exports[`'configtest' command with the configuration path option should validate webpack config successfully: stderr 1`] = `""`;
 
 exports[`'configtest' command with the configuration path option should validate webpack config successfully: stdout 1`] = `
 "
-  ⬡ webpack configtest
-  ────────────────────────────────────────────────────────────────────────
-  Validating your webpack configuration.
+⬡ webpack configtest
+────────────────────────────────────────────────────────────────────────
+Validating your webpack configuration.
 
-  ℹ Validating: ./basic.config.js
-  ✔ No validation errors found.
-  ℹ Run 'webpack --help=verbose' to see all available commands and options.
+ℹ Validating: ./basic.config.js
+✔ No validation errors found.
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;

--- a/test/configtest/without-config-path-custom-extension/__snapshots__/without-config-path.test.js.snap.webpack5
+++ b/test/configtest/without-config-path-custom-extension/__snapshots__/without-config-path.test.js.snap.webpack5
@@ -4,15 +4,15 @@ exports[`'configtest' command without the configuration path option should valid
 
 exports[`'configtest' command without the configuration path option should validate default configuration: stdout 1`] = `
 "
-  ⬡ webpack configtest
-  ────────────────────────────────────────────────────────────────────────
-  Validating your webpack configuration.
+⬡ webpack configtest
+────────────────────────────────────────────────────────────────────────
+Validating your webpack configuration.
 
-  ℹ Validating: <cwd>/test/configtest/without-config-path-custom-extension/webpack.config.json
-  ✔ No validation errors found.
-  ℹ Run 'webpack --help=verbose' to see all available commands and options.
+ℹ Validating: <cwd>/test/configtest/without-config-path-custom-extension/webpack.config.json
+✔ No validation errors found.
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;

--- a/test/configtest/without-config-path-error/__snapshots__/without-config-path-error.test.js.snap.webpack5
+++ b/test/configtest/without-config-path-error/__snapshots__/without-config-path-error.test.js.snap.webpack5
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`'configtest' command without the configuration path option should validate default configuration: stderr 1`] = `
-"  ✖ Invalid configuration object. Webpack has been initialized using a configuration object that does not match the API schema.
+"✖ Invalid configuration object. Webpack has been initialized using a configuration object that does not match the API schema.
  - configuration.mode should be one of these:
    "development" | "production" | "none"
    -> Enable production optimizations or development hints."
@@ -9,9 +9,9 @@ exports[`'configtest' command without the configuration path option should valid
 
 exports[`'configtest' command without the configuration path option should validate default configuration: stdout 1`] = `
 "
-  ⬡ webpack configtest
-  ────────────────────────────────────────────────────────────────────────
-  Validating your webpack configuration.
+⬡ webpack configtest
+────────────────────────────────────────────────────────────────────────
+Validating your webpack configuration.
 
-  ℹ Validating: <cwd>/test/configtest/without-config-path-error/webpack.config.js"
+ℹ Validating: <cwd>/test/configtest/without-config-path-error/webpack.config.js"
 `;

--- a/test/configtest/without-config-path-multi-compiler-mode/__snapshots__/without-config-path-multi-compiler-mode.test.js.snap.webpack5
+++ b/test/configtest/without-config-path-multi-compiler-mode/__snapshots__/without-config-path-multi-compiler-mode.test.js.snap.webpack5
@@ -4,15 +4,15 @@ exports[`'configtest' command without the configuration path option should valid
 
 exports[`'configtest' command without the configuration path option should validate default configuration: stdout 1`] = `
 "
-  ⬡ webpack configtest
-  ────────────────────────────────────────────────────────────────────────
-  Validating your webpack configuration.
+⬡ webpack configtest
+────────────────────────────────────────────────────────────────────────
+Validating your webpack configuration.
 
-  ℹ Validating: <cwd>/test/configtest/without-config-path-multi-compiler-mode/webpack.config.js
-  ✔ No validation errors found.
-  ℹ Run 'webpack --help=verbose' to see all available commands and options.
+ℹ Validating: <cwd>/test/configtest/without-config-path-multi-compiler-mode/webpack.config.js
+✔ No validation errors found.
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;

--- a/test/configtest/without-config-path-no-configuration/__snapshots__/without-config-path-no-configuration.test.js.snap.webpack5
+++ b/test/configtest/without-config-path-no-configuration/__snapshots__/without-config-path-no-configuration.test.js.snap.webpack5
@@ -1,11 +1,11 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`'configtest' command without the configuration path option should validate default configuration: stderr 1`] = `"  ✖ No configuration found."`;
+exports[`'configtest' command without the configuration path option should validate default configuration: stderr 1`] = `"✖ No configuration found."`;
 
 exports[`'configtest' command without the configuration path option should validate default configuration: stdout 1`] = `
 "
-  ⬡ webpack configtest
-  ────────────────────────────────────────────────────────────────────────
-  Validating your webpack configuration.
+⬡ webpack configtest
+────────────────────────────────────────────────────────────────────────
+Validating your webpack configuration.
 "
 `;

--- a/test/configtest/without-config-path/__snapshots__/without-config-path.test.js.snap.webpack5
+++ b/test/configtest/without-config-path/__snapshots__/without-config-path.test.js.snap.webpack5
@@ -4,15 +4,15 @@ exports[`'configtest' command without the configuration path option should valid
 
 exports[`'configtest' command without the configuration path option should validate default configuration: stdout 1`] = `
 "
-  ⬡ webpack configtest
-  ────────────────────────────────────────────────────────────────────────
-  Validating your webpack configuration.
+⬡ webpack configtest
+────────────────────────────────────────────────────────────────────────
+Validating your webpack configuration.
 
-  ℹ Validating: <cwd>/test/configtest/without-config-path/webpack.config.js
-  ✔ No validation errors found.
-  ℹ Run 'webpack --help=verbose' to see all available commands and options.
+ℹ Validating: <cwd>/test/configtest/without-config-path/webpack.config.js
+✔ No validation errors found.
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;

--- a/test/help/__snapshots__/help.test.js.snap.devServer5.webpack5
+++ b/test/help/__snapshots__/help.test.js.snap.devServer5.webpack5
@@ -98,8 +98,7 @@ exports[`help should show help information and respect the "--color" flag using 
 ────────────────────────────────────────────────────────────────────────
 The build tool for modern web applications.
 
-Usage: webpack [entries...] [options]
-  Alternative usage to run commands: webpack [command] [options]
+Usage: webpack [entries...] [options] | webpack [command] [options]
 
 Options
 ────────────────────────────────────────────────────────────────────────
@@ -158,8 +157,7 @@ exports[`help should show help information and respect the "--no-color" flag usi
 ────────────────────────────────────────────────────────────────────────
 The build tool for modern web applications.
 
-Usage: webpack [entries...] [options]
-  Alternative usage to run commands: webpack [command] [options]
+Usage: webpack [entries...] [options] | webpack [command] [options]
 
 Options
 ────────────────────────────────────────────────────────────────────────
@@ -218,8 +216,7 @@ exports[`help should show help information and taking precedence when "--help" a
 ────────────────────────────────────────────────────────────────────────
 The build tool for modern web applications.
 
-Usage: webpack [entries...] [options]
-  Alternative usage to run commands: webpack [command] [options]
+Usage: webpack [entries...] [options] | webpack [command] [options]
 
 Options
 ────────────────────────────────────────────────────────────────────────
@@ -2610,8 +2607,7 @@ exports[`help should show help information using command syntax: stdout 1`] = `
 ────────────────────────────────────────────────────────────────────────
 The build tool for modern web applications.
 
-Usage: webpack [entries...] [options]
-  Alternative usage to run commands: webpack [command] [options]
+Usage: webpack [entries...] [options] | webpack [command] [options]
 
 Options
 ────────────────────────────────────────────────────────────────────────
@@ -2700,8 +2696,7 @@ exports[`help should show help information using the "--help" option: stdout 1`]
 ────────────────────────────────────────────────────────────────────────
 The build tool for modern web applications.
 
-Usage: webpack [entries...] [options]
-  Alternative usage to run commands: webpack [command] [options]
+Usage: webpack [entries...] [options] | webpack [command] [options]
 
 Options
 ────────────────────────────────────────────────────────────────────────
@@ -3058,8 +3053,7 @@ exports[`help should show the same information using the "--help" option and com
 ────────────────────────────────────────────────────────────────────────
 The build tool for modern web applications.
 
-Usage: webpack [entries...] [options]
-  Alternative usage to run commands: webpack [command] [options]
+Usage: webpack [entries...] [options] | webpack [command] [options]
 
 Options
 ────────────────────────────────────────────────────────────────────────
@@ -3116,8 +3110,7 @@ exports[`help should show the same information using the "--help" option and com
 ────────────────────────────────────────────────────────────────────────
 The build tool for modern web applications.
 
-Usage: webpack [entries...] [options]
-  Alternative usage to run commands: webpack [command] [options]
+Usage: webpack [entries...] [options] | webpack [command] [options]
 
 Options
 ────────────────────────────────────────────────────────────────────────

--- a/test/help/__snapshots__/help.test.js.snap.devServer5.webpack5
+++ b/test/help/__snapshots__/help.test.js.snap.devServer5.webpack5
@@ -94,15 +94,15 @@ exports[`help should show help information and respect the "--color" flag using 
 
 exports[`help should show help information and respect the "--color" flag using the "--help" option: stdout 1`] = `
 "
-  ⬡ webpack
-  ────────────────────────────────────────────────────────────────────────
-  The build tool for modern web applications.
+⬡ webpack
+────────────────────────────────────────────────────────────────────────
+The build tool for modern web applications.
 
-  Usage: webpack [entries...] [options]
+Usage: webpack [entries...] [options]
   Alternative usage to run commands: webpack [command] [options]
 
-  Options
-  ────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────
   -c, --config <pathToConfigFile...>     Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
   --config-name <name...>                Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
   -m, --merge                            Merge two or more configurations using 'webpack-merge'.
@@ -125,15 +125,15 @@ exports[`help should show help information and respect the "--color" flag using 
   -w, --watch                            Enter watch mode, which rebuilds on file change.
   --watch-options-stdin                  Stop watching when stdin stream has ended.
 
-  Global options
-  ────────────────────────────────────────────────────────────────────────
+Global options
+────────────────────────────────────────────────────────────────────────
   --color                                Enable colors on console.
   --no-color                             Disable colors on console.
   -v, --version                          Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
   -h, --help [verbose]                   Display help for commands and options.
 
-  Commands
-  ────────────────────────────────────────────────────────────────────────
+Commands
+────────────────────────────────────────────────────────────────────────
   build|bundle|b [entries...] [options]  Run webpack (default command, can be omitted).
   configtest|t [config-path]             Validate a webpack configuration.
   help|h [command] [option]              Display help for commands and options.
@@ -142,27 +142,27 @@ exports[`help should show help information and respect the "--color" flag using 
   version|v [options]                    Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
   watch|w [entries...] [options]         Run webpack and watch for files changes.
 
-  ────────────────────────────────────────────────────────────────────────
-  ℹ Run 'webpack --help=verbose' to see all available commands and options.
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information and respect the "--no-color" flag using the "--help" option: stderr 1`] = `""`;
 
 exports[`help should show help information and respect the "--no-color" flag using the "--help" option: stdout 1`] = `
 "
-  ⬡ webpack
-  ────────────────────────────────────────────────────────────────────────
-  The build tool for modern web applications.
+⬡ webpack
+────────────────────────────────────────────────────────────────────────
+The build tool for modern web applications.
 
-  Usage: webpack [entries...] [options]
+Usage: webpack [entries...] [options]
   Alternative usage to run commands: webpack [command] [options]
 
-  Options
-  ────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────
   -c, --config <pathToConfigFile...>     Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
   --config-name <name...>                Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
   -m, --merge                            Merge two or more configurations using 'webpack-merge'.
@@ -185,15 +185,15 @@ exports[`help should show help information and respect the "--no-color" flag usi
   -w, --watch                            Enter watch mode, which rebuilds on file change.
   --watch-options-stdin                  Stop watching when stdin stream has ended.
 
-  Global options
-  ────────────────────────────────────────────────────────────────────────
+Global options
+────────────────────────────────────────────────────────────────────────
   --color                                Enable colors on console.
   --no-color                             Disable colors on console.
   -v, --version                          Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
   -h, --help [verbose]                   Display help for commands and options.
 
-  Commands
-  ────────────────────────────────────────────────────────────────────────
+Commands
+────────────────────────────────────────────────────────────────────────
   build|bundle|b [entries...] [options]  Run webpack (default command, can be omitted).
   configtest|t [config-path]             Validate a webpack configuration.
   help|h [command] [option]              Display help for commands and options.
@@ -202,27 +202,27 @@ exports[`help should show help information and respect the "--no-color" flag usi
   version|v [options]                    Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
   watch|w [entries...] [options]         Run webpack and watch for files changes.
 
-  ────────────────────────────────────────────────────────────────────────
-  ℹ Run 'webpack --help=verbose' to see all available commands and options.
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information and taking precedence when "--help" and "--version" option using together: stderr 1`] = `""`;
 
 exports[`help should show help information and taking precedence when "--help" and "--version" option using together: stdout 1`] = `
 "
-  ⬡ webpack
-  ────────────────────────────────────────────────────────────────────────
-  The build tool for modern web applications.
+⬡ webpack
+────────────────────────────────────────────────────────────────────────
+The build tool for modern web applications.
 
-  Usage: webpack [entries...] [options]
+Usage: webpack [entries...] [options]
   Alternative usage to run commands: webpack [command] [options]
 
-  Options
-  ────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────
   -c, --config <pathToConfigFile...>     Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
   --config-name <name...>                Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
   -m, --merge                            Merge two or more configurations using 'webpack-merge'.
@@ -245,15 +245,15 @@ exports[`help should show help information and taking precedence when "--help" a
   -w, --watch                            Enter watch mode, which rebuilds on file change.
   --watch-options-stdin                  Stop watching when stdin stream has ended.
 
-  Global options
-  ────────────────────────────────────────────────────────────────────────
+Global options
+────────────────────────────────────────────────────────────────────────
   --color                                Enable colors on console.
   --no-color                             Disable colors on console.
   -v, --version                          Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
   -h, --help [verbose]                   Display help for commands and options.
 
-  Commands
-  ────────────────────────────────────────────────────────────────────────
+Commands
+────────────────────────────────────────────────────────────────────────
   build|bundle|b [entries...] [options]  Run webpack (default command, can be omitted).
   configtest|t [config-path]             Validate a webpack configuration.
   help|h [command] [option]              Display help for commands and options.
@@ -262,26 +262,26 @@ exports[`help should show help information and taking precedence when "--help" a
   version|v [options]                    Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
   watch|w [entries...] [options]         Run webpack and watch for files changes.
 
-  ────────────────────────────────────────────────────────────────────────
-  ℹ Run 'webpack --help=verbose' to see all available commands and options.
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information for 'b' command using command syntax: stderr 1`] = `""`;
 
 exports[`help should show help information for 'b' command using command syntax: stdout 1`] = `
 "
-  ⬡ webpack build
-  ────────────────────────────────────────────────────────────────────────
-  Run webpack (default command, can be omitted).
+⬡ webpack build
+────────────────────────────────────────────────────────────────────────
+Run webpack (default command, can be omitted).
 
-  Usage: webpack build|bundle|b [entries...] [options]
+Usage: webpack build|bundle|b [entries...] [options]
 
-  Options
-  ────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────
   -c, --config <pathToConfigFile...>  Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
   --config-name <name...>             Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
   -m, --merge                         Merge two or more configurations using 'webpack-merge'.
@@ -304,33 +304,33 @@ exports[`help should show help information for 'b' command using command syntax:
   -w, --watch                         Enter watch mode, which rebuilds on file change.
   --watch-options-stdin               Stop watching when stdin stream has ended.
 
-  Global options
-  ────────────────────────────────────────────────────────────────────────
+Global options
+────────────────────────────────────────────────────────────────────────
   --color                             Enable colors on console.
   --no-color                          Disable colors on console.
   -v, --version                       Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
   -h, --help [verbose]                Display help for commands and options.
 
-  ────────────────────────────────────────────────────────────────────────
-  ℹ Run 'webpack --help=verbose' to see all available commands and options.
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information for 'b' command using the "--help verbose" option: stderr 1`] = `""`;
 
 exports[`help should show help information for 'b' command using the "--help verbose" option: stdout 1`] = `
 "
-  ⬡ webpack build
-  ────────────────────────────────────────────────────────────────────────
-  Run webpack (default command, can be omitted).
+⬡ webpack build
+────────────────────────────────────────────────────────────────────────
+Run webpack (default command, can be omitted).
 
-  Usage: webpack build|bundle|b [entries...] [options]
+Usage: webpack build|bundle|b [entries...] [options]
 
-  Options
-  ────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────
   -c, --config <pathToConfigFile...>                                                 Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
   --config-name <name...>                                                            Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
   -m, --merge                                                                        Merge two or more configurations using 'webpack-merge'.
@@ -355,32 +355,32 @@ exports[`help should show help information for 'b' command using the "--help ver
   --watch-options-stdin                                                              Stop watching when stdin stream has ended.
   --no-watch-options-stdin                                                           Negative 'watch-options-stdin' option.
 
-  Global options
-  ────────────────────────────────────────────────────────────────────────
+Global options
+────────────────────────────────────────────────────────────────────────
   --color                                                                            Enable colors on console.
   --no-color                                                                         Disable colors on console.
   -v, --version                                                                      Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
   -h, --help [verbose]                                                               Display help for commands and options.
 
-  ────────────────────────────────────────────────────────────────────────
+────────────────────────────────────────────────────────────────────────
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information for 'b' command using the "--help" option: stderr 1`] = `""`;
 
 exports[`help should show help information for 'b' command using the "--help" option: stdout 1`] = `
 "
-  ⬡ webpack build
-  ────────────────────────────────────────────────────────────────────────
-  Run webpack (default command, can be omitted).
+⬡ webpack build
+────────────────────────────────────────────────────────────────────────
+Run webpack (default command, can be omitted).
 
-  Usage: webpack build|bundle|b [entries...] [options]
+Usage: webpack build|bundle|b [entries...] [options]
 
-  Options
-  ────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────
   -c, --config <pathToConfigFile...>  Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
   --config-name <name...>             Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
   -m, --merge                         Merge two or more configurations using 'webpack-merge'.
@@ -403,33 +403,33 @@ exports[`help should show help information for 'b' command using the "--help" op
   -w, --watch                         Enter watch mode, which rebuilds on file change.
   --watch-options-stdin               Stop watching when stdin stream has ended.
 
-  Global options
-  ────────────────────────────────────────────────────────────────────────
+Global options
+────────────────────────────────────────────────────────────────────────
   --color                             Enable colors on console.
   --no-color                          Disable colors on console.
   -v, --version                       Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
   -h, --help [verbose]                Display help for commands and options.
 
-  ────────────────────────────────────────────────────────────────────────
-  ℹ Run 'webpack --help=verbose' to see all available commands and options.
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information for 'build' and respect the "--color" flag using the "--help" option: stderr 1`] = `""`;
 
 exports[`help should show help information for 'build' and respect the "--color" flag using the "--help" option: stdout 1`] = `
 "
-  ⬡ webpack build
-  ────────────────────────────────────────────────────────────────────────
-  Run webpack (default command, can be omitted).
+⬡ webpack build
+────────────────────────────────────────────────────────────────────────
+Run webpack (default command, can be omitted).
 
-  Usage: webpack build|bundle|b [entries...] [options]
+Usage: webpack build|bundle|b [entries...] [options]
 
-  Options
-  ────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────
   -c, --config <pathToConfigFile...>  Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
   --config-name <name...>             Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
   -m, --merge                         Merge two or more configurations using 'webpack-merge'.
@@ -452,33 +452,33 @@ exports[`help should show help information for 'build' and respect the "--color"
   -w, --watch                         Enter watch mode, which rebuilds on file change.
   --watch-options-stdin               Stop watching when stdin stream has ended.
 
-  Global options
-  ────────────────────────────────────────────────────────────────────────
+Global options
+────────────────────────────────────────────────────────────────────────
   --color                             Enable colors on console.
   --no-color                          Disable colors on console.
   -v, --version                       Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
   -h, --help [verbose]                Display help for commands and options.
 
-  ────────────────────────────────────────────────────────────────────────
-  ℹ Run 'webpack --help=verbose' to see all available commands and options.
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information for 'build' and respect the "--no-color" flag using the "--help" option: stderr 1`] = `""`;
 
 exports[`help should show help information for 'build' and respect the "--no-color" flag using the "--help" option: stdout 1`] = `
 "
-  ⬡ webpack build
-  ────────────────────────────────────────────────────────────────────────
-  Run webpack (default command, can be omitted).
+⬡ webpack build
+────────────────────────────────────────────────────────────────────────
+Run webpack (default command, can be omitted).
 
-  Usage: webpack build|bundle|b [entries...] [options]
+Usage: webpack build|bundle|b [entries...] [options]
 
-  Options
-  ────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────
   -c, --config <pathToConfigFile...>  Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
   --config-name <name...>             Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
   -m, --merge                         Merge two or more configurations using 'webpack-merge'.
@@ -501,33 +501,33 @@ exports[`help should show help information for 'build' and respect the "--no-col
   -w, --watch                         Enter watch mode, which rebuilds on file change.
   --watch-options-stdin               Stop watching when stdin stream has ended.
 
-  Global options
-  ────────────────────────────────────────────────────────────────────────
+Global options
+────────────────────────────────────────────────────────────────────────
   --color                             Enable colors on console.
   --no-color                          Disable colors on console.
   -v, --version                       Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
   -h, --help [verbose]                Display help for commands and options.
 
-  ────────────────────────────────────────────────────────────────────────
-  ℹ Run 'webpack --help=verbose' to see all available commands and options.
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information for 'build' command using command syntax: stderr 1`] = `""`;
 
 exports[`help should show help information for 'build' command using command syntax: stdout 1`] = `
 "
-  ⬡ webpack build
-  ────────────────────────────────────────────────────────────────────────
-  Run webpack (default command, can be omitted).
+⬡ webpack build
+────────────────────────────────────────────────────────────────────────
+Run webpack (default command, can be omitted).
 
-  Usage: webpack build|bundle|b [entries...] [options]
+Usage: webpack build|bundle|b [entries...] [options]
 
-  Options
-  ────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────
   -c, --config <pathToConfigFile...>  Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
   --config-name <name...>             Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
   -m, --merge                         Merge two or more configurations using 'webpack-merge'.
@@ -550,33 +550,33 @@ exports[`help should show help information for 'build' command using command syn
   -w, --watch                         Enter watch mode, which rebuilds on file change.
   --watch-options-stdin               Stop watching when stdin stream has ended.
 
-  Global options
-  ────────────────────────────────────────────────────────────────────────
+Global options
+────────────────────────────────────────────────────────────────────────
   --color                             Enable colors on console.
   --no-color                          Disable colors on console.
   -v, --version                       Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
   -h, --help [verbose]                Display help for commands and options.
 
-  ────────────────────────────────────────────────────────────────────────
-  ℹ Run 'webpack --help=verbose' to see all available commands and options.
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information for 'build' command using the "--help verbose" option: stderr 1`] = `""`;
 
 exports[`help should show help information for 'build' command using the "--help verbose" option: stdout 1`] = `
 "
-  ⬡ webpack build
-  ────────────────────────────────────────────────────────────────────────
-  Run webpack (default command, can be omitted).
+⬡ webpack build
+────────────────────────────────────────────────────────────────────────
+Run webpack (default command, can be omitted).
 
-  Usage: webpack build|bundle|b [entries...] [options]
+Usage: webpack build|bundle|b [entries...] [options]
 
-  Options
-  ────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────
   -c, --config <pathToConfigFile...>                                                 Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
   --config-name <name...>                                                            Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
   -m, --merge                                                                        Merge two or more configurations using 'webpack-merge'.
@@ -601,32 +601,32 @@ exports[`help should show help information for 'build' command using the "--help
   --watch-options-stdin                                                              Stop watching when stdin stream has ended.
   --no-watch-options-stdin                                                           Negative 'watch-options-stdin' option.
 
-  Global options
-  ────────────────────────────────────────────────────────────────────────
+Global options
+────────────────────────────────────────────────────────────────────────
   --color                                                                            Enable colors on console.
   --no-color                                                                         Disable colors on console.
   -v, --version                                                                      Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
   -h, --help [verbose]                                                               Display help for commands and options.
 
-  ────────────────────────────────────────────────────────────────────────
+────────────────────────────────────────────────────────────────────────
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information for 'build' command using the "--help" option: stderr 1`] = `""`;
 
 exports[`help should show help information for 'build' command using the "--help" option: stdout 1`] = `
 "
-  ⬡ webpack build
-  ────────────────────────────────────────────────────────────────────────
-  Run webpack (default command, can be omitted).
+⬡ webpack build
+────────────────────────────────────────────────────────────────────────
+Run webpack (default command, can be omitted).
 
-  Usage: webpack build|bundle|b [entries...] [options]
+Usage: webpack build|bundle|b [entries...] [options]
 
-  Options
-  ────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────
   -c, --config <pathToConfigFile...>  Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
   --config-name <name...>             Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
   -m, --merge                         Merge two or more configurations using 'webpack-merge'.
@@ -649,395 +649,395 @@ exports[`help should show help information for 'build' command using the "--help
   -w, --watch                         Enter watch mode, which rebuilds on file change.
   --watch-options-stdin               Stop watching when stdin stream has ended.
 
-  Global options
-  ────────────────────────────────────────────────────────────────────────
+Global options
+────────────────────────────────────────────────────────────────────────
   --color                             Enable colors on console.
   --no-color                          Disable colors on console.
   -v, --version                       Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
   -h, --help [verbose]                Display help for commands and options.
 
-  ────────────────────────────────────────────────────────────────────────
-  ℹ Run 'webpack --help=verbose' to see all available commands and options.
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information for 'configtest' and respect the "--color" flag using the "--help" option: stderr 1`] = `""`;
 
 exports[`help should show help information for 'configtest' and respect the "--color" flag using the "--help" option: stdout 1`] = `
 "
-  ⬡ webpack configtest
-  ────────────────────────────────────────────────────────────────────────
-  Validate a webpack configuration.
+⬡ webpack configtest
+────────────────────────────────────────────────────────────────────────
+Validate a webpack configuration.
 
-  Usage: webpack configtest|t [config-path]
+Usage: webpack configtest|t [config-path]
 
-  Global options
-  ────────────────────────────────────────────────────────────────────────
+Global options
+────────────────────────────────────────────────────────────────────────
   --color               Enable colors on console.
   --no-color            Disable colors on console.
   -v, --version         Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
   -h, --help [verbose]  Display help for commands and options.
 
-  ────────────────────────────────────────────────────────────────────────
-  ℹ Run 'webpack --help=verbose' to see all available commands and options.
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information for 'configtest' and respect the "--no-color" flag using the "--help" option: stderr 1`] = `""`;
 
 exports[`help should show help information for 'configtest' and respect the "--no-color" flag using the "--help" option: stdout 1`] = `
 "
-  ⬡ webpack configtest
-  ────────────────────────────────────────────────────────────────────────
-  Validate a webpack configuration.
+⬡ webpack configtest
+────────────────────────────────────────────────────────────────────────
+Validate a webpack configuration.
 
-  Usage: webpack configtest|t [config-path]
+Usage: webpack configtest|t [config-path]
 
-  Global options
-  ────────────────────────────────────────────────────────────────────────
+Global options
+────────────────────────────────────────────────────────────────────────
   --color               Enable colors on console.
   --no-color            Disable colors on console.
   -v, --version         Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
   -h, --help [verbose]  Display help for commands and options.
 
-  ────────────────────────────────────────────────────────────────────────
-  ℹ Run 'webpack --help=verbose' to see all available commands and options.
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information for 'configtest' command using command syntax: stderr 1`] = `""`;
 
 exports[`help should show help information for 'configtest' command using command syntax: stdout 1`] = `
 "
-  ⬡ webpack configtest
-  ────────────────────────────────────────────────────────────────────────
-  Validate a webpack configuration.
+⬡ webpack configtest
+────────────────────────────────────────────────────────────────────────
+Validate a webpack configuration.
 
-  Usage: webpack configtest|t [config-path]
+Usage: webpack configtest|t [config-path]
 
-  Global options
-  ────────────────────────────────────────────────────────────────────────
+Global options
+────────────────────────────────────────────────────────────────────────
   --color               Enable colors on console.
   --no-color            Disable colors on console.
   -v, --version         Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
   -h, --help [verbose]  Display help for commands and options.
 
-  ────────────────────────────────────────────────────────────────────────
-  ℹ Run 'webpack --help=verbose' to see all available commands and options.
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information for 'configtest' command using the "--help verbose" option: stderr 1`] = `""`;
 
 exports[`help should show help information for 'configtest' command using the "--help verbose" option: stdout 1`] = `
 "
-  ⬡ webpack configtest
-  ────────────────────────────────────────────────────────────────────────
-  Validate a webpack configuration.
+⬡ webpack configtest
+────────────────────────────────────────────────────────────────────────
+Validate a webpack configuration.
 
-  Usage: webpack configtest|t [config-path]
+Usage: webpack configtest|t [config-path]
 
-  Global options
-  ────────────────────────────────────────────────────────────────────────
+Global options
+────────────────────────────────────────────────────────────────────────
   --color               Enable colors on console.
   --no-color            Disable colors on console.
   -v, --version         Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
   -h, --help [verbose]  Display help for commands and options.
 
-  ────────────────────────────────────────────────────────────────────────
+────────────────────────────────────────────────────────────────────────
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information for 'configtest' command using the "--help" option: stderr 1`] = `""`;
 
 exports[`help should show help information for 'configtest' command using the "--help" option: stdout 1`] = `
 "
-  ⬡ webpack configtest
-  ────────────────────────────────────────────────────────────────────────
-  Validate a webpack configuration.
+⬡ webpack configtest
+────────────────────────────────────────────────────────────────────────
+Validate a webpack configuration.
 
-  Usage: webpack configtest|t [config-path]
+Usage: webpack configtest|t [config-path]
 
-  Global options
-  ────────────────────────────────────────────────────────────────────────
+Global options
+────────────────────────────────────────────────────────────────────────
   --color               Enable colors on console.
   --no-color            Disable colors on console.
   -v, --version         Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
   -h, --help [verbose]  Display help for commands and options.
 
-  ────────────────────────────────────────────────────────────────────────
-  ℹ Run 'webpack --help=verbose' to see all available commands and options.
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information for 'i' command using command syntax: stderr 1`] = `""`;
 
 exports[`help should show help information for 'i' command using command syntax: stdout 1`] = `
 "
-  ⬡ webpack info
-  ────────────────────────────────────────────────────────────────────────
-  Outputs information about your system.
+⬡ webpack info
+────────────────────────────────────────────────────────────────────────
+Outputs information about your system.
 
-  Usage: webpack info|i [options]
+Usage: webpack info|i [options]
 
-  Options
-  ────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────
   -o, --output <value>                 To get the output in a specified format (accept json or markdown)
   -a, --additional-package <value...>  Adds additional packages to the output
 
-  Global options
-  ────────────────────────────────────────────────────────────────────────
+Global options
+────────────────────────────────────────────────────────────────────────
   --color                              Enable colors on console.
   --no-color                           Disable colors on console.
   -v, --version                        Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
   -h, --help [verbose]                 Display help for commands and options.
 
-  ────────────────────────────────────────────────────────────────────────
-  ℹ Run 'webpack --help=verbose' to see all available commands and options.
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information for 'i' command using the "--help verbose" option: stderr 1`] = `""`;
 
 exports[`help should show help information for 'i' command using the "--help verbose" option: stdout 1`] = `
 "
-  ⬡ webpack info
-  ────────────────────────────────────────────────────────────────────────
-  Outputs information about your system.
+⬡ webpack info
+────────────────────────────────────────────────────────────────────────
+Outputs information about your system.
 
-  Usage: webpack info|i [options]
+Usage: webpack info|i [options]
 
-  Options
-  ────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────
   -o, --output <value>                 To get the output in a specified format (accept json or markdown)
   -a, --additional-package <value...>  Adds additional packages to the output
 
-  Global options
-  ────────────────────────────────────────────────────────────────────────
+Global options
+────────────────────────────────────────────────────────────────────────
   --color                              Enable colors on console.
   --no-color                           Disable colors on console.
   -v, --version                        Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
   -h, --help [verbose]                 Display help for commands and options.
 
-  ────────────────────────────────────────────────────────────────────────
+────────────────────────────────────────────────────────────────────────
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information for 'i' command using the "--help" option: stderr 1`] = `""`;
 
 exports[`help should show help information for 'i' command using the "--help" option: stdout 1`] = `
 "
-  ⬡ webpack info
-  ────────────────────────────────────────────────────────────────────────
-  Outputs information about your system.
+⬡ webpack info
+────────────────────────────────────────────────────────────────────────
+Outputs information about your system.
 
-  Usage: webpack info|i [options]
+Usage: webpack info|i [options]
 
-  Options
-  ────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────
   -o, --output <value>                 To get the output in a specified format (accept json or markdown)
   -a, --additional-package <value...>  Adds additional packages to the output
 
-  Global options
-  ────────────────────────────────────────────────────────────────────────
+Global options
+────────────────────────────────────────────────────────────────────────
   --color                              Enable colors on console.
   --no-color                           Disable colors on console.
   -v, --version                        Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
   -h, --help [verbose]                 Display help for commands and options.
 
-  ────────────────────────────────────────────────────────────────────────
-  ℹ Run 'webpack --help=verbose' to see all available commands and options.
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information for 'info' and respect the "--color" flag using the "--help" option: stderr 1`] = `""`;
 
 exports[`help should show help information for 'info' and respect the "--color" flag using the "--help" option: stdout 1`] = `
 "
-  ⬡ webpack info
-  ────────────────────────────────────────────────────────────────────────
-  Outputs information about your system.
+⬡ webpack info
+────────────────────────────────────────────────────────────────────────
+Outputs information about your system.
 
-  Usage: webpack info|i [options]
+Usage: webpack info|i [options]
 
-  Options
-  ────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────
   -o, --output <value>                 To get the output in a specified format (accept json or markdown)
   -a, --additional-package <value...>  Adds additional packages to the output
 
-  Global options
-  ────────────────────────────────────────────────────────────────────────
+Global options
+────────────────────────────────────────────────────────────────────────
   --color                              Enable colors on console.
   --no-color                           Disable colors on console.
   -v, --version                        Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
   -h, --help [verbose]                 Display help for commands and options.
 
-  ────────────────────────────────────────────────────────────────────────
-  ℹ Run 'webpack --help=verbose' to see all available commands and options.
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information for 'info' and respect the "--no-color" flag using the "--help" option: stderr 1`] = `""`;
 
 exports[`help should show help information for 'info' and respect the "--no-color" flag using the "--help" option: stdout 1`] = `
 "
-  ⬡ webpack info
-  ────────────────────────────────────────────────────────────────────────
-  Outputs information about your system.
+⬡ webpack info
+────────────────────────────────────────────────────────────────────────
+Outputs information about your system.
 
-  Usage: webpack info|i [options]
+Usage: webpack info|i [options]
 
-  Options
-  ────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────
   -o, --output <value>                 To get the output in a specified format (accept json or markdown)
   -a, --additional-package <value...>  Adds additional packages to the output
 
-  Global options
-  ────────────────────────────────────────────────────────────────────────
+Global options
+────────────────────────────────────────────────────────────────────────
   --color                              Enable colors on console.
   --no-color                           Disable colors on console.
   -v, --version                        Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
   -h, --help [verbose]                 Display help for commands and options.
 
-  ────────────────────────────────────────────────────────────────────────
-  ℹ Run 'webpack --help=verbose' to see all available commands and options.
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information for 'info' command using command syntax: stderr 1`] = `""`;
 
 exports[`help should show help information for 'info' command using command syntax: stdout 1`] = `
 "
-  ⬡ webpack info
-  ────────────────────────────────────────────────────────────────────────
-  Outputs information about your system.
+⬡ webpack info
+────────────────────────────────────────────────────────────────────────
+Outputs information about your system.
 
-  Usage: webpack info|i [options]
+Usage: webpack info|i [options]
 
-  Options
-  ────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────
   -o, --output <value>                 To get the output in a specified format (accept json or markdown)
   -a, --additional-package <value...>  Adds additional packages to the output
 
-  Global options
-  ────────────────────────────────────────────────────────────────────────
+Global options
+────────────────────────────────────────────────────────────────────────
   --color                              Enable colors on console.
   --no-color                           Disable colors on console.
   -v, --version                        Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
   -h, --help [verbose]                 Display help for commands and options.
 
-  ────────────────────────────────────────────────────────────────────────
-  ℹ Run 'webpack --help=verbose' to see all available commands and options.
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information for 'info' command using the "--help verbose" option: stderr 1`] = `""`;
 
 exports[`help should show help information for 'info' command using the "--help verbose" option: stdout 1`] = `
 "
-  ⬡ webpack info
-  ────────────────────────────────────────────────────────────────────────
-  Outputs information about your system.
+⬡ webpack info
+────────────────────────────────────────────────────────────────────────
+Outputs information about your system.
 
-  Usage: webpack info|i [options]
+Usage: webpack info|i [options]
 
-  Options
-  ────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────
   -o, --output <value>                 To get the output in a specified format (accept json or markdown)
   -a, --additional-package <value...>  Adds additional packages to the output
 
-  Global options
-  ────────────────────────────────────────────────────────────────────────
+Global options
+────────────────────────────────────────────────────────────────────────
   --color                              Enable colors on console.
   --no-color                           Disable colors on console.
   -v, --version                        Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
   -h, --help [verbose]                 Display help for commands and options.
 
-  ────────────────────────────────────────────────────────────────────────
+────────────────────────────────────────────────────────────────────────
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information for 'info' command using the "--help" option: stderr 1`] = `""`;
 
 exports[`help should show help information for 'info' command using the "--help" option: stdout 1`] = `
 "
-  ⬡ webpack info
-  ────────────────────────────────────────────────────────────────────────
-  Outputs information about your system.
+⬡ webpack info
+────────────────────────────────────────────────────────────────────────
+Outputs information about your system.
 
-  Usage: webpack info|i [options]
+Usage: webpack info|i [options]
 
-  Options
-  ────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────
   -o, --output <value>                 To get the output in a specified format (accept json or markdown)
   -a, --additional-package <value...>  Adds additional packages to the output
 
-  Global options
-  ────────────────────────────────────────────────────────────────────────
+Global options
+────────────────────────────────────────────────────────────────────────
   --color                              Enable colors on console.
   --no-color                           Disable colors on console.
   -v, --version                        Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
   -h, --help [verbose]                 Display help for commands and options.
 
-  ────────────────────────────────────────────────────────────────────────
-  ℹ Run 'webpack --help=verbose' to see all available commands and options.
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information for 's' command using command syntax: stderr 1`] = `""`;
 
 exports[`help should show help information for 's' command using command syntax: stdout 1`] = `
 "
-  ⬡ webpack serve
-  ────────────────────────────────────────────────────────────────────────
-  Run the webpack dev server and watch for source file changes while serving.
+⬡ webpack serve
+────────────────────────────────────────────────────────────────────────
+Run the webpack dev server and watch for source file changes while serving.
 
-  Usage: webpack serve|server|s [entries...] [options]
+Usage: webpack serve|server|s [entries...] [options]
 
-  Options
-  ────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────
   -c, --config <pathToConfigFile...>                  Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
   --config-name <name...>                             Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
   -m, --merge                                         Merge two or more configurations using 'webpack-merge'.
@@ -1133,33 +1133,33 @@ exports[`help should show help information for 's' command using command syntax:
   --no-web-socket-server                              Disallows to set web socket server and options.
   --web-socket-server-type <value>                    Allows to set web socket server and options (by default 'ws').
 
-  Global options
-  ────────────────────────────────────────────────────────────────────────
+Global options
+────────────────────────────────────────────────────────────────────────
   --color                                             Enable colors on console.
   --no-color                                          Disable colors on console.
   -v, --version                                       Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
   -h, --help [verbose]                                Display help for commands and options.
 
-  ────────────────────────────────────────────────────────────────────────
-  ℹ Run 'webpack --help=verbose' to see all available commands and options.
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information for 's' command using the "--help verbose" option: stderr 1`] = `""`;
 
 exports[`help should show help information for 's' command using the "--help verbose" option: stdout 1`] = `
 "
-  ⬡ webpack serve
-  ────────────────────────────────────────────────────────────────────────
-  Run the webpack dev server and watch for source file changes while serving.
+⬡ webpack serve
+────────────────────────────────────────────────────────────────────────
+Run the webpack dev server and watch for source file changes while serving.
 
-  Usage: webpack serve|server|s [entries...] [options]
+Usage: webpack serve|server|s [entries...] [options]
 
-  Options
-  ────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────
   -c, --config <pathToConfigFile...>                                                 Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
   --config-name <name...>                                                            Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
   -m, --merge                                                                        Merge two or more configurations using 'webpack-merge'.
@@ -1180,32 +1180,32 @@ exports[`help should show help information for 's' command using the "--help ver
   --cache-max-generations <value>                                                    Number of generations unused cache entries stay in memory cache
     at stack.
 
-  Global options
-  ────────────────────────────────────────────────────────────────────────
+Global options
+────────────────────────────────────────────────────────────────────────
   --color                                                                            Enable colors on console.
   --no-color                                                                         Disable colors on console.
   -v, --version                                                                      Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
   -h, --help [verbose]                                                               Display help for commands and options.
 
-  ────────────────────────────────────────────────────────────────────────
+────────────────────────────────────────────────────────────────────────
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information for 's' command using the "--help" option: stderr 1`] = `""`;
 
 exports[`help should show help information for 's' command using the "--help" option: stdout 1`] = `
 "
-  ⬡ webpack serve
-  ────────────────────────────────────────────────────────────────────────
-  Run the webpack dev server and watch for source file changes while serving.
+⬡ webpack serve
+────────────────────────────────────────────────────────────────────────
+Run the webpack dev server and watch for source file changes while serving.
 
-  Usage: webpack serve|server|s [entries...] [options]
+Usage: webpack serve|server|s [entries...] [options]
 
-  Options
-  ────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────
   -c, --config <pathToConfigFile...>                  Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
   --config-name <name...>                             Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
   -m, --merge                                         Merge two or more configurations using 'webpack-merge'.
@@ -1301,33 +1301,33 @@ exports[`help should show help information for 's' command using the "--help" op
   --no-web-socket-server                              Disallows to set web socket server and options.
   --web-socket-server-type <value>                    Allows to set web socket server and options (by default 'ws').
 
-  Global options
-  ────────────────────────────────────────────────────────────────────────
+Global options
+────────────────────────────────────────────────────────────────────────
   --color                                             Enable colors on console.
   --no-color                                          Disable colors on console.
   -v, --version                                       Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
   -h, --help [verbose]                                Display help for commands and options.
 
-  ────────────────────────────────────────────────────────────────────────
-  ℹ Run 'webpack --help=verbose' to see all available commands and options.
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information for 'serve' and respect the "--color" flag using the "--help" option: stderr 1`] = `""`;
 
 exports[`help should show help information for 'serve' and respect the "--color" flag using the "--help" option: stdout 1`] = `
 "
-  ⬡ webpack serve
-  ────────────────────────────────────────────────────────────────────────
-  Run the webpack dev server and watch for source file changes while serving.
+⬡ webpack serve
+────────────────────────────────────────────────────────────────────────
+Run the webpack dev server and watch for source file changes while serving.
 
-  Usage: webpack serve|server|s [entries...] [options]
+Usage: webpack serve|server|s [entries...] [options]
 
-  Options
-  ────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────
   -c, --config <pathToConfigFile...>                  Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
   --config-name <name...>                             Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
   -m, --merge                                         Merge two or more configurations using 'webpack-merge'.
@@ -1423,33 +1423,33 @@ exports[`help should show help information for 'serve' and respect the "--color"
   --no-web-socket-server                              Disallows to set web socket server and options.
   --web-socket-server-type <value>                    Allows to set web socket server and options (by default 'ws').
 
-  Global options
-  ────────────────────────────────────────────────────────────────────────
+Global options
+────────────────────────────────────────────────────────────────────────
   --color                                             Enable colors on console.
   --no-color                                          Disable colors on console.
   -v, --version                                       Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
   -h, --help [verbose]                                Display help for commands and options.
 
-  ────────────────────────────────────────────────────────────────────────
-  ℹ Run 'webpack --help=verbose' to see all available commands and options.
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information for 'serve' and respect the "--no-color" flag using the "--help" option: stderr 1`] = `""`;
 
 exports[`help should show help information for 'serve' and respect the "--no-color" flag using the "--help" option: stdout 1`] = `
 "
-  ⬡ webpack serve
-  ────────────────────────────────────────────────────────────────────────
-  Run the webpack dev server and watch for source file changes while serving.
+⬡ webpack serve
+────────────────────────────────────────────────────────────────────────
+Run the webpack dev server and watch for source file changes while serving.
 
-  Usage: webpack serve|server|s [entries...] [options]
+Usage: webpack serve|server|s [entries...] [options]
 
-  Options
-  ────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────
   -c, --config <pathToConfigFile...>                  Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
   --config-name <name...>                             Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
   -m, --merge                                         Merge two or more configurations using 'webpack-merge'.
@@ -1545,33 +1545,33 @@ exports[`help should show help information for 'serve' and respect the "--no-col
   --no-web-socket-server                              Disallows to set web socket server and options.
   --web-socket-server-type <value>                    Allows to set web socket server and options (by default 'ws').
 
-  Global options
-  ────────────────────────────────────────────────────────────────────────
+Global options
+────────────────────────────────────────────────────────────────────────
   --color                                             Enable colors on console.
   --no-color                                          Disable colors on console.
   -v, --version                                       Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
   -h, --help [verbose]                                Display help for commands and options.
 
-  ────────────────────────────────────────────────────────────────────────
-  ℹ Run 'webpack --help=verbose' to see all available commands and options.
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information for 'serve' command using command syntax: stderr 1`] = `""`;
 
 exports[`help should show help information for 'serve' command using command syntax: stdout 1`] = `
 "
-  ⬡ webpack serve
-  ────────────────────────────────────────────────────────────────────────
-  Run the webpack dev server and watch for source file changes while serving.
+⬡ webpack serve
+────────────────────────────────────────────────────────────────────────
+Run the webpack dev server and watch for source file changes while serving.
 
-  Usage: webpack serve|server|s [entries...] [options]
+Usage: webpack serve|server|s [entries...] [options]
 
-  Options
-  ────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────
   -c, --config <pathToConfigFile...>                  Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
   --config-name <name...>                             Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
   -m, --merge                                         Merge two or more configurations using 'webpack-merge'.
@@ -1667,33 +1667,33 @@ exports[`help should show help information for 'serve' command using command syn
   --no-web-socket-server                              Disallows to set web socket server and options.
   --web-socket-server-type <value>                    Allows to set web socket server and options (by default 'ws').
 
-  Global options
-  ────────────────────────────────────────────────────────────────────────
+Global options
+────────────────────────────────────────────────────────────────────────
   --color                                             Enable colors on console.
   --no-color                                          Disable colors on console.
   -v, --version                                       Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
   -h, --help [verbose]                                Display help for commands and options.
 
-  ────────────────────────────────────────────────────────────────────────
-  ℹ Run 'webpack --help=verbose' to see all available commands and options.
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information for 'serve' command using the "--help verbose" option: stderr 1`] = `""`;
 
 exports[`help should show help information for 'serve' command using the "--help verbose" option: stdout 1`] = `
 "
-  ⬡ webpack serve
-  ────────────────────────────────────────────────────────────────────────
-  Run the webpack dev server and watch for source file changes while serving.
+⬡ webpack serve
+────────────────────────────────────────────────────────────────────────
+Run the webpack dev server and watch for source file changes while serving.
 
-  Usage: webpack serve|server|s [entries...] [options]
+Usage: webpack serve|server|s [entries...] [options]
 
-  Options
-  ────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────
   -c, --config <pathToConfigFile...>                                                 Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
   --config-name <name...>                                                            Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
   -m, --merge                                                                        Merge two or more configurations using 'webpack-merge'.
@@ -1714,32 +1714,32 @@ exports[`help should show help information for 'serve' command using the "--help
   --cache-max-generations <value>                                                    Number of generations unused cache entries stay in memory cache
     at stack.
 
-  Global options
-  ────────────────────────────────────────────────────────────────────────
+Global options
+────────────────────────────────────────────────────────────────────────
   --color                                                                            Enable colors on console.
   --no-color                                                                         Disable colors on console.
   -v, --version                                                                      Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
   -h, --help [verbose]                                                               Display help for commands and options.
 
-  ────────────────────────────────────────────────────────────────────────
+────────────────────────────────────────────────────────────────────────
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information for 'serve' command using the "--help" option: stderr 1`] = `""`;
 
 exports[`help should show help information for 'serve' command using the "--help" option: stdout 1`] = `
 "
-  ⬡ webpack serve
-  ────────────────────────────────────────────────────────────────────────
-  Run the webpack dev server and watch for source file changes while serving.
+⬡ webpack serve
+────────────────────────────────────────────────────────────────────────
+Run the webpack dev server and watch for source file changes while serving.
 
-  Usage: webpack serve|server|s [entries...] [options]
+Usage: webpack serve|server|s [entries...] [options]
 
-  Options
-  ────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────
   -c, --config <pathToConfigFile...>                  Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
   --config-name <name...>                             Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
   -m, --merge                                         Merge two or more configurations using 'webpack-merge'.
@@ -1835,33 +1835,33 @@ exports[`help should show help information for 'serve' command using the "--help
   --no-web-socket-server                              Disallows to set web socket server and options.
   --web-socket-server-type <value>                    Allows to set web socket server and options (by default 'ws').
 
-  Global options
-  ────────────────────────────────────────────────────────────────────────
+Global options
+────────────────────────────────────────────────────────────────────────
   --color                                             Enable colors on console.
   --no-color                                          Disable colors on console.
   -v, --version                                       Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
   -h, --help [verbose]                                Display help for commands and options.
 
-  ────────────────────────────────────────────────────────────────────────
-  ℹ Run 'webpack --help=verbose' to see all available commands and options.
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information for 'server' command using command syntax: stderr 1`] = `""`;
 
 exports[`help should show help information for 'server' command using command syntax: stdout 1`] = `
 "
-  ⬡ webpack serve
-  ────────────────────────────────────────────────────────────────────────
-  Run the webpack dev server and watch for source file changes while serving.
+⬡ webpack serve
+────────────────────────────────────────────────────────────────────────
+Run the webpack dev server and watch for source file changes while serving.
 
-  Usage: webpack serve|server|s [entries...] [options]
+Usage: webpack serve|server|s [entries...] [options]
 
-  Options
-  ────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────
   -c, --config <pathToConfigFile...>                  Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
   --config-name <name...>                             Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
   -m, --merge                                         Merge two or more configurations using 'webpack-merge'.
@@ -1957,33 +1957,33 @@ exports[`help should show help information for 'server' command using command sy
   --no-web-socket-server                              Disallows to set web socket server and options.
   --web-socket-server-type <value>                    Allows to set web socket server and options (by default 'ws').
 
-  Global options
-  ────────────────────────────────────────────────────────────────────────
+Global options
+────────────────────────────────────────────────────────────────────────
   --color                                             Enable colors on console.
   --no-color                                          Disable colors on console.
   -v, --version                                       Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
   -h, --help [verbose]                                Display help for commands and options.
 
-  ────────────────────────────────────────────────────────────────────────
-  ℹ Run 'webpack --help=verbose' to see all available commands and options.
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information for 'server' command using the "--help verbose" option: stderr 1`] = `""`;
 
 exports[`help should show help information for 'server' command using the "--help verbose" option: stdout 1`] = `
 "
-  ⬡ webpack serve
-  ────────────────────────────────────────────────────────────────────────
-  Run the webpack dev server and watch for source file changes while serving.
+⬡ webpack serve
+────────────────────────────────────────────────────────────────────────
+Run the webpack dev server and watch for source file changes while serving.
 
-  Usage: webpack serve|server|s [entries...] [options]
+Usage: webpack serve|server|s [entries...] [options]
 
-  Options
-  ────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────
   -c, --config <pathToConfigFile...>                                                 Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
   --config-name <name...>                                                            Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
   -m, --merge                                                                        Merge two or more configurations using 'webpack-merge'.
@@ -2004,32 +2004,32 @@ exports[`help should show help information for 'server' command using the "--hel
   --cache-max-generations <value>                                                    Number of generations unused cache entries stay in memory cache
     at stack.
 
-  Global options
-  ────────────────────────────────────────────────────────────────────────
+Global options
+────────────────────────────────────────────────────────────────────────
   --color                                                                            Enable colors on console.
   --no-color                                                                         Disable colors on console.
   -v, --version                                                                      Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
   -h, --help [verbose]                                                               Display help for commands and options.
 
-  ────────────────────────────────────────────────────────────────────────
+────────────────────────────────────────────────────────────────────────
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information for 'server' command using the "--help" option: stderr 1`] = `""`;
 
 exports[`help should show help information for 'server' command using the "--help" option: stdout 1`] = `
 "
-  ⬡ webpack serve
-  ────────────────────────────────────────────────────────────────────────
-  Run the webpack dev server and watch for source file changes while serving.
+⬡ webpack serve
+────────────────────────────────────────────────────────────────────────
+Run the webpack dev server and watch for source file changes while serving.
 
-  Usage: webpack serve|server|s [entries...] [options]
+Usage: webpack serve|server|s [entries...] [options]
 
-  Options
-  ────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────
   -c, --config <pathToConfigFile...>                  Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
   --config-name <name...>                             Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
   -m, --merge                                         Merge two or more configurations using 'webpack-merge'.
@@ -2125,107 +2125,107 @@ exports[`help should show help information for 'server' command using the "--hel
   --no-web-socket-server                              Disallows to set web socket server and options.
   --web-socket-server-type <value>                    Allows to set web socket server and options (by default 'ws').
 
-  Global options
-  ────────────────────────────────────────────────────────────────────────
+Global options
+────────────────────────────────────────────────────────────────────────
   --color                                             Enable colors on console.
   --no-color                                          Disable colors on console.
   -v, --version                                       Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
   -h, --help [verbose]                                Display help for commands and options.
 
-  ────────────────────────────────────────────────────────────────────────
-  ℹ Run 'webpack --help=verbose' to see all available commands and options.
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information for 't' command using command syntax: stderr 1`] = `""`;
 
 exports[`help should show help information for 't' command using command syntax: stdout 1`] = `
 "
-  ⬡ webpack configtest
-  ────────────────────────────────────────────────────────────────────────
-  Validate a webpack configuration.
+⬡ webpack configtest
+────────────────────────────────────────────────────────────────────────
+Validate a webpack configuration.
 
-  Usage: webpack configtest|t [config-path]
+Usage: webpack configtest|t [config-path]
 
-  Global options
-  ────────────────────────────────────────────────────────────────────────
+Global options
+────────────────────────────────────────────────────────────────────────
   --color               Enable colors on console.
   --no-color            Disable colors on console.
   -v, --version         Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
   -h, --help [verbose]  Display help for commands and options.
 
-  ────────────────────────────────────────────────────────────────────────
-  ℹ Run 'webpack --help=verbose' to see all available commands and options.
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information for 't' command using the "--help verbose" option: stderr 1`] = `""`;
 
 exports[`help should show help information for 't' command using the "--help verbose" option: stdout 1`] = `
 "
-  ⬡ webpack configtest
-  ────────────────────────────────────────────────────────────────────────
-  Validate a webpack configuration.
+⬡ webpack configtest
+────────────────────────────────────────────────────────────────────────
+Validate a webpack configuration.
 
-  Usage: webpack configtest|t [config-path]
+Usage: webpack configtest|t [config-path]
 
-  Global options
-  ────────────────────────────────────────────────────────────────────────
+Global options
+────────────────────────────────────────────────────────────────────────
   --color               Enable colors on console.
   --no-color            Disable colors on console.
   -v, --version         Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
   -h, --help [verbose]  Display help for commands and options.
 
-  ────────────────────────────────────────────────────────────────────────
+────────────────────────────────────────────────────────────────────────
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information for 't' command using the "--help" option: stderr 1`] = `""`;
 
 exports[`help should show help information for 't' command using the "--help" option: stdout 1`] = `
 "
-  ⬡ webpack configtest
-  ────────────────────────────────────────────────────────────────────────
-  Validate a webpack configuration.
+⬡ webpack configtest
+────────────────────────────────────────────────────────────────────────
+Validate a webpack configuration.
 
-  Usage: webpack configtest|t [config-path]
+Usage: webpack configtest|t [config-path]
 
-  Global options
-  ────────────────────────────────────────────────────────────────────────
+Global options
+────────────────────────────────────────────────────────────────────────
   --color               Enable colors on console.
   --no-color            Disable colors on console.
   -v, --version         Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
   -h, --help [verbose]  Display help for commands and options.
 
-  ────────────────────────────────────────────────────────────────────────
-  ℹ Run 'webpack --help=verbose' to see all available commands and options.
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information for 'w' command using command syntax: stderr 1`] = `""`;
 
 exports[`help should show help information for 'w' command using command syntax: stdout 1`] = `
 "
-  ⬡ webpack watch
-  ────────────────────────────────────────────────────────────────────────
-  Run webpack and watch for files changes.
+⬡ webpack watch
+────────────────────────────────────────────────────────────────────────
+Run webpack and watch for files changes.
 
-  Usage: webpack watch|w [entries...] [options]
+Usage: webpack watch|w [entries...] [options]
 
-  Options
-  ────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────
   -c, --config <pathToConfigFile...>  Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
   --config-name <name...>             Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
   -m, --merge                         Merge two or more configurations using 'webpack-merge'.
@@ -2247,33 +2247,33 @@ exports[`help should show help information for 'w' command using command syntax:
   -t, --target <value...>             Specific environment, runtime, or syntax. Environment to build for. An array of environments to build for all of them when possible.
   --watch-options-stdin               Stop watching when stdin stream has ended.
 
-  Global options
-  ────────────────────────────────────────────────────────────────────────
+Global options
+────────────────────────────────────────────────────────────────────────
   --color                             Enable colors on console.
   --no-color                          Disable colors on console.
   -v, --version                       Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
   -h, --help [verbose]                Display help for commands and options.
 
-  ────────────────────────────────────────────────────────────────────────
-  ℹ Run 'webpack --help=verbose' to see all available commands and options.
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information for 'w' command using the "--help verbose" option: stderr 1`] = `""`;
 
 exports[`help should show help information for 'w' command using the "--help verbose" option: stdout 1`] = `
 "
-  ⬡ webpack watch
-  ────────────────────────────────────────────────────────────────────────
-  Run webpack and watch for files changes.
+⬡ webpack watch
+────────────────────────────────────────────────────────────────────────
+Run webpack and watch for files changes.
 
-  Usage: webpack watch|w [entries...] [options]
+Usage: webpack watch|w [entries...] [options]
 
-  Options
-  ────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────
   -c, --config <pathToConfigFile...>                                                 Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
   --config-name <name...>                                                            Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
   -m, --merge                                                                        Merge two or more configurations using 'webpack-merge'.
@@ -2298,32 +2298,32 @@ exports[`help should show help information for 'w' command using the "--help ver
   --watch-options-stdin                                                              Stop watching when stdin stream has ended.
   --no-watch-options-stdin                                                           Negative 'watch-options-stdin' option.
 
-  Global options
-  ────────────────────────────────────────────────────────────────────────
+Global options
+────────────────────────────────────────────────────────────────────────
   --color                                                                            Enable colors on console.
   --no-color                                                                         Disable colors on console.
   -v, --version                                                                      Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
   -h, --help [verbose]                                                               Display help for commands and options.
 
-  ────────────────────────────────────────────────────────────────────────
+────────────────────────────────────────────────────────────────────────
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information for 'w' command using the "--help" option: stderr 1`] = `""`;
 
 exports[`help should show help information for 'w' command using the "--help" option: stdout 1`] = `
 "
-  ⬡ webpack watch
-  ────────────────────────────────────────────────────────────────────────
-  Run webpack and watch for files changes.
+⬡ webpack watch
+────────────────────────────────────────────────────────────────────────
+Run webpack and watch for files changes.
 
-  Usage: webpack watch|w [entries...] [options]
+Usage: webpack watch|w [entries...] [options]
 
-  Options
-  ────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────
   -c, --config <pathToConfigFile...>  Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
   --config-name <name...>             Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
   -m, --merge                         Merge two or more configurations using 'webpack-merge'.
@@ -2345,33 +2345,33 @@ exports[`help should show help information for 'w' command using the "--help" op
   -t, --target <value...>             Specific environment, runtime, or syntax. Environment to build for. An array of environments to build for all of them when possible.
   --watch-options-stdin               Stop watching when stdin stream has ended.
 
-  Global options
-  ────────────────────────────────────────────────────────────────────────
+Global options
+────────────────────────────────────────────────────────────────────────
   --color                             Enable colors on console.
   --no-color                          Disable colors on console.
   -v, --version                       Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
   -h, --help [verbose]                Display help for commands and options.
 
-  ────────────────────────────────────────────────────────────────────────
-  ℹ Run 'webpack --help=verbose' to see all available commands and options.
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information for 'watch' and respect the "--color" flag using the "--help" option: stderr 1`] = `""`;
 
 exports[`help should show help information for 'watch' and respect the "--color" flag using the "--help" option: stdout 1`] = `
 "
-  ⬡ webpack watch
-  ────────────────────────────────────────────────────────────────────────
-  Run webpack and watch for files changes.
+⬡ webpack watch
+────────────────────────────────────────────────────────────────────────
+Run webpack and watch for files changes.
 
-  Usage: webpack watch|w [entries...] [options]
+Usage: webpack watch|w [entries...] [options]
 
-  Options
-  ────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────
   -c, --config <pathToConfigFile...>  Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
   --config-name <name...>             Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
   -m, --merge                         Merge two or more configurations using 'webpack-merge'.
@@ -2393,33 +2393,33 @@ exports[`help should show help information for 'watch' and respect the "--color"
   -t, --target <value...>             Specific environment, runtime, or syntax. Environment to build for. An array of environments to build for all of them when possible.
   --watch-options-stdin               Stop watching when stdin stream has ended.
 
-  Global options
-  ────────────────────────────────────────────────────────────────────────
+Global options
+────────────────────────────────────────────────────────────────────────
   --color                             Enable colors on console.
   --no-color                          Disable colors on console.
   -v, --version                       Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
   -h, --help [verbose]                Display help for commands and options.
 
-  ────────────────────────────────────────────────────────────────────────
-  ℹ Run 'webpack --help=verbose' to see all available commands and options.
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information for 'watch' and respect the "--no-color" flag using the "--help" option: stderr 1`] = `""`;
 
 exports[`help should show help information for 'watch' and respect the "--no-color" flag using the "--help" option: stdout 1`] = `
 "
-  ⬡ webpack watch
-  ────────────────────────────────────────────────────────────────────────
-  Run webpack and watch for files changes.
+⬡ webpack watch
+────────────────────────────────────────────────────────────────────────
+Run webpack and watch for files changes.
 
-  Usage: webpack watch|w [entries...] [options]
+Usage: webpack watch|w [entries...] [options]
 
-  Options
-  ────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────
   -c, --config <pathToConfigFile...>  Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
   --config-name <name...>             Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
   -m, --merge                         Merge two or more configurations using 'webpack-merge'.
@@ -2441,33 +2441,33 @@ exports[`help should show help information for 'watch' and respect the "--no-col
   -t, --target <value...>             Specific environment, runtime, or syntax. Environment to build for. An array of environments to build for all of them when possible.
   --watch-options-stdin               Stop watching when stdin stream has ended.
 
-  Global options
-  ────────────────────────────────────────────────────────────────────────
+Global options
+────────────────────────────────────────────────────────────────────────
   --color                             Enable colors on console.
   --no-color                          Disable colors on console.
   -v, --version                       Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
   -h, --help [verbose]                Display help for commands and options.
 
-  ────────────────────────────────────────────────────────────────────────
-  ℹ Run 'webpack --help=verbose' to see all available commands and options.
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information for 'watch' command using command syntax: stderr 1`] = `""`;
 
 exports[`help should show help information for 'watch' command using command syntax: stdout 1`] = `
 "
-  ⬡ webpack watch
-  ────────────────────────────────────────────────────────────────────────
-  Run webpack and watch for files changes.
+⬡ webpack watch
+────────────────────────────────────────────────────────────────────────
+Run webpack and watch for files changes.
 
-  Usage: webpack watch|w [entries...] [options]
+Usage: webpack watch|w [entries...] [options]
 
-  Options
-  ────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────
   -c, --config <pathToConfigFile...>  Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
   --config-name <name...>             Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
   -m, --merge                         Merge two or more configurations using 'webpack-merge'.
@@ -2489,33 +2489,33 @@ exports[`help should show help information for 'watch' command using command syn
   -t, --target <value...>             Specific environment, runtime, or syntax. Environment to build for. An array of environments to build for all of them when possible.
   --watch-options-stdin               Stop watching when stdin stream has ended.
 
-  Global options
-  ────────────────────────────────────────────────────────────────────────
+Global options
+────────────────────────────────────────────────────────────────────────
   --color                             Enable colors on console.
   --no-color                          Disable colors on console.
   -v, --version                       Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
   -h, --help [verbose]                Display help for commands and options.
 
-  ────────────────────────────────────────────────────────────────────────
-  ℹ Run 'webpack --help=verbose' to see all available commands and options.
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information for 'watch' command using the "--help verbose" option: stderr 1`] = `""`;
 
 exports[`help should show help information for 'watch' command using the "--help verbose" option: stdout 1`] = `
 "
-  ⬡ webpack watch
-  ────────────────────────────────────────────────────────────────────────
-  Run webpack and watch for files changes.
+⬡ webpack watch
+────────────────────────────────────────────────────────────────────────
+Run webpack and watch for files changes.
 
-  Usage: webpack watch|w [entries...] [options]
+Usage: webpack watch|w [entries...] [options]
 
-  Options
-  ────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────
   -c, --config <pathToConfigFile...>                                                 Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
   --config-name <name...>                                                            Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
   -m, --merge                                                                        Merge two or more configurations using 'webpack-merge'.
@@ -2540,32 +2540,32 @@ exports[`help should show help information for 'watch' command using the "--help
   --watch-options-stdin                                                              Stop watching when stdin stream has ended.
   --no-watch-options-stdin                                                           Negative 'watch-options-stdin' option.
 
-  Global options
-  ────────────────────────────────────────────────────────────────────────
+Global options
+────────────────────────────────────────────────────────────────────────
   --color                                                                            Enable colors on console.
   --no-color                                                                         Disable colors on console.
   -v, --version                                                                      Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
   -h, --help [verbose]                                                               Display help for commands and options.
 
-  ────────────────────────────────────────────────────────────────────────
+────────────────────────────────────────────────────────────────────────
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information for 'watch' command using the "--help" option: stderr 1`] = `""`;
 
 exports[`help should show help information for 'watch' command using the "--help" option: stdout 1`] = `
 "
-  ⬡ webpack watch
-  ────────────────────────────────────────────────────────────────────────
-  Run webpack and watch for files changes.
+⬡ webpack watch
+────────────────────────────────────────────────────────────────────────
+Run webpack and watch for files changes.
 
-  Usage: webpack watch|w [entries...] [options]
+Usage: webpack watch|w [entries...] [options]
 
-  Options
-  ────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────
   -c, --config <pathToConfigFile...>  Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
   --config-name <name...>             Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
   -m, --merge                         Merge two or more configurations using 'webpack-merge'.
@@ -2587,34 +2587,34 @@ exports[`help should show help information for 'watch' command using the "--help
   -t, --target <value...>             Specific environment, runtime, or syntax. Environment to build for. An array of environments to build for all of them when possible.
   --watch-options-stdin               Stop watching when stdin stream has ended.
 
-  Global options
-  ────────────────────────────────────────────────────────────────────────
+Global options
+────────────────────────────────────────────────────────────────────────
   --color                             Enable colors on console.
   --no-color                          Disable colors on console.
   -v, --version                       Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
   -h, --help [verbose]                Display help for commands and options.
 
-  ────────────────────────────────────────────────────────────────────────
-  ℹ Run 'webpack --help=verbose' to see all available commands and options.
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information using command syntax: stderr 1`] = `""`;
 
 exports[`help should show help information using command syntax: stdout 1`] = `
 "
-  ⬡ webpack
-  ────────────────────────────────────────────────────────────────────────
-  The build tool for modern web applications.
+⬡ webpack
+────────────────────────────────────────────────────────────────────────
+The build tool for modern web applications.
 
-  Usage: webpack [entries...] [options]
+Usage: webpack [entries...] [options]
   Alternative usage to run commands: webpack [command] [options]
 
-  Options
-  ────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────
   -c, --config <pathToConfigFile...>     Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
   --config-name <name...>                Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
   -m, --merge                            Merge two or more configurations using 'webpack-merge'.
@@ -2637,15 +2637,15 @@ exports[`help should show help information using command syntax: stdout 1`] = `
   -w, --watch                            Enter watch mode, which rebuilds on file change.
   --watch-options-stdin                  Stop watching when stdin stream has ended.
 
-  Global options
-  ────────────────────────────────────────────────────────────────────────
+Global options
+────────────────────────────────────────────────────────────────────────
   --color                                Enable colors on console.
   --no-color                             Disable colors on console.
   -v, --version                          Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
   -h, --help [verbose]                   Display help for commands and options.
 
-  Commands
-  ────────────────────────────────────────────────────────────────────────
+Commands
+────────────────────────────────────────────────────────────────────────
   build|bundle|b [entries...] [options]  Run webpack (default command, can be omitted).
   configtest|t [config-path]             Validate a webpack configuration.
   help|h [command] [option]              Display help for commands and options.
@@ -2654,57 +2654,57 @@ exports[`help should show help information using command syntax: stdout 1`] = `
   version|v [options]                    Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
   watch|w [entries...] [options]         Run webpack and watch for files changes.
 
-  ────────────────────────────────────────────────────────────────────────
-  ℹ Run 'webpack --help=verbose' to see all available commands and options.
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information using the "--help" option with the "verbose" value #2: stderr 1`] = `""`;
 
 exports[`help should show help information using the "--help" option with the "verbose" value #2: stdout 1`] = `
 "
-  ⬡ webpack
-  ────────────────────────────────────────────────────────────────────────
-  The build tool for modern web applications.
+⬡ webpack
+────────────────────────────────────────────────────────────────────────
+The build tool for modern web applications.
 
-  Usage: w
+Usage: webpack [
 ...
- documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+pack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information using the "--help" option with the "verbose" value: stderr 1`] = `""`;
 
 exports[`help should show help information using the "--help" option with the "verbose" value: stdout 1`] = `
 "
-  ⬡ webpack
-  ────────────────────────────────────────────────────────────────────────
-  The build tool for modern web applications.
+⬡ webpack
+────────────────────────────────────────────────────────────────────────
+The build tool for modern web applications.
 
-  Usage: w
+Usage: webpack [
 ...
- documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+pack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information using the "--help" option: stderr 1`] = `""`;
 
 exports[`help should show help information using the "--help" option: stdout 1`] = `
 "
-  ⬡ webpack
-  ────────────────────────────────────────────────────────────────────────
-  The build tool for modern web applications.
+⬡ webpack
+────────────────────────────────────────────────────────────────────────
+The build tool for modern web applications.
 
-  Usage: webpack [entries...] [options]
+Usage: webpack [entries...] [options]
   Alternative usage to run commands: webpack [command] [options]
 
-  Options
-  ────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────
   -c, --config <pathToConfigFile...>     Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
   --config-name <name...>                Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
   -m, --merge                            Merge two or more configurations using 'webpack-merge'.
@@ -2727,15 +2727,15 @@ exports[`help should show help information using the "--help" option: stdout 1`]
   -w, --watch                            Enter watch mode, which rebuilds on file change.
   --watch-options-stdin                  Stop watching when stdin stream has ended.
 
-  Global options
-  ────────────────────────────────────────────────────────────────────────
+Global options
+────────────────────────────────────────────────────────────────────────
   --color                                Enable colors on console.
   --no-color                             Disable colors on console.
   -v, --version                          Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
   -h, --help [verbose]                   Display help for commands and options.
 
-  Commands
-  ────────────────────────────────────────────────────────────────────────
+Commands
+────────────────────────────────────────────────────────────────────────
   build|bundle|b [entries...] [options]  Run webpack (default command, can be omitted).
   configtest|t [config-path]             Validate a webpack configuration.
   help|h [command] [option]              Display help for commands and options.
@@ -2744,308 +2744,308 @@ exports[`help should show help information using the "--help" option: stdout 1`]
   version|v [options]                    Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
   watch|w [entries...] [options]         Run webpack and watch for files changes.
 
-  ────────────────────────────────────────────────────────────────────────
-  ℹ Run 'webpack --help=verbose' to see all available commands and options.
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information using the "help --cache-type" option when using serve: stderr 1`] = `""`;
 
 exports[`help should show help information using the "help --cache-type" option when using serve: stdout 1`] = `
 "
-  ⬡ --cache-type
-  ────────────────────────────────────────────────────────────────────────
+⬡ --cache-type
+────────────────────────────────────────────────────────────────────────
   Usage: webpack serve --cache-type <value>
   Description: In memory caching. Filesystem caching.
   Possible values: 'memory' | 'filesystem'
-  ────────────────────────────────────────────────────────────────────────
+────────────────────────────────────────────────────────────────────────
 
-  ℹ Run 'webpack --help=verbose' to see all available commands and options.
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information using the "help --cache-type" option: stderr 1`] = `""`;
 
 exports[`help should show help information using the "help --cache-type" option: stdout 1`] = `
 "
-  ⬡ --cache-type
-  ────────────────────────────────────────────────────────────────────────
+⬡ --cache-type
+────────────────────────────────────────────────────────────────────────
   Usage: webpack --cache-type <value>
   Description: In memory caching. Filesystem caching.
   Possible values: 'memory' | 'filesystem'
-  ────────────────────────────────────────────────────────────────────────
+────────────────────────────────────────────────────────────────────────
 
-  ℹ Run 'webpack --help=verbose' to see all available commands and options.
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information using the "help --color" option: stderr 1`] = `""`;
 
 exports[`help should show help information using the "help --color" option: stdout 1`] = `
 "
-  ⬡ --color
-  ────────────────────────────────────────────────────────────────────────
+⬡ --color
+────────────────────────────────────────────────────────────────────────
   Usage: webpack --color
   Description: Enable colors on console.
-  ────────────────────────────────────────────────────────────────────────
+────────────────────────────────────────────────────────────────────────
 
-  ℹ Run 'webpack --help=verbose' to see all available commands and options.
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information using the "help --mode" option: stderr 1`] = `""`;
 
 exports[`help should show help information using the "help --mode" option: stdout 1`] = `
 "
-  ⬡ --mode
-  ────────────────────────────────────────────────────────────────────────
+⬡ --mode
+────────────────────────────────────────────────────────────────────────
   Usage: webpack --mode <value>
   Description: Enable production optimizations or development hints.
   Possible values: 'development' | 'production' | 'none'
-  ────────────────────────────────────────────────────────────────────────
+────────────────────────────────────────────────────────────────────────
 
-  ℹ Run 'webpack --help=verbose' to see all available commands and options.
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information using the "help --no-color" option: stderr 1`] = `""`;
 
 exports[`help should show help information using the "help --no-color" option: stdout 1`] = `
 "
-  ⬡ --no-color
-  ────────────────────────────────────────────────────────────────────────
+⬡ --no-color
+────────────────────────────────────────────────────────────────────────
   Usage: webpack --no-color
   Description: Disable colors on console.
-  ────────────────────────────────────────────────────────────────────────
+────────────────────────────────────────────────────────────────────────
 
-  ℹ Run 'webpack --help=verbose' to see all available commands and options.
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information using the "help --no-stats" option: stderr 1`] = `""`;
 
 exports[`help should show help information using the "help --no-stats" option: stdout 1`] = `
 "
-  ⬡ --no-stats
-  ────────────────────────────────────────────────────────────────────────
+⬡ --no-stats
+────────────────────────────────────────────────────────────────────────
   Usage: webpack --no-stats
   Description: Negative 'stats' option.
-  ────────────────────────────────────────────────────────────────────────
+────────────────────────────────────────────────────────────────────────
 
-  ℹ Run 'webpack --help=verbose' to see all available commands and options.
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information using the "help --output-chunk-format" option: stderr 1`] = `""`;
 
 exports[`help should show help information using the "help --output-chunk-format" option: stdout 1`] = `
 "
-  ⬡ --output-chunk-format
-  ────────────────────────────────────────────────────────────────────────
+⬡ --output-chunk-format
+────────────────────────────────────────────────────────────────────────
   Usage: webpack --output-chunk-format <value>
   Description: The format of chunks (formats included by default are 'array-push' (web/WebWorker), 'commonjs' (node.js), 'module' (ESM), but others might be added by plugins).
   Possible values: 'array-push' | 'commonjs' | 'module' | false
-  ────────────────────────────────────────────────────────────────────────
+────────────────────────────────────────────────────────────────────────
 
-  ℹ Run 'webpack --help=verbose' to see all available commands and options.
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information using the "help --server-type" option when using serve: stderr 1`] = `""`;
 
 exports[`help should show help information using the "help --server-type" option when using serve: stdout 1`] = `
 "
-  ⬡ --server-type
-  ────────────────────────────────────────────────────────────────────────
+⬡ --server-type
+────────────────────────────────────────────────────────────────────────
   Usage: webpack serve --server-type <value>
   Description: Allows to set server and options (by default 'http').
   Possible values: 'http' | 'https' | 'spdy' | 'http2'
-  ────────────────────────────────────────────────────────────────────────
+────────────────────────────────────────────────────────────────────────
 
-  ℹ Run 'webpack --help=verbose' to see all available commands and options.
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information using the "help --stats" option: stderr 1`] = `""`;
 
 exports[`help should show help information using the "help --stats" option: stdout 1`] = `
 "
-  ⬡ --stats
-  ────────────────────────────────────────────────────────────────────────
+⬡ --stats
+────────────────────────────────────────────────────────────────────────
   Usage: webpack --stats [value]
   Description: Stats options object or preset name.
   Possible values: 'none' | 'summary' | 'errors-only' | 'errors-warnings' | 'minimal' | 'normal' | 'detailed' | 'verbose'
-  ────────────────────────────────────────────────────────────────────────
+────────────────────────────────────────────────────────────────────────
 
-  ℹ Run 'webpack --help=verbose' to see all available commands and options.
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information using the "help --target" option: stderr 1`] = `""`;
 
 exports[`help should show help information using the "help --target" option: stdout 1`] = `
 "
-  ⬡ --target
-  ────────────────────────────────────────────────────────────────────────
+⬡ --target
+────────────────────────────────────────────────────────────────────────
   Usage: webpack --target <value...>
   Short: webpack -t <value...>
   Description: Specific environment, runtime, or syntax. Environment to build for. An array of environments to build for all of them when possible.
   Possible values: false
-  ────────────────────────────────────────────────────────────────────────
+────────────────────────────────────────────────────────────────────────
 
-  ℹ Run 'webpack --help=verbose' to see all available commands and options.
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information using the "help --version" option: stderr 1`] = `""`;
 
 exports[`help should show help information using the "help --version" option: stdout 1`] = `
 "
-  ⬡ --version
-  ────────────────────────────────────────────────────────────────────────
+⬡ --version
+────────────────────────────────────────────────────────────────────────
   Usage: webpack --version
   Short: webpack -v
   Description: Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
-  ────────────────────────────────────────────────────────────────────────
+────────────────────────────────────────────────────────────────────────
 
-  ℹ Run 'webpack --help=verbose' to see all available commands and options.
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information using the "help -v" option: stderr 1`] = `""`;
 
 exports[`help should show help information using the "help -v" option: stdout 1`] = `
 "
-  ⬡ --version
-  ────────────────────────────────────────────────────────────────────────
+⬡ --version
+────────────────────────────────────────────────────────────────────────
   Usage: webpack --version
   Short: webpack -v
   Description: Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
-  ────────────────────────────────────────────────────────────────────────
+────────────────────────────────────────────────────────────────────────
 
-  ℹ Run 'webpack --help=verbose' to see all available commands and options.
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information using the "help serve --color" option: stderr 1`] = `""`;
 
 exports[`help should show help information using the "help serve --color" option: stdout 1`] = `
 "
-  ⬡ --color
-  ────────────────────────────────────────────────────────────────────────
+⬡ --color
+────────────────────────────────────────────────────────────────────────
   Usage: webpack serve --color
   Description: Enable colors on console.
-  ────────────────────────────────────────────────────────────────────────
+────────────────────────────────────────────────────────────────────────
 
-  ℹ Run 'webpack --help=verbose' to see all available commands and options.
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information using the "help serve --mode" option: stderr 1`] = `""`;
 
 exports[`help should show help information using the "help serve --mode" option: stdout 1`] = `
 "
-  ⬡ --mode
-  ────────────────────────────────────────────────────────────────────────
+⬡ --mode
+────────────────────────────────────────────────────────────────────────
   Usage: webpack serve --mode <value>
   Description: Enable production optimizations or development hints.
   Possible values: 'development' | 'production' | 'none'
-  ────────────────────────────────────────────────────────────────────────
+────────────────────────────────────────────────────────────────────────
 
-  ℹ Run 'webpack --help=verbose' to see all available commands and options.
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information using the "help serve --no-color" option: stderr 1`] = `""`;
 
 exports[`help should show help information using the "help serve --no-color" option: stdout 1`] = `
 "
-  ⬡ --no-color
-  ────────────────────────────────────────────────────────────────────────
+⬡ --no-color
+────────────────────────────────────────────────────────────────────────
   Usage: webpack serve --no-color
   Description: Disable colors on console.
-  ────────────────────────────────────────────────────────────────────────
+────────────────────────────────────────────────────────────────────────
 
-  ℹ Run 'webpack --help=verbose' to see all available commands and options.
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show help information with options for sub commands: stderr 1`] = `""`;
 
 exports[`help should show help information with options for sub commands: stdout 1`] = `
 "
-  ⬡ webpack info
-  ────────────────────────────────────────────────────────────────────────
-  Outputs information about your system.
+⬡ webpack info
+────────────────────────────────────────────────────────────────────────
+Outputs information about your system.
 
-  Usage: webpack info|i [options]
+Usage: webpack info|i [options]
 
-  Options
-  ────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────
   -o, --output <value>                 To get the output in a specified format (accept json or markdown)
   -a, --additional-package <value...>  Adds additional packages to the output
 
-  Global options
-  ────────────────────────────────────────────────────────────────────────
+Global options
+────────────────────────────────────────────────────────────────────────
   --color                              Enable colors on console.
   --no-color                           Disable colors on console.
   -v, --version                        Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
   -h, --help [verbose]                 Display help for commands and options.
 
-  ────────────────────────────────────────────────────────────────────────
-  ℹ Run 'webpack --help=verbose' to see all available commands and options.
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show the same information using the "--help" option and command syntax: stderr from command syntax 1`] = `""`;
@@ -3054,15 +3054,15 @@ exports[`help should show the same information using the "--help" option and com
 
 exports[`help should show the same information using the "--help" option and command syntax: stdout from command syntax 1`] = `
 "
-  ⬡ webpack
-  ────────────────────────────────────────────────────────────────────────
-  The build tool for modern web applications.
+⬡ webpack
+────────────────────────────────────────────────────────────────────────
+The build tool for modern web applications.
 
-  Usage: webpack [entries...] [options]
+Usage: webpack [entries...] [options]
   Alternative usage to run commands: webpack [command] [options]
 
-  Options
-  ────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────
   -c, --config <pathToConfigFile...>     Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
   --config-name <name...>                Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
   -m, --merge                            Merge two or more configurations using 'webpack-merge'.
@@ -3085,15 +3085,15 @@ exports[`help should show the same information using the "--help" option and com
   -w, --watch                            Enter watch mode, which rebuilds on file change.
   --watch-options-stdin                  Stop watching when stdin stream has ended.
 
-  Global options
-  ────────────────────────────────────────────────────────────────────────
+Global options
+────────────────────────────────────────────────────────────────────────
   --color                                Enable colors on console.
   --no-color                             Disable colors on console.
   -v, --version                          Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
   -h, --help [verbose]                   Display help for commands and options.
 
-  Commands
-  ────────────────────────────────────────────────────────────────────────
+Commands
+────────────────────────────────────────────────────────────────────────
   build|bundle|b [entries...] [options]  Run webpack (default command, can be omitted).
   configtest|t [config-path]             Validate a webpack configuration.
   help|h [command] [option]              Display help for commands and options.
@@ -3102,25 +3102,25 @@ exports[`help should show the same information using the "--help" option and com
   version|v [options]                    Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
   watch|w [entries...] [options]         Run webpack and watch for files changes.
 
-  ────────────────────────────────────────────────────────────────────────
-  ℹ Run 'webpack --help=verbose' to see all available commands and options.
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;
 
 exports[`help should show the same information using the "--help" option and command syntax: stdout from option 1`] = `
 "
-  ⬡ webpack
-  ────────────────────────────────────────────────────────────────────────
-  The build tool for modern web applications.
+⬡ webpack
+────────────────────────────────────────────────────────────────────────
+The build tool for modern web applications.
 
-  Usage: webpack [entries...] [options]
+Usage: webpack [entries...] [options]
   Alternative usage to run commands: webpack [command] [options]
 
-  Options
-  ────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────
   -c, --config <pathToConfigFile...>     Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
   --config-name <name...>                Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
   -m, --merge                            Merge two or more configurations using 'webpack-merge'.
@@ -3143,15 +3143,15 @@ exports[`help should show the same information using the "--help" option and com
   -w, --watch                            Enter watch mode, which rebuilds on file change.
   --watch-options-stdin                  Stop watching when stdin stream has ended.
 
-  Global options
-  ────────────────────────────────────────────────────────────────────────
+Global options
+────────────────────────────────────────────────────────────────────────
   --color                                Enable colors on console.
   --no-color                             Disable colors on console.
   -v, --version                          Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
   -h, --help [verbose]                   Display help for commands and options.
 
-  Commands
-  ────────────────────────────────────────────────────────────────────────
+Commands
+────────────────────────────────────────────────────────────────────────
   build|bundle|b [entries...] [options]  Run webpack (default command, can be omitted).
   configtest|t [config-path]             Validate a webpack configuration.
   help|h [command] [option]              Display help for commands and options.
@@ -3160,10 +3160,10 @@ exports[`help should show the same information using the "--help" option and com
   version|v [options]                    Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
   watch|w [entries...] [options]         Run webpack and watch for files changes.
 
-  ────────────────────────────────────────────────────────────────────────
-  ℹ Run 'webpack --help=verbose' to see all available commands and options.
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;

--- a/test/version/__snapshots__/output.test.js.snap.webpack5
+++ b/test/version/__snapshots__/output.test.js.snap.webpack5
@@ -2,13 +2,13 @@
 
 exports[`'-o, --output <value>' usage gets info text by default: stdout 1`] = `
 "
-  ⬡ webpack version
-  ────────────────────────────────────────────────────────────────────────
-  Installed package versions.
+⬡ webpack version
+────────────────────────────────────────────────────────────────────────
+Installed package versions.
 
 
-  ⬡ Packages:
-  ────────────────────────────────────────────────────────────────────────
+⬡ Packages:
+────────────────────────────────────────────────────────────────────────
   css-loader:               ^x.x.x → x.x.x
   eslint-config-webpack:    ^x.x.x → x.x.x
   sass-loader:              ^x.x.x → x.x.x
@@ -17,10 +17,10 @@ exports[`'-o, --output <value>' usage gets info text by default: stdout 1`] = `
   webpack:                  ^x.x.x → x.x.x
   webpack-bundle-analyzer:  ^x.x.x → x.x.x
   webpack-dev-server:       ^x.x.x → x.x.x
-  ────────────────────────────────────────────────────────────────────────
-  ℹ Run 'webpack --help=verbose' to see all available commands and options.
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
 
-  Webpack documentation:  https://webpack.js.org/
-  CLI documentation:      https://webpack.js.org/api/cli/
-  Made with ♥ by the webpack team"
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
 `;


### PR DESCRIPTION
## What this does

The styled help/info/version/configtest output introduced in #4779 prefixes a two-space gutter to **every** line. This makes the left margin uniform rather than meaningful.

This change makes the indentation **hierarchical**:

- **Column 0:** branded headers (`⬡ webpack …`), dividers, command descriptions, the `Usage:` line, section titles (`Options`, `Global options`, …), status messages (`✖`/`✔`/`⚠`/`ℹ`), and the footer.
- **Indented (two spaces):** only content *nested inside* a section — envinfo rows, option/command lists, and the option-help rows.

So the indent now encodes hierarchy, and output that never went through the renderer (e.g. webpack / dev-server validation errors) keeps its own formatting untouched.

## Before / after (`info`)

```
  ⬡ webpack info                 →   ⬡ webpack info
  ──────────────                     ──────────────
  System and environment …           System and environment …

  ⬡ System:                          ⬡ System:
  ──────────────                     ──────────────
  OS:   Linux …                        OS:   Linux …
```

## Scope

- Single source change: ~11 lines in `webpack-cli.ts` (the shared `#ui*` chrome helpers + the command-help description/usage lines).
- Snapshots regenerated for the framed screens (help / info / version / configtest / CLI API).

## Testing

- Build ✅, lint ✅
- `build` + `serve` + `watch` (473) pass with **0 snapshot changes** — the change is contained to the framed screens; webpack/dev-server error output is unaffected.
- `help` / `info` / `version` / `configtest` / CLI API suites pass with regenerated snapshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TgNXy9shNnZEnbCfsSbtiQ