### PR TITLE
chore: remove unused cross-env dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
         "coffeescript": "^2.7.0",
         "colorette": "^2.0.20",
         "concat-stream": "^2.0.0",
-        "cross-env": "^10.1.0",
         "cspell": "^10.0.1",
         "css-loader": "^7.1.4",
         "del-cli": "^7.0.0",
@@ -4006,13 +4005,6 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
-    },
-    "node_modules/@epic-web/invariant": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
-      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@es-joy/jsdoccomment": {
       "version": "0.86.0",
@@ -10576,24 +10568,6 @@
     "node_modules/create-webpack-app": {
       "resolved": "packages/create-webpack-app",
       "link": true
-    },
-    "node_modules/cross-env": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
-      "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@epic-web/invariant": "^1.0.0",
-        "cross-spawn": "^7.0.6"
-      },
-      "bin": {
-        "cross-env": "dist/bin/cross-env.js",
-        "cross-env-shell": "dist/bin/cross-env-shell.js"
-      },
-      "engines": {
-        "node": ">=20"
-      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "coffeescript": "^2.7.0",
     "colorette": "^2.0.20",
     "concat-stream": "^2.0.0",
-    "cross-env": "^10.1.0",
     "cspell": "^10.0.1",
     "css-loader": "^7.1.4",
     "del-cli": "^7.0.0",


### PR DESCRIPTION
**Summary**

Removes the unused `cross-env` development dependency and its orphaned transitive dependency from `package-lock.json`.

`cross-env` was added for the previous `nyc`-based coverage command in [a01f01b](https://github.com/webpack/webpack-cli/commit/a01f01b59793eaf5e9fef0a2e7be4d35b4e91a9d). The coverage workflow was later migrated to `c8` in [47fc332](https://github.com/webpack/webpack-cli/commit/47fc3321acd1e92d405d6b1d8290433ac09788d3), which removed the only usage of `cross-env` while leaving the dependency declaration behind.

No related issue; this is dependency cleanup.

**What kind of change does this PR introduce?**

chore

**Did you add tests for your changes?**

No. This change only removes unused dependency metadata and does not alter runtime behavior.

Validated that `cross-env` and its orphaned transitive dependency are absent from both the manifest and lockfile.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

No documentation changes are needed.

**Use of AI**

Yes. I used Codex to audit dependency usage, inspect the Git history, identify the obsolete dependency and its orphaned transitive dependency, and validate the manifest and lockfile changes. I reviewed the resulting changes.