### PR TITLE
fix: CLIPlugin dynamic import interop under Bun

### DIFF
--- a/.changeset/cli-plugin-import-interop.md
+++ b/.changeset/cli-plugin-import-interop.md
@@ -1,0 +1,5 @@
+---
+"webpack-cli": patch
+---
+
+fix: `CLIPlugin` dynamic import interop under Bun

--- a/packages/webpack-cli/src/webpack-cli.ts
+++ b/packages/webpack-cli/src/webpack-cli.ts
@@ -3250,7 +3250,10 @@ class WebpackCLI {
       process.exit(2);
     }
 
-    const { default: CLIPlugin } = (await import("./plugins/cli-plugin.js")).default;
+    // Node's CJS interop nests the class under `.default.default`; Bun honors
+    // `__esModule` and unwraps once already, leaving the class one level up.
+    const cliPluginModule = (await import("./plugins/cli-plugin.js")).default;
+    const CLIPlugin = cliPluginModule.default ?? cliPluginModule;
 
     // `getArguments()` already returns a name-keyed map of exactly the argument
     // metadata `processArguments` consumes, so use it directly (cached) instead

--- a/test/api/cli-plugin-interop/cli-plugin-interop.test.js
+++ b/test/api/cli-plugin-interop/cli-plugin-interop.test.js
@@ -1,0 +1,46 @@
+const path = require("node:path");
+
+// Simulate Bun's ESM↔CJS interop: the dynamic import of cli-plugin resolves to
+// the class itself instead of Node's `{ __esModule, default }` wrapper. Guards
+// the interop-safe unwrap in `webpack-cli.ts` against reintroducing the
+// Node-only double-`.default` unwrap (which crashes every build under Bun).
+jest.mock(
+  "../../../packages/webpack-cli/lib/plugins/cli-plugin",
+  () => jest.requireActual("../../../packages/webpack-cli/lib/plugins/cli-plugin").default,
+);
+
+const CLIPlugin = jest.requireActual(
+  "../../../packages/webpack-cli/lib/plugins/cli-plugin",
+).default;
+
+describe("CLIPlugin import interop", () => {
+  it("applies CLIPlugin when the dynamic import resolves to the class itself", async () => {
+    process.env.WEBPACK_PACKAGE = path.resolve(__dirname, "./mock-webpack.js");
+
+    const WebpackCLI = require("../../../packages/webpack-cli/lib/webpack-cli").default;
+
+    const exitSpy = jest.spyOn(process, "exit").mockImplementation((code) => {
+      throw new Error(`process.exit(${code})`);
+    });
+    const errors = [];
+    const errorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation((message) => errors.push(`${message}`));
+
+    try {
+      await new WebpackCLI().run(["node", "webpack", "build"]);
+    } catch (error) {
+      throw new Error(`${error.message}\n${errors.join("\n")}`, {
+        cause: error,
+      });
+    } finally {
+      exitSpy.mockRestore();
+      errorSpy.mockRestore();
+      delete process.env.WEBPACK_PACKAGE;
+    }
+
+    const options = globalThis.__capturedWebpackOptions;
+
+    expect(options.plugins[0]).toBeInstanceOf(CLIPlugin);
+  });
+});

--- a/test/api/cli-plugin-interop/mock-webpack.js
+++ b/test/api/cli-plugin-interop/mock-webpack.js
@@ -1,0 +1,14 @@
+// Minimal webpack stand-in (loaded via WEBPACK_PACKAGE): captures the config
+// webpack-cli assembles so tests can assert on the applied plugins.
+const realWebpack = require("webpack");
+
+const webpack = (options) => {
+  globalThis.__capturedWebpackOptions = options;
+
+  return { options };
+};
+
+webpack.cli = realWebpack.cli;
+webpack.version = realWebpack.version;
+
+module.exports = webpack;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

The CLIPlugin lazy import unwraps `.default` twice, which is correct for Node's CJS interop but `undefined` under Bun (it honors the `__esModule` marker and unwraps once already), so every `bun --bun webpack build` fails with "undefined is not a constructor"; unwrap interop-safely like the existing `parserModule` pattern.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

fix

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

No; covered by webpack/webpack#21334, which runs webpack's `WebpackCli.longtest.js` suite under Bun (existing suites here still pass).

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Written with Claude Code: it diagnosed the Bun interop failure and authored the fix and changeset; verified via `tsc --build`, a Bun/Node runtime repro, and webpack's WebpackCli suite under Bun.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BB5WfTA2CNBM7tQFnjp74z)_