### PR TITLE
fix(webpack-cli): declare json5/js-yaml/toml as optional peerDependencies

### DIFF
--- a/.changeset/json5-and-yaml-config.md
+++ b/.changeset/json5-and-yaml-config.md
@@ -2,4 +2,4 @@
 "webpack-cli": minor
 ---
 
-feat: support `.json5`, `.yaml`/`.yml` and `.toml` configuration files by parsing them directly, with the parser package (`json5`, `js-yaml`, `toml`) installed on demand by the user
+feat: support `.json5`, `.yaml`/`.yml` and `.toml` configuration files by parsing them directly, with the parser package (`json5`, `js-yaml`, `toml`) installed on demand by the user and declared as optional `peerDependencies` so the parsers resolve correctly under Yarn PnP

--- a/packages/webpack-cli/package.json
+++ b/packages/webpack-cli/package.json
@@ -44,11 +44,23 @@
     "@types/envinfo": "^7.8.4"
   },
   "peerDependencies": {
+    "js-yaml": "^4.0.0 || ^5.0.0",
+    "json5": "^2.2.3",
+    "toml": "^3.0.0 || ^4.0.0",
     "webpack": "^5.101.0",
     "webpack-bundle-analyzer": "^4.0.0 || ^5.0.0",
     "webpack-dev-server": "^5.0.0"
   },
   "peerDependenciesMeta": {
+    "js-yaml": {
+      "optional": true
+    },
+    "json5": {
+      "optional": true
+    },
+    "toml": {
+      "optional": true
+    },
     "webpack-bundle-analyzer": {
       "optional": true
     },


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bugfix / dependency-metadata fix for the new non-JS config support.

## Did you add tests for your changes?

No new automated test (this is a manifest/metadata change). It was verified manually with a real Yarn Berry PnP reproduction — see below.

## Summary

webpack-cli now parses `.json5`, `.yaml`/`.yml` and `.toml` configs by loading the respective parser (`json5`, `js-yaml`, `toml`) from the user's project, and asks users to install it on demand. However, those packages were **not declared anywhere** in `packages/webpack-cli/package.json` — not in `dependencies`, `peerDependencies`, or `peerDependenciesMeta`.

Under **Yarn PnP** an undeclared package is unsound to resolve, so the parser cannot be reached and there is no package-manager signal telling users which package to install.

This PR declares the three parsers as **optional** `peerDependencies` (mirroring the existing `webpack-dev-server` / `webpack-bundle-analyzer` pattern):

```json
"js-yaml": "^4.0.0 || ^5.0.0",
"json5": "^2.2.3",
"toml": "^3.0.0 || ^4.0.0"
```

## Verification

Reproduced webpack-cli's actual parser-resolution mechanism under real Yarn Berry (4.17) PnP:

| Scenario (strict PnP, `pnpFallbackMode: none`) | Result |
|---|---|
| Parser resolved from the package's own module context, **not declared** | ❌ `tried to access json5, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound` |
| Parser declared as **optional peerDependency**, user installs it | ✅ resolves |
| Parser not installed | ❌ undeclared / unsound |

Notes:
- Default PnP (`fallback-except-top-level`) can mask the issue by silently falling back to a top-level dependency — the classic fragile phantom-dependency behavior. Strict setups (and configs that live in a workspace not declaring the parser) break.
- Without the declaration there is no signal prompting users to install the right parser; they only find out on a runtime crash.

The version ranges reflect the latest published versions (json5 `2.2.3`, js-yaml `5.1.0`, toml `4.1.1`) and the used APIs (`.parse` / `.load`), which are stable across those majors. Happy to tighten/loosen them per maintainer preference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E8q7bNUb92fDzxLRdLY6L5

---
_Generated by [Claude Code](https://claude.ai/code/session_01E8q7bNUb92fDzxLRdLY6L5)_