### PR TITLE
test: update target flag tests for webpack 5.108

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "ts-loader": "^9.6.2",
         "ts-node": "^10.9.2",
         "typescript": "^6.0.3",
-        "webpack": "^5.107.2",
+        "webpack": "^5.108.3",
         "webpack-bundle-analyzer": "^5.3.0",
         "webpack-dev-server": "^5.2.5"
       },
@@ -8281,7 +8281,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "Python-2.0"
     },
     "node_modules/array-buffer-byte-length": {
@@ -10950,9 +10950,9 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.22.0.tgz",
-      "integrity": "sha512-xYcDWrpELkFzz9SpZ3PlI6Eu6eD93Yf0WLDRxikGhWJ3MAir2SNZTIVCVZqZ/NUyx8AdMc2gT9C0gPiw18kG+A==",
+      "version": "5.24.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.1.tgz",
+      "integrity": "sha512-7DdUaTjmNwMcH2gLr1qycesKII3BK4RLy/mdAb7x10Lq7bR4aNKHt1BR1ZALSv0rPM/hF5wYF0PhGop/rJm8vw==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -13154,12 +13154,6 @@
       "peerDependencies": {
         "tslib": "2"
       }
-    },
-    "node_modules/glob-to-regexp": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-      "license": "BSD-2-Clause"
     },
     "node_modules/glob/node_modules/brace-expansion": {
       "version": "2.1.0",
@@ -16579,7 +16573,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.0.0.tgz",
       "integrity": "sha512-GSvaPUbk1U+FMZ7rJzF+F8e5YVtu7KnD40et/5rBXXRBv2jCO9L3qCewvIDDdudC0QycTFlf6EAA+h3kxBsuUw==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -16653,7 +16647,7 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
@@ -18343,6 +18337,95 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minimizer-webpack-plugin": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/minimizer-webpack-plugin/-/minimizer-webpack-plugin-5.6.1.tgz",
+      "integrity": "sha512-DoeAZz8Q1C1znwsUzej1fdoi4jCf7/+Em27ouLqfK/+3m8G+D7yDhUwrc3CNhjSzGUN1kn7Iv4sWmjflQHenpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "jest-worker": "^27.4.5",
+        "schema-utils": "^4.3.0",
+        "terser": "^5.31.1"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@minify-html/node": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/css": {
+          "optional": true
+        },
+        "@swc/html": {
+          "optional": true
+        },
+        "clean-css": {
+          "optional": true
+        },
+        "cssnano": {
+          "optional": true
+        },
+        "csso": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "html-minifier-terser": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "uglify-js": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/minimizer-webpack-plugin/node_modules/jest-worker": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
+      "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/minimizer-webpack-plugin/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/minipass": {
@@ -21464,95 +21547,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/terser-webpack-plugin": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.6.0.tgz",
-      "integrity": "sha512-Eum+5ajkaOhf5KbM26osvv21kLD7BaGqQ1UA4Ami4arYwylmGUQTgHFpHDdmJod1q4QXa66p0to/FBKID+J1vA==",
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.25",
-        "jest-worker": "^27.4.5",
-        "schema-utils": "^4.3.0",
-        "terser": "^5.31.1"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "^5.1.0"
-      },
-      "peerDependenciesMeta": {
-        "@minify-html/node": {
-          "optional": true
-        },
-        "@swc/core": {
-          "optional": true
-        },
-        "@swc/css": {
-          "optional": true
-        },
-        "@swc/html": {
-          "optional": true
-        },
-        "clean-css": {
-          "optional": true
-        },
-        "cssnano": {
-          "optional": true
-        },
-        "csso": {
-          "optional": true
-        },
-        "esbuild": {
-          "optional": true
-        },
-        "html-minifier-terser": {
-          "optional": true
-        },
-        "lightningcss": {
-          "optional": true
-        },
-        "postcss": {
-          "optional": true
-        },
-        "uglify-js": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/terser-webpack-plugin/node_modules/jest-worker": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
-      "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "merge-stream": "^2.0.0",
-        "supports-color": "^8.0.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      }
-    },
-    "node_modules/terser-webpack-plugin/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
     "node_modules/terser/node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -22517,12 +22511,11 @@
       }
     },
     "node_modules/watchpack": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
-      "integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.2.tgz",
+      "integrity": "sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==",
       "license": "MIT",
       "dependencies": {
-        "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
       },
       "engines": {
@@ -22556,9 +22549,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/webpack": {
-      "version": "5.107.2",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.107.2.tgz",
-      "integrity": "sha512-v7RhXaJbpMlV0D7hC7lb2EbnxkoeUqf9qhKr6lozx3Q48pmFrqqNRmZFUEGmi7pSwm6fCQ2H1IjvCkHqdpVdjQ==",
+      "version": "5.108.3",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.108.3.tgz",
+      "integrity": "sha512-hOpaCHmQVVY66IVTjofnH14IgSdmod2aquSGHGuYig/OIdWge01Hk2Wt988DZcwXumFUT4+FvJY5N+ikl8o/ww==",
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.8",
@@ -22570,19 +22563,18 @@
         "acorn-import-phases": "^1.0.3",
         "browserslist": "^4.28.1",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.22.0",
+        "enhanced-resolve": "^5.22.2",
         "es-module-lexer": "^2.1.0",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
-        "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.2.11",
         "loader-runner": "^4.3.2",
         "mime-db": "^1.54.0",
+        "minimizer-webpack-plugin": "^5.6.1",
         "neo-async": "^2.6.2",
         "schema-utils": "^4.3.3",
         "tapable": "^2.3.0",
-        "terser-webpack-plugin": "^5.5.0",
-        "watchpack": "^2.5.1",
+        "watchpack": "^2.5.2",
         "webpack-sources": "^3.5.0"
       },
       "bin": {
@@ -23435,7 +23427,7 @@
       }
     },
     "packages/webpack-cli": {
-      "version": "7.0.3",
+      "version": "7.1.0",
       "license": "MIT",
       "dependencies": {
         "@discoveryjs/json-ext": "^1.1.0",
@@ -23461,11 +23453,23 @@
         "url": "https://opencollective.com/webpack"
       },
       "peerDependencies": {
+        "js-yaml": "^4.0.0 || ^5.0.0",
+        "json5": "^2.2.3",
+        "toml": "^3.0.0 || ^4.0.0",
         "webpack": "^5.101.0",
         "webpack-bundle-analyzer": "^4.0.0 || ^5.0.0",
-        "webpack-dev-server": "^5.0.0"
+        "webpack-dev-server": "^5.0.0 || ^6.0.0"
       },
       "peerDependenciesMeta": {
+        "js-yaml": {
+          "optional": true
+        },
+        "json5": {
+          "optional": true
+        },
+        "toml": {
+          "optional": true
+        },
         "webpack-bundle-analyzer": {
           "optional": true
         },

--- a/test/build/target/flag-test/__snapshots__/target-flag.test.js.snap.webpack5
+++ b/test/build/target/flag-test/__snapshots__/target-flag.test.js.snap.webpack5
@@ -4,23 +4,15 @@ exports[`--target flag should reset the \`target\` option when the \`--target-re
 
 exports[`--target flag should reset the \`target\` option when the \`--target-reset\` is used: stderr 1`] = `""`;
 
-exports[`--target flag should throw an error for incompatible multiple targets: stderr 1`] = `
-"[webpack-cli] ✖ Error: For the selected environment is no default script chunk format available:
-
-JSONP Array push ('array-push') can be chosen when 'document' or 'importScripts' is available.
-CommonJs exports ('commonjs') can be chosen when 'require' or node builtins are available.
-Select an appropriate 'target' to allow selecting one by default, or specify the 'output.chunkFormat' directly.
-    at stack"
-`;
-
-exports[`--target flag should throw an error for incompatible multiple targets: stdout 1`] = `""`;
-
 exports[`--target flag should throw an error for invalid target in multiple syntax: stderr 1`] = `
 "[webpack-cli] ✖ Error: Unknown target 'invalid'. The following targets are supported:
 * browserslist / browserslist:env / browserslist:query / browserslist:path-to-config / browserslist:path-to-config:env: Resolve features from browserslist. Will resolve browserslist config automatically. Only browser or node queries are supported (electron is not supported). Examples: 'browserslist:modern' to use 'modern' environment from browserslist config
 * web: Web browser.
 * webworker: Web Worker, SharedWorker or Service Worker.
+* universal: Universal target running in browser, web worker, Node.js, Electron and NW.js. Output is always ECMAScript modules.
 * [async-]node[X[.Y]]: Node.js in version X.Y. The 'async-' prefix will load chunks asynchronously via 'fs' and 'vm' instead of 'require()'. Examples: node14.5, async-node10.
+* deno[X[.Y]]: Deno in version X.Y. Emits ESM output; node.js built-ins are available via the required 'node:' specifier and web APIs (fetch, WebAssembly, ...) are available too. Examples: deno2, deno1.40.
+* bun[X[.Y]]: Bun in version X.Y. Output is always ECMAScript modules. Examples: bun, bun1.1.
 * electron[X[.Y]]-main/preload/renderer: Electron in version X.Y. Script is running in main, preload resp. renderer context.
 * nwjs[X[.Y]] / node-webkit[X[.Y]]: NW.js in version X.Y.
 * esX: EcmaScript in this version. Examples: es2020, es5.
@@ -41,7 +33,10 @@ exports[`--target flag should throw error with invalid value for --target: stder
 * browserslist / browserslist:env / browserslist:query / browserslist:path-to-config / browserslist:path-to-config:env: Resolve features from browserslist. Will resolve browserslist config automatically. Only browser or node queries are supported (electron is not supported). Examples: 'browserslist:modern' to use 'modern' environment from browserslist config
 * web: Web browser.
 * webworker: Web Worker, SharedWorker or Service Worker.
+* universal: Universal target running in browser, web worker, Node.js, Electron and NW.js. Output is always ECMAScript modules.
 * [async-]node[X[.Y]]: Node.js in version X.Y. The 'async-' prefix will load chunks asynchronously via 'fs' and 'vm' instead of 'require()'. Examples: node14.5, async-node10.
+* deno[X[.Y]]: Deno in version X.Y. Emits ESM output; node.js built-ins are available via the required 'node:' specifier and web APIs (fetch, WebAssembly, ...) are available too. Examples: deno2, deno1.40.
+* bun[X[.Y]]: Bun in version X.Y. Output is always ECMAScript modules. Examples: bun, bun1.1.
 * electron[X[.Y]]-main/preload/renderer: Electron in version X.Y. Script is running in main, preload resp. renderer context.
 * nwjs[X[.Y]] / node-webkit[X[.Y]]: NW.js in version X.Y.
 * esX: EcmaScript in this version. Examples: es2020, es5.

--- a/test/build/target/flag-test/target-flag.test.js
+++ b/test/build/target/flag-test/target-flag.test.js
@@ -66,7 +66,7 @@ describe("--target flag", () => {
     expect(normalizeStdout(stdout)).toMatchSnapshot("stdout");
   });
 
-  it("should throw an error for incompatible multiple targets", async () => {
+  it("should allow multiple different targets", async () => {
     const { exitCode, stderr, stdout } = await run(__dirname, [
       "--target",
       "node",
@@ -74,9 +74,9 @@ describe("--target flag", () => {
       "web",
     ]);
 
-    expect(exitCode).toBe(2);
-    expect(normalizeStderr(stderr)).toMatchSnapshot("stderr");
-    expect(normalizeStdout(stdout)).toMatchSnapshot("stdout");
+    expect(exitCode).toBe(0);
+    expect(stderr).toBeFalsy();
+    expect(stdout).toContain("target: [ 'node', 'web' ]");
   });
 
   it("should reset the `target` option when the `--target-reset` is used", async () => {


### PR DESCRIPTION
## Summary

CI on #4792 fails (and #4795 is blocked) because webpack 5.108 changed target behavior in two ways that broke `test/build/target/flag-test/target-flag.test.js`:

- webpack 5.108 introduces the `universal`, `deno` and `bun` targets, so the "Unknown target 'invalid'" stderr snapshots no longer match.
- Combining targets like `node` + `web` no longer fails with "no default script chunk format available" — webpack now builds them successfully with universal ESM output, so the "should throw an error for incompatible multiple targets" test gets exit code 0 instead of 2.

## Changes

- Bump webpack to 5.108.3 in `package-lock.json` (already allowed by the `^5.107.2` range; snapshots are keyed per webpack major and must match the locked version).
- Regenerate the two "Unknown target" stderr snapshots to include the new `universal`, `deno` and `bun` target descriptions.
- Replace the "should throw an error for incompatible multiple targets" test with "should allow multiple different targets", asserting that `node` + `web` now builds successfully.

## Testing

Full jest suite passes locally with webpack 5.108.3 (727 passed, 330/330 snapshots).

Once merged, Dependabot can rebase #4792 and #4795 and their CI should go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012iKSSr35Ue6UtyA6rcw6UA

---
_Generated by [Claude Code](https://claude.ai/code/session_012iKSSr35Ue6UtyA6rcw6UA)_