### PR TITLE
feat(create-webpack-app): use webpack's native CSS and HTML support in init templates

### DIFF
--- a/.changeset/native-css-templates.md
+++ b/.changeset/native-css-templates.md
@@ -1,0 +1,5 @@
+---
+"create-webpack-app": minor
+---
+
+feat: use webpack's native CSS and HTML support in the `init` templates

--- a/packages/create-webpack-app/src/generators/init/default.ts
+++ b/packages/create-webpack-app/src/generators/init/default.ts
@@ -35,7 +35,7 @@ export default async function defaultInitGenerator(plop: NodePlopAPI) {
       },
       {
         type: "confirm",
-        name: "htmlWebpackPlugin",
+        name: "html",
         message: "Do you want to simplify the creation of HTML files for your bundle?",
         default: true,
       },
@@ -55,7 +55,6 @@ export default async function defaultInitGenerator(plop: NodePlopAPI) {
           if (input === "none") {
             answers.isCSS = false;
             answers.isPostCSS = false;
-            answers.extractPlugin = "No";
           } else if (input === "CSS only") {
             answers.isCSS = true;
           }
@@ -75,13 +74,6 @@ export default async function defaultInitGenerator(plop: NodePlopAPI) {
         name: "isPostCSS",
         message: "Do you want to use PostCSS in your project?",
         default: (answers: Answers) => answers.cssType === "CSS only",
-      },
-      {
-        type: "list",
-        name: "extractPlugin",
-        message: "Do you want to extract CSS into separate files?",
-        choices: ["No", "Only for Production", "Yes"],
-        default: "Only for Production",
       },
       {
         type: "list",
@@ -113,10 +105,6 @@ export default async function defaultInitGenerator(plop: NodePlopAPI) {
         devDependencies.push("webpack-dev-server");
       }
 
-      if (answers.htmlWebpackPlugin) {
-        devDependencies.push("html-webpack-plugin", "html-loader");
-      }
-
       if (answers.workboxWebpackPlugin) {
         devDependencies.push("workbox-webpack-plugin");
       }
@@ -125,12 +113,7 @@ export default async function defaultInitGenerator(plop: NodePlopAPI) {
         devDependencies.push("postcss-loader", "postcss", "autoprefixer");
       }
 
-      if (answers.extractPlugin !== "No") {
-        devDependencies.push("mini-css-extract-plugin");
-      }
-
       if (answers.cssType !== "none") {
-        devDependencies.push("style-loader", "css-loader");
         switch (answers.cssType) {
           case "SASS":
             devDependencies.push("sass-loader", "sass");
@@ -142,9 +125,6 @@ export default async function defaultInitGenerator(plop: NodePlopAPI) {
             devDependencies.push("stylus-loader", "stylus");
             break;
         }
-      }
-      if (answers.extractPlugin !== "No") {
-        devDependencies.push("mini-css-extract-plugin");
       }
 
       const files: FileRecord[] = [

--- a/packages/create-webpack-app/src/generators/init/react.ts
+++ b/packages/create-webpack-app/src/generators/init/react.ts
@@ -13,7 +13,6 @@ export default async function reactInitGenerator(plop: NodePlopAPI) {
     "react@18",
     "react-dom@18",
     "webpack-dev-server",
-    "html-webpack-plugin",
     "react-router-dom",
     "@types/react-router-dom",
   ];
@@ -58,7 +57,6 @@ export default async function reactInitGenerator(plop: NodePlopAPI) {
           if (input === "none") {
             answers.isCSS = false;
             answers.isPostCSS = false;
-            answers.extractPlugin = "No";
           } else if (input === "CSS only") {
             answers.isCSS = true;
           }
@@ -81,13 +79,6 @@ export default async function reactInitGenerator(plop: NodePlopAPI) {
       },
       {
         type: "list",
-        name: "extractPlugin",
-        message: "Do you want to extract CSS into separate files?",
-        choices: ["No", "Only for Production", "Yes"],
-        default: "Only for Production",
-      },
-      {
-        type: "list",
         name: "packageManager",
         message: "Which package manager do you want to use?",
         choices: ["npm", "yarn", "pnpm"],
@@ -103,7 +94,7 @@ export default async function reactInitGenerator(plop: NodePlopAPI) {
     actions: function actions(answers: Answers) {
       // setting some default values based on the answers
       const actions: ActionType[] = [];
-      answers.htmlWebpackPlugin = true;
+      answers.html = true;
       answers.devServer = true;
       switch (answers.langType) {
         case "ES6":
@@ -124,9 +115,7 @@ export default async function reactInitGenerator(plop: NodePlopAPI) {
       if (answers.cssType === "none") {
         answers.isCSS = false;
         answers.isPostCSS = false;
-        answers.extractPlugin = "No";
       } else {
-        devDependencies.push("style-loader", "css-loader");
         switch (answers.cssType) {
           case "CSS only":
             answers.isCSS = true;
@@ -141,9 +130,6 @@ export default async function reactInitGenerator(plop: NodePlopAPI) {
             devDependencies.push("stylus-loader", "stylus");
             break;
         }
-      }
-      if (answers.extractPlugin !== "No") {
-        devDependencies.push("mini-css-extract-plugin");
       }
       if (answers.workboxWebpackPlugin) {
         devDependencies.push("workbox-webpack-plugin");

--- a/packages/create-webpack-app/src/generators/init/svelte.ts
+++ b/packages/create-webpack-app/src/generators/init/svelte.ts
@@ -13,7 +13,6 @@ export default async function svelteInitGenerator(plop: NodePlopAPI) {
     "svelte",
     "svelte-loader",
     "webpack-dev-server",
-    "html-webpack-plugin",
   ];
 
   await plop.load("../../utils/install-dependencies.js", {}, true);
@@ -49,7 +48,6 @@ export default async function svelteInitGenerator(plop: NodePlopAPI) {
           if (input === "none") {
             answers.isCSS = false;
             answers.isPostCSS = false;
-            answers.extractPlugin = "No";
           } else if (input === "CSS only") {
             answers.isCSS = true;
           }
@@ -72,13 +70,6 @@ export default async function svelteInitGenerator(plop: NodePlopAPI) {
       },
       {
         type: "list",
-        name: "extractPlugin",
-        message: "Do you want to extract CSS into separate files?",
-        choices: ["No", "Only for Production", "Yes"],
-        default: "Only for Production",
-      },
-      {
-        type: "list",
         name: "packageManager",
         message: "Which package manager do you want to use?",
         choices: ["npm", "yarn", "pnpm"],
@@ -94,7 +85,7 @@ export default async function svelteInitGenerator(plop: NodePlopAPI) {
     actions: function actions(answers: Answers) {
       // setting some default values based on the answers
       const actions: ActionType[] = [];
-      answers.htmlWebpackPlugin = true;
+      answers.html = true;
       answers.devServer = true;
 
       switch (answers.langType) {
@@ -117,9 +108,7 @@ export default async function svelteInitGenerator(plop: NodePlopAPI) {
       if (answers.cssType === "none") {
         answers.isCSS = false;
         answers.isPostCSS = false;
-        answers.extractPlugin = "No";
       } else {
-        devDependencies.push("style-loader", "css-loader");
         switch (answers.cssType) {
           case "CSS only":
             answers.isCSS = true;
@@ -134,10 +123,6 @@ export default async function svelteInitGenerator(plop: NodePlopAPI) {
             devDependencies.push("stylus-loader", "stylus");
             break;
         }
-      }
-
-      if (answers.extractPlugin !== "No") {
-        devDependencies.push("mini-css-extract-plugin");
       }
 
       const files: FileRecord[] = [

--- a/packages/create-webpack-app/src/generators/init/vue.ts
+++ b/packages/create-webpack-app/src/generators/init/vue.ts
@@ -12,7 +12,6 @@ export default async function vueInitGenerator(plop: NodePlopAPI) {
     "webpack-cli",
     "vue@3",
     "webpack-dev-server",
-    "html-webpack-plugin",
     "vue-loader@next",
     "@vue/compiler-sfc",
     "vue-router@4",
@@ -57,7 +56,6 @@ export default async function vueInitGenerator(plop: NodePlopAPI) {
           if (input === "none") {
             answers.isCSS = false;
             answers.isPostCSS = false;
-            answers.extractPlugin = "No";
           } else if (input === "CSS only") {
             answers.isCSS = true;
           }
@@ -80,13 +78,6 @@ export default async function vueInitGenerator(plop: NodePlopAPI) {
       },
       {
         type: "list",
-        name: "extractPlugin",
-        message: "Do you want to extract CSS into separate files?",
-        choices: ["No", "Only for Production", "Yes"],
-        default: "Only for Production",
-      },
-      {
-        type: "list",
         name: "packageManager",
         message: "Which package manager do you want to use?",
         choices: ["npm", "yarn", "pnpm"],
@@ -102,7 +93,7 @@ export default async function vueInitGenerator(plop: NodePlopAPI) {
     actions: function actions(answers: Answers) {
       // setting some default values based on the answers
       const actions: ActionType[] = [];
-      answers.htmlWebpackPlugin = true;
+      answers.html = true;
       answers.devServer = true;
 
       switch (answers.langType) {
@@ -129,9 +120,7 @@ export default async function vueInitGenerator(plop: NodePlopAPI) {
       if (answers.cssType === "none") {
         answers.isCSS = false;
         answers.isPostCSS = false;
-        answers.extractPlugin = "No";
       } else {
-        devDependencies.push("vue-style-loader", "style-loader", "css-loader");
         switch (answers.cssType) {
           case "CSS only":
             answers.isCSS = true;
@@ -146,10 +135,6 @@ export default async function vueInitGenerator(plop: NodePlopAPI) {
             devDependencies.push("stylus-loader", "stylus");
             break;
         }
-      }
-
-      if (answers.extractPlugin !== "No") {
-        devDependencies.push("mini-css-extract-plugin");
       }
 
       const files: FileRecord[] = [

--- a/packages/create-webpack-app/src/index.ts
+++ b/packages/create-webpack-app/src/index.ts
@@ -17,12 +17,11 @@ const baseAnswers: Answers = {
   projectPath: process.cwd(),
   langType: "none",
   devServer: true,
-  htmlWebpackPlugin: true,
+  html: true,
   workboxWebpackPlugin: true,
   cssType: "none",
   isCSS: false,
   isPostCSS: false,
-  extractPlugin: "No",
   packageManager: "npm",
 };
 const initValues: Record<string, Answers> = {

--- a/packages/create-webpack-app/templates/init/default/index.html.tpl
+++ b/packages/create-webpack-app/templates/init/default/index.html.tpl
@@ -6,7 +6,8 @@
     </head>
     <body>
         <h1>Hello world!</h1>
-        <h2>Tip: Check your console</h2>
+        <h2>Tip: Check your console</h2><% if (html) { %>
+        <script src="<%= entryPoint %>"></script><% } %>
     </body>
     <% if (workboxWebpackPlugin) { %>
     <script>

--- a/packages/create-webpack-app/templates/init/default/webpack.config.tpl
+++ b/packages/create-webpack-app/templates/init/default/webpack.config.tpl
@@ -3,32 +3,26 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";<% if (langType === "Typescript") { %>
 import { type Configuration } from "webpack";<% if (devServer) { %>
-import "webpack-dev-server";<% } %><% } %><% if (htmlWebpackPlugin) { %>
-import HtmlWebpackPlugin from "html-webpack-plugin";<% } %><% if (extractPlugin !== "No") { %>
-import MiniCssExtractPlugin from "mini-css-extract-plugin";<% } %><% if (workboxWebpackPlugin) { %>
+import "webpack-dev-server";<% } %><% } %><% if (workboxWebpackPlugin) { %>
 import WorkboxWebpackPlugin from "workbox-webpack-plugin";<% } %>
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-const isProduction = process.env.NODE_ENV === "production";<% if (cssType !== "none") { %><% if (extractPlugin === "Yes") { %>
-const stylesHandler = MiniCssExtractPlugin.loader;<% } else if (extractPlugin === "Only for Production") { %>
-const stylesHandler = isProduction ? MiniCssExtractPlugin.loader : "style-loader";<% } else { %>
-const stylesHandler = "style-loader";<% } %><% } %>
+const isProduction = process.env.NODE_ENV === "production";
 
 /** @type {import("webpack").Configuration} */
 const config <% if (langType === "Typescript") { %>: Configuration <% } %>= {
-    entry: "<%= entryPoint %>",
+    entry: <% if (html) { %>"./index.html"<% } else { %>"<%= entryPoint %>"<% } %>,
     output: {
         path: path.resolve(__dirname, "dist"),
     },<% if (devServer) { %>
     devServer: {
         open: true,
+    },<% } %><% if (isCSS && isPostCSS) { %>
+    experiments: {
+        css: true,
     },<% } %>
-    plugins: [<% if (htmlWebpackPlugin) { %>
-        new HtmlWebpackPlugin({
-            template: "index.html",
-        }),<% } %><% if (extractPlugin === "Yes") { %>
-        new MiniCssExtractPlugin(),<% } %>
+    plugins: [
         // Add your plugins here
         // Learn more about plugins from https://webpack.js.org/configuration/plugins/
     ],
@@ -42,36 +36,31 @@ const config <% if (langType === "Typescript") { %>: Configuration <% } %>= {
                 test: /\.(ts|tsx)$/i,
                 loader: "ts-loader",
                 exclude: ["/node_modules/"],
-            },<% } %><%  if (isCSS && !isPostCSS) { %>
+            },<% } %><%  if (isCSS && isPostCSS) { %>
             {
                 test: /\.css$/i,
-                use: [stylesHandler,"css-loader"],
+                type: "css/auto",
+                use: ["postcss-loader"],
             },<% } %><%  if (cssType == "SASS") { %>
             {
                 test: /\.s[ac]ss$/i,
-                use: [stylesHandler, "css-loader", <% if (isPostCSS) { %>"postcss-loader", <% } %>"sass-loader"],
+                type: "css/auto",
+                use: [<% if (isPostCSS) { %>"postcss-loader", <% } %>"sass-loader"],
             },<% } %><%  if (cssType == "LESS") { %>
             {
                 test: /\.less$/i,
-                use: [stylesHandler, "css-loader", <% if (isPostCSS) { %>"postcss-loader", <% } %>"less-loader"],
+                type: "css/auto",
+                use: [<% if (isPostCSS) { %>"postcss-loader", <% } %>"less-loader"],
             },<% } %><%  if (cssType == "Stylus") { %>
             {
                 test: /\.styl$/i,
-                use: [stylesHandler, "css-loader", <% if (isPostCSS) { %>"postcss-loader", <% } %>"stylus-loader"],
-            },<% } %><%  if (isPostCSS && isCSS) { %>
-            {
-                test: /\.css$/i,
-                use: [stylesHandler, "css-loader", "postcss-loader"],
+                type: "css/auto",
+                use: [<% if (isPostCSS) { %>"postcss-loader", <% } %>"stylus-loader"],
             },<% } %>
             {
                 test: /\.(eot|svg|ttf|woff|woff2|png|jpg|gif)$/i,
                 type: "asset",
             },
-            %><%  if (htmlWebpackPlugin) { %>
-            {
-                test: /\.html$/i,
-                use: ["html-loader"],
-            },<% } %>
 
             // Add your rules for custom modules here
             // Learn more about loaders from https://webpack.js.org/loaders/
@@ -84,8 +73,7 @@ const config <% if (langType === "Typescript") { %>: Configuration <% } %>= {
 
 export default () => {
     if (isProduction) {
-        config.mode = "production";<% if (extractPlugin === "Only for Production") { %>
-        config.plugins?.push(new MiniCssExtractPlugin());<% } %><% if (workboxWebpackPlugin) { %>
+        config.mode = "production";<% if (workboxWebpackPlugin) { %>
         config.plugins?.push(new WorkboxWebpackPlugin.GenerateSW());<% } %>
     } else {
         config.mode = "development";

--- a/packages/create-webpack-app/templates/init/react/index.html.tpl
+++ b/packages/create-webpack-app/templates/init/react/index.html.tpl
@@ -8,5 +8,6 @@
     </head>
     <body>
         <div id="root"></div>
+        <script src="<%= entry %>"></script>
     </body>
 </html>

--- a/packages/create-webpack-app/templates/init/react/webpack.config.tpl
+++ b/packages/create-webpack-app/templates/init/react/webpack.config.tpl
@@ -3,32 +3,26 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";<% if (langType === "Typescript") { %>
 import { type Configuration } from "webpack";<% if (devServer) { %>
-import "webpack-dev-server";<% } %><% } %><% if (htmlWebpackPlugin) { %>
-import HtmlWebpackPlugin from "html-webpack-plugin";<% } %><% if (extractPlugin !== "No") { %>
-import MiniCssExtractPlugin from "mini-css-extract-plugin";<% } %><% if (workboxWebpackPlugin) { %>
+import "webpack-dev-server";<% } %><% } %><% if (workboxWebpackPlugin) { %>
 import WorkboxWebpackPlugin from "workbox-webpack-plugin";<% } %>
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-const isProduction = process.env.NODE_ENV === "production";<% if (cssType !== "none") { %><% if (extractPlugin === "Yes") { %>
-const stylesHandler = MiniCssExtractPlugin.loader;<% } else if (extractPlugin === "Only for Production") { %>
-const stylesHandler = isProduction ? MiniCssExtractPlugin.loader : "style-loader";<% } else { %>
-const stylesHandler = "style-loader";<% } %><% } %>
+const isProduction = process.env.NODE_ENV === "production";
 
 /** @type {import("webpack").Configuration} */
 const config <% if (langType === "Typescript") { %>: Configuration <% } %>= {
-    entry: "<%= entry %>",
+    entry: <% if (html) { %>"./index.html"<% } else { %>"<%= entry %>"<% } %>,
     output: {
         path: path.resolve(__dirname, "dist"),
     },<% if (devServer) { %>
     devServer: {
         open: true,
+    },<% } %><% if (isCSS && isPostCSS) { %>
+    experiments: {
+        css: true,
     },<% } %>
-    plugins: [<% if (htmlWebpackPlugin) { %>
-        new HtmlWebpackPlugin({
-            template: "index.html",
-        }),<% } %><% if (extractPlugin === "Yes") { %>
-        new MiniCssExtractPlugin(),<% } %>
+    plugins: [
         // Add your plugins here
         // Learn more about plugins from https://webpack.js.org/configuration/plugins/
     ],
@@ -48,26 +42,26 @@ const config <% if (langType === "Typescript") { %>: Configuration <% } %>= {
                 test: /\.(ts|tsx)$/i,
                 loader: "ts-loader",
                 exclude: ["/node_modules/"],
-            },<% } %><%  if (isCSS && !isPostCSS) { %>
+            },<% } %><%  if (isCSS && isPostCSS) { %>
             {
                 test: /\.css$/i,
-                use: [stylesHandler,"css-loader"],
+                type: "css/auto",
+                use: ["postcss-loader"],
             },<% } %><%  if (cssType == "SASS") { %>
             {
                 test: /\.s[ac]ss$/i,
-                use: [stylesHandler, "css-loader", <% if (isPostCSS) { %>"postcss-loader", <% } %>"sass-loader"],
+                type: "css/auto",
+                use: [<% if (isPostCSS) { %>"postcss-loader", <% } %>"sass-loader"],
             },<% } %><%  if (cssType == "LESS") { %>
             {
                 test: /\.less$/i,
-                use: [stylesHandler, "css-loader", <% if (isPostCSS) { %>"postcss-loader", <% } %>"less-loader"],
+                type: "css/auto",
+                use: [<% if (isPostCSS) { %>"postcss-loader", <% } %>"less-loader"],
             },<% } %><%  if (cssType == "Stylus") { %>
             {
                 test: /\.styl$/i,
-                use: [stylesHandler, "css-loader", <% if (isPostCSS) { %>"postcss-loader", <% } %>"stylus-loader"],
-            },<% } %><%  if (isPostCSS && isCSS) { %>
-            {
-                test: /\.css$/i,
-                use: [stylesHandler, "css-loader", "postcss-loader"],
+                type: "css/auto",
+                use: [<% if (isPostCSS) { %>"postcss-loader", <% } %>"stylus-loader"],
             },<% } %>
             {
                 test: /\.(eot|svg|ttf|woff|woff2|png|jpg|gif)$/i,
@@ -88,8 +82,7 @@ const config <% if (langType === "Typescript") { %>: Configuration <% } %>= {
 
 export default () => {
     if (isProduction) {
-        config.mode = "production";<% if (extractPlugin === "Only for Production") { %>
-        config.plugins?.push(new MiniCssExtractPlugin());<% } %><% if (workboxWebpackPlugin) { %>
+        config.mode = "production";<% if (workboxWebpackPlugin) { %>
         config.plugins?.push(new WorkboxWebpackPlugin.GenerateSW());<% } %>
     } else {
         config.mode = "development";

--- a/packages/create-webpack-app/templates/init/svelte/index.html.tpl
+++ b/packages/create-webpack-app/templates/init/svelte/index.html.tpl
@@ -7,6 +7,6 @@
 </head>
 <body>
     <div id="app"></div>
-    <!-- built files will be auto injected -->
+    <script src="<%= entry %>"></script>
 </body>
 </html>

--- a/packages/create-webpack-app/templates/init/svelte/webpack.config.tpl
+++ b/packages/create-webpack-app/templates/init/svelte/webpack.config.tpl
@@ -3,32 +3,26 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";<% if (langType === "Typescript") { %>
 import { type Configuration } from "webpack";<% if (devServer) { %>
-import "webpack-dev-server";<% } %><% } %><% if (htmlWebpackPlugin) { %>
-import HtmlWebpackPlugin from "html-webpack-plugin";<% } %><% if (extractPlugin !== "No") { %>
-import MiniCssExtractPlugin from "mini-css-extract-plugin";<% } %><% if (workboxWebpackPlugin) { %>
+import "webpack-dev-server";<% } %><% } %><% if (workboxWebpackPlugin) { %>
 import WorkboxWebpackPlugin from "workbox-webpack-plugin";<% } %>
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-const isProduction = process.env.NODE_ENV === "production";<% if (cssType !== "none") { %><% if (extractPlugin === "Yes") { %>
-const stylesHandler = MiniCssExtractPlugin.loader;<% } else if (extractPlugin === "Only for Production") { %>
-const stylesHandler = isProduction ? MiniCssExtractPlugin.loader : "style-loader";<% } else { %>
-const stylesHandler = "style-loader";<% } %><% } %>
+const isProduction = process.env.NODE_ENV === "production";
 
 /** @type {import("webpack").Configuration} */
 const config <% if (langType === "Typescript") { %>: Configuration <% } %>= {
-    entry: "<%= entry %>",
+    entry: <% if (html) { %>"./index.html"<% } else { %>"<%= entry %>"<% } %>,
     output: {
         path: path.resolve(__dirname, "dist"),
     },<% if (devServer) { %>
     devServer: {
         open: true,
+    },<% } %><% if (isCSS && isPostCSS) { %>
+    experiments: {
+        css: true,
     },<% } %>
-    plugins: [<% if (htmlWebpackPlugin) { %>
-        new HtmlWebpackPlugin({
-            template: "./index.html",
-        }),<% } %><% if (extractPlugin === "Yes") { %>
-        new MiniCssExtractPlugin(),<% } %>
+    plugins: [
         // Add your plugins here
         // Learn more about plugins from https://webpack.js.org/configuration/plugins/
     ],
@@ -61,26 +55,26 @@ const config <% if (langType === "Typescript") { %>: Configuration <% } %>= {
                 options: {
                     appendTsSuffixTo: [/\.svelte$/],
                 },
-            },<% } %><%  if (isCSS && !isPostCSS) { %>
+            },<% } %><%  if (isCSS && isPostCSS) { %>
             {
                 test: /\.css$/i,
-                use: [stylesHandler,"css-loader"],
+                type: "css/auto",
+                use: ["postcss-loader"],
             },<% } %><%  if (cssType == "SASS") { %>
             {
                 test: /\.s[ac]ss$/i,
-                use: [stylesHandler, "css-loader", <% if (isPostCSS) { %>"postcss-loader", <% } %>"sass-loader"],
+                type: "css/auto",
+                use: [<% if (isPostCSS) { %>"postcss-loader", <% } %>"sass-loader"],
             },<% } %><%  if (cssType == "LESS") { %>
             {
                 test: /\.less$/i,
-                use: [stylesHandler, "css-loader", <% if (isPostCSS) { %>"postcss-loader", <% } %>"less-loader"],
+                type: "css/auto",
+                use: [<% if (isPostCSS) { %>"postcss-loader", <% } %>"less-loader"],
             },<% } %><%  if (cssType == "Stylus") { %>
             {
                 test: /\.styl$/i,
-                use: [stylesHandler, "css-loader", <% if (isPostCSS) { %>"postcss-loader", <% } %>"stylus-loader"],
-            },<% } %><%  if (isPostCSS && isCSS) { %>
-            {
-                test: /\.css$/i,
-                use: [stylesHandler, "css-loader", "postcss-loader"],
+                type: "css/auto",
+                use: [<% if (isPostCSS) { %>"postcss-loader", <% } %>"stylus-loader"],
             },<% } %>
             {
                 test: /\.(eot|svg|ttf|woff|woff2|png|jpg|gif)$/i,
@@ -102,8 +96,7 @@ const config <% if (langType === "Typescript") { %>: Configuration <% } %>= {
 
 export default () => {
     if (isProduction) {
-        config.mode = "production";<% if (extractPlugin === "Only for Production") { %>
-        config.plugins?.push(new MiniCssExtractPlugin());<% } %><% if (workboxWebpackPlugin) { %>
+        config.mode = "production";<% if (workboxWebpackPlugin) { %>
         config.plugins?.push(new WorkboxWebpackPlugin.GenerateSW());<% } %>
     } else {
         config.mode = "development";

--- a/packages/create-webpack-app/templates/init/vue/index.html.tpl
+++ b/packages/create-webpack-app/templates/init/vue/index.html.tpl
@@ -7,6 +7,6 @@
 </head>
 <body>
     <div id="root"></div>
-    <!-- built files will be auto injected -->
+    <script src="<%= entry %>"></script>
 </body>
 </html>

--- a/packages/create-webpack-app/templates/init/vue/webpack.config.tpl
+++ b/packages/create-webpack-app/templates/init/vue/webpack.config.tpl
@@ -4,33 +4,28 @@ import { VueLoaderPlugin } from "vue-loader";
 import path from "node:path";
 import { fileURLToPath } from "node:url";<% if (langType === "Typescript") { %>
 import { type Configuration } from "webpack";<% if (devServer) { %>
-import "webpack-dev-server";<% } %><% } %><% if (htmlWebpackPlugin) { %>
-import HtmlWebpackPlugin from "html-webpack-plugin";<% } %><% if (extractPlugin !== "No") { %>
-import MiniCssExtractPlugin from "mini-css-extract-plugin";<% } %><% if (workboxWebpackPlugin) { %>
+import "webpack-dev-server";<% } %><% } %><% if (workboxWebpackPlugin) { %>
 import WorkboxWebpackPlugin from "workbox-webpack-plugin";<% } %>
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-const isProduction = process.env.NODE_ENV === "production";<% if (cssType !== "none") { %><% if (extractPlugin === "Yes") { %>
-const stylesHandler = MiniCssExtractPlugin.loader;<% } else if (extractPlugin === "Only for Production") { %>
-const stylesHandler = isProduction ? MiniCssExtractPlugin.loader : "vue-style-loader";<% } else { %>
-const stylesHandler = "vue-style-loader";<% } %><% } %>
+const isProduction = process.env.NODE_ENV === "production";
 
 /** @type {import("webpack").Configuration} */
 const config <% if (langType === "Typescript") { %>: Configuration <% } %>= {
-    entry: "<%= entry %>",
+    entry: <% if (html) { %>"./index.html"<% } else { %>"<%= entry %>"<% } %>,
     output: {
         path: path.resolve(__dirname, "dist"),
     },<% if (devServer) { %>
     devServer: {
         open: true,
     },<% } %>
+    experiments: {
+        css: true,<% if (html) { %>
+        html: true,<% } %>
+    },
     plugins: [
-        new VueLoaderPlugin(),<% if (htmlWebpackPlugin) { %>
-        new HtmlWebpackPlugin({
-            template: "index.html",
-        }),<% } %><% if (extractPlugin === "Yes") { %>
-        new MiniCssExtractPlugin(),<% } %>
+        new VueLoaderPlugin(),
         // Add your plugins here
         // Learn more about plugins from https://webpack.js.org/configuration/plugins/
     ],
@@ -38,7 +33,10 @@ const config <% if (langType === "Typescript") { %>: Configuration <% } %>= {
         rules: [
             {
                 test: /\.vue$/,
-                loader: "vue-loader"
+                loader: "vue-loader",
+                options: {
+                    experimentalInlineMatchResource: true,
+                },
             },<% if (langType == "ES6") { %>
             {
                 test: /\.js$/,
@@ -58,26 +56,26 @@ const config <% if (langType === "Typescript") { %>: Configuration <% } %>= {
                     transpileOnly: true,
                 },
                 exclude: ["/node_modules/"],
-            },<% } %><%  if (isCSS && !isPostCSS) { %>
+            },<% } %><%  if (isCSS && isPostCSS) { %>
             {
                 test: /\.css$/i,
-                use: [stylesHandler,"css-loader"],
+                type: "css/auto",
+                use: ["postcss-loader"],
             },<% } %><%  if (cssType == "SASS") { %>
             {
                 test: /\.s[ac]ss$/i,
-                use: [stylesHandler, "css-loader", <% if (isPostCSS) { %>"postcss-loader", <% } %>"sass-loader"],
+                type: "css/auto",
+                use: [<% if (isPostCSS) { %>"postcss-loader", <% } %>"sass-loader"],
             },<% } %><%  if (cssType == "LESS") { %>
             {
                 test: /\.less$/i,
-                use: [stylesHandler, "css-loader", <% if (isPostCSS) { %>"postcss-loader", <% } %>"less-loader"],
+                type: "css/auto",
+                use: [<% if (isPostCSS) { %>"postcss-loader", <% } %>"less-loader"],
             },<% } %><%  if (cssType == "Stylus") { %>
             {
                 test: /\.styl$/i,
-                use: [stylesHandler, "css-loader", <% if (isPostCSS) { %>"postcss-loader", <% } %>"stylus-loader"],
-            },<% } %><%  if (isPostCSS && isCSS) { %>
-            {
-                test: /\.css$/i,
-                use: [stylesHandler, "css-loader", "postcss-loader"],
+                type: "css/auto",
+                use: [<% if (isPostCSS) { %>"postcss-loader", <% } %>"stylus-loader"],
             },<% } %>
             {
                 test: /\.(eot|svg|ttf|woff|woff2|png|jpg|gif)$/i,
@@ -97,8 +95,7 @@ const config <% if (langType === "Typescript") { %>: Configuration <% } %>= {
 
 export default () => {
     if (isProduction) {
-        config.mode = "production";<% if (extractPlugin === "Only for Production") { %>
-        config.plugins?.push(new MiniCssExtractPlugin());<% } %><% if (workboxWebpackPlugin) { %>
+        config.mode = "production";<% if (workboxWebpackPlugin) { %>
         config.plugins?.push(new WorkboxWebpackPlugin.GenerateSW());<% } %>
     } else {
         config.mode = "development";

--- a/test/create-webpack-app/init/__snapshots__/init.test.js.snap.webpack5
+++ b/test/create-webpack-app/init/__snapshots__/init.test.js.snap.webpack5
@@ -4,8 +4,6 @@ exports[`create-webpack-app cli recognizes '-t' as an alias for '--template' and
 {
   "description": "My webpack project",
   "devDependencies": {
-    "html-loader": "x.x.x",
-    "html-webpack-plugin": "x.x.x",
     "webpack": "x.x.x",
     "webpack-cli": "x.x.x",
     "webpack-dev-server": "x.x.x",
@@ -27,8 +25,6 @@ exports[`create-webpack-app cli should ask question when wrong template is suppl
 {
   "description": "My webpack project",
   "devDependencies": {
-    "html-loader": "x.x.x",
-    "html-webpack-plugin": "x.x.x",
     "webpack": "x.x.x",
     "webpack-cli": "x.x.x",
     "webpack-dev-server": "x.x.x",
@@ -95,7 +91,6 @@ const config = {
                 test: /\\.(eot|svg|ttf|woff|woff2|png|jpg|gif)$/i,
                 type: "asset",
             },
-            
 
             // Add your rules for custom modules here
             // Learn more about loaders from https://webpack.js.org/loaders/
@@ -114,12 +109,10 @@ export default () => {
 "
 `;
 
-exports[`create-webpack-app cli should configure html-webpack-plugin as opted 1`] = `
+exports[`create-webpack-app cli should configure native HTML support as opted 1`] = `
 {
   "description": "My webpack project",
   "devDependencies": {
-    "html-loader": "x.x.x",
-    "html-webpack-plugin": "x.x.x",
     "webpack": "x.x.x",
     "webpack-cli": "x.x.x",
   },
@@ -134,12 +127,11 @@ exports[`create-webpack-app cli should configure html-webpack-plugin as opted 1`
 }
 `;
 
-exports[`create-webpack-app cli should configure html-webpack-plugin as opted 2`] = `
+exports[`create-webpack-app cli should configure native HTML support as opted 2`] = `
 "// Generated using webpack-cli https://github.com/webpack/webpack-cli
 
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import HtmlWebpackPlugin from "html-webpack-plugin";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -147,14 +139,11 @@ const isProduction = process.env.NODE_ENV === "production";
 
 /** @type {import("webpack").Configuration} */
 const config = {
-    entry: "./src/index.js",
+    entry: "./index.html",
     output: {
         path: path.resolve(__dirname, "dist"),
     },
     plugins: [
-        new HtmlWebpackPlugin({
-            template: "index.html",
-        }),
         // Add your plugins here
         // Learn more about plugins from https://webpack.js.org/configuration/plugins/
     ],
@@ -163,11 +152,6 @@ const config = {
             {
                 test: /\\.(eot|svg|ttf|woff|woff2|png|jpg|gif)$/i,
                 type: "asset",
-            },
-            
-            {
-                test: /\\.html$/i,
-                use: ["html-loader"],
             },
 
             // Add your rules for custom modules here
@@ -191,8 +175,6 @@ exports[`create-webpack-app cli should configure workbox-webpack-plugin as opted
 {
   "description": "My webpack project",
   "devDependencies": {
-    "html-loader": "x.x.x",
-    "html-webpack-plugin": "x.x.x",
     "webpack": "x.x.x",
     "webpack-cli": "x.x.x",
     "workbox-webpack-plugin": "x.x.x",
@@ -213,7 +195,6 @@ exports[`create-webpack-app cli should configure workbox-webpack-plugin as opted
 
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import HtmlWebpackPlugin from "html-webpack-plugin";
 import WorkboxWebpackPlugin from "workbox-webpack-plugin";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -222,14 +203,11 @@ const isProduction = process.env.NODE_ENV === "production";
 
 /** @type {import("webpack").Configuration} */
 const config = {
-    entry: "./src/index.js",
+    entry: "./index.html",
     output: {
         path: path.resolve(__dirname, "dist"),
     },
     plugins: [
-        new HtmlWebpackPlugin({
-            template: "index.html",
-        }),
         // Add your plugins here
         // Learn more about plugins from https://webpack.js.org/configuration/plugins/
     ],
@@ -238,11 +216,6 @@ const config = {
             {
                 test: /\\.(eot|svg|ttf|woff|woff2|png|jpg|gif)$/i,
                 type: "asset",
-            },
-            
-            {
-                test: /\\.html$/i,
-                use: ["html-loader"],
             },
 
             // Add your rules for custom modules here
@@ -314,7 +287,6 @@ const config = {
                 test: /\\.(eot|svg|ttf|woff|woff2|png|jpg|gif)$/i,
                 type: "asset",
             },
-            
 
             // Add your rules for custom modules here
             // Learn more about loaders from https://webpack.js.org/loaders/
@@ -337,8 +309,6 @@ exports[`create-webpack-app cli should generate default project when nothing is 
 {
   "description": "My webpack project",
   "devDependencies": {
-    "html-loader": "x.x.x",
-    "html-webpack-plugin": "x.x.x",
     "webpack": "x.x.x",
     "webpack-cli": "x.x.x",
     "webpack-dev-server": "x.x.x",
@@ -361,7 +331,6 @@ exports[`create-webpack-app cli should generate default project when nothing is 
 
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import HtmlWebpackPlugin from "html-webpack-plugin";
 import WorkboxWebpackPlugin from "workbox-webpack-plugin";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -370,7 +339,7 @@ const isProduction = process.env.NODE_ENV === "production";
 
 /** @type {import("webpack").Configuration} */
 const config = {
-    entry: "./src/index.js",
+    entry: "./index.html",
     output: {
         path: path.resolve(__dirname, "dist"),
     },
@@ -378,9 +347,6 @@ const config = {
         open: true,
     },
     plugins: [
-        new HtmlWebpackPlugin({
-            template: "index.html",
-        }),
         // Add your plugins here
         // Learn more about plugins from https://webpack.js.org/configuration/plugins/
     ],
@@ -389,11 +355,6 @@ const config = {
             {
                 test: /\\.(eot|svg|ttf|woff|woff2|png|jpg|gif)$/i,
                 type: "asset",
-            },
-            
-            {
-                test: /\\.html$/i,
-                use: ["html-loader"],
             },
 
             // Add your rules for custom modules here
@@ -418,8 +379,6 @@ exports[`create-webpack-app cli should generate default project when nothing is 
 {
   "description": "My webpack project",
   "devDependencies": {
-    "html-loader": "x.x.x",
-    "html-webpack-plugin": "x.x.x",
     "webpack": "x.x.x",
     "webpack-cli": "x.x.x",
     "webpack-dev-server": "x.x.x",
@@ -442,7 +401,6 @@ exports[`create-webpack-app cli should generate default project when nothing is 
 
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import HtmlWebpackPlugin from "html-webpack-plugin";
 import WorkboxWebpackPlugin from "workbox-webpack-plugin";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -451,7 +409,7 @@ const isProduction = process.env.NODE_ENV === "production";
 
 /** @type {import("webpack").Configuration} */
 const config = {
-    entry: "./src/index.js",
+    entry: "./index.html",
     output: {
         path: path.resolve(__dirname, "dist"),
     },
@@ -459,9 +417,6 @@ const config = {
         open: true,
     },
     plugins: [
-        new HtmlWebpackPlugin({
-            template: "index.html",
-        }),
         // Add your plugins here
         // Learn more about plugins from https://webpack.js.org/configuration/plugins/
     ],
@@ -470,11 +425,6 @@ const config = {
             {
                 test: /\\.(eot|svg|ttf|woff|woff2|png|jpg|gif)$/i,
                 type: "asset",
-            },
-            
-            {
-                test: /\\.html$/i,
-                use: ["html-loader"],
             },
 
             // Add your rules for custom modules here
@@ -521,7 +471,6 @@ exports[`create-webpack-app cli should generate default project when nothing is 
 
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import HtmlWebpackPlugin from "html-webpack-plugin";
 import WorkboxWebpackPlugin from "workbox-webpack-plugin";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -530,7 +479,7 @@ const isProduction = process.env.NODE_ENV === "production";
 
 /** @type {import("webpack").Configuration} */
 const config = {
-    entry: "./src/index.js",
+    entry: "./index.html",
     output: {
         path: path.resolve(__dirname, "dist"),
     },
@@ -538,9 +487,6 @@ const config = {
         open: true,
     },
     plugins: [
-        new HtmlWebpackPlugin({
-            template: "index.html",
-        }),
         // Add your plugins here
         // Learn more about plugins from https://webpack.js.org/configuration/plugins/
     ],
@@ -549,11 +495,6 @@ const config = {
             {
                 test: /\\.(eot|svg|ttf|woff|woff2|png|jpg|gif)$/i,
                 type: "asset",
-            },
-            
-            {
-                test: /\\.html$/i,
-                use: ["html-loader"],
             },
 
             // Add your rules for custom modules here
@@ -578,8 +519,6 @@ exports[`create-webpack-app cli should generate default project when nothing is 
 {
   "description": "My webpack project",
   "devDependencies": {
-    "html-loader": "x.x.x",
-    "html-webpack-plugin": "x.x.x",
     "webpack": "x.x.x",
     "webpack-cli": "x.x.x",
     "webpack-dev-server": "x.x.x",
@@ -602,7 +541,6 @@ exports[`create-webpack-app cli should generate default project when nothing is 
 
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import HtmlWebpackPlugin from "html-webpack-plugin";
 import WorkboxWebpackPlugin from "workbox-webpack-plugin";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -611,7 +549,7 @@ const isProduction = process.env.NODE_ENV === "production";
 
 /** @type {import("webpack").Configuration} */
 const config = {
-    entry: "./src/index.js",
+    entry: "./index.html",
     output: {
         path: path.resolve(__dirname, "dist"),
     },
@@ -619,9 +557,6 @@ const config = {
         open: true,
     },
     plugins: [
-        new HtmlWebpackPlugin({
-            template: "index.html",
-        }),
         // Add your plugins here
         // Learn more about plugins from https://webpack.js.org/configuration/plugins/
     ],
@@ -630,11 +565,6 @@ const config = {
             {
                 test: /\\.(eot|svg|ttf|woff|woff2|png|jpg|gif)$/i,
                 type: "asset",
-            },
-            
-            {
-                test: /\\.html$/i,
-                use: ["html-loader"],
             },
 
             // Add your rules for custom modules here
@@ -659,8 +589,6 @@ exports[`create-webpack-app cli should generate default project when nothing is 
 {
   "description": "My webpack project",
   "devDependencies": {
-    "html-loader": "x.x.x",
-    "html-webpack-plugin": "x.x.x",
     "webpack": "x.x.x",
     "webpack-cli": "x.x.x",
     "webpack-dev-server": "x.x.x",
@@ -683,7 +611,6 @@ exports[`create-webpack-app cli should generate default project when nothing is 
 
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import HtmlWebpackPlugin from "html-webpack-plugin";
 import WorkboxWebpackPlugin from "workbox-webpack-plugin";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -692,7 +619,7 @@ const isProduction = process.env.NODE_ENV === "production";
 
 /** @type {import("webpack").Configuration} */
 const config = {
-    entry: "./src/index.js",
+    entry: "./index.html",
     output: {
         path: path.resolve(__dirname, "dist"),
     },
@@ -700,9 +627,6 @@ const config = {
         open: true,
     },
     plugins: [
-        new HtmlWebpackPlugin({
-            template: "index.html",
-        }),
         // Add your plugins here
         // Learn more about plugins from https://webpack.js.org/configuration/plugins/
     ],
@@ -711,11 +635,6 @@ const config = {
             {
                 test: /\\.(eot|svg|ttf|woff|woff2|png|jpg|gif)$/i,
                 type: "asset",
-            },
-            
-            {
-                test: /\\.html$/i,
-                use: ["html-loader"],
             },
 
             // Add your rules for custom modules here
@@ -740,8 +659,6 @@ exports[`create-webpack-app cli should generate folders if non existing generati
 {
   "description": "My webpack project",
   "devDependencies": {
-    "html-loader": "x.x.x",
-    "html-webpack-plugin": "x.x.x",
     "webpack": "x.x.x",
     "webpack-cli": "x.x.x",
     "webpack-dev-server": "x.x.x",
@@ -763,8 +680,6 @@ exports[`create-webpack-app cli should generate project when generationPath is s
 {
   "description": "My webpack project",
   "devDependencies": {
-    "html-loader": "x.x.x",
-    "html-webpack-plugin": "x.x.x",
     "webpack": "x.x.x",
     "webpack-cli": "x.x.x",
     "webpack-dev-server": "x.x.x",
@@ -792,15 +707,11 @@ exports[`create-webpack-app cli should generate react template with state and ro
     "@types/react-router-dom": "x.x.x",
     "autoprefixer": "x.x.x",
     "babel-loader": "x.x.x",
-    "css-loader": "x.x.x",
-    "html-webpack-plugin": "x.x.x",
-    "mini-css-extract-plugin": "x.x.x",
     "postcss": "x.x.x",
     "postcss-loader": "x.x.x",
     "react": "x.x.x",
     "react-dom": "x.x.x",
     "react-router-dom": "x.x.x",
-    "style-loader": "x.x.x",
     "webpack": "x.x.x",
     "webpack-cli": "x.x.x",
     "webpack-dev-server": "x.x.x",
@@ -823,28 +734,25 @@ exports[`create-webpack-app cli should generate react template with state and ro
 
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import HtmlWebpackPlugin from "html-webpack-plugin";
-import MiniCssExtractPlugin from "mini-css-extract-plugin";
 import WorkboxWebpackPlugin from "workbox-webpack-plugin";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const isProduction = process.env.NODE_ENV === "production";
-const stylesHandler = isProduction ? MiniCssExtractPlugin.loader : "style-loader";
 
 /** @type {import("webpack").Configuration} */
 const config = {
-    entry: "./src/index.jsx",
+    entry: "./index.html",
     output: {
         path: path.resolve(__dirname, "dist"),
     },
     devServer: {
         open: true,
     },
+    experiments: {
+        css: true,
+    },
     plugins: [
-        new HtmlWebpackPlugin({
-            template: "index.html",
-        }),
         // Add your plugins here
         // Learn more about plugins from https://webpack.js.org/configuration/plugins/
     ],
@@ -862,7 +770,8 @@ const config = {
             },
             {
                 test: /\\.css$/i,
-                use: [stylesHandler, "css-loader", "postcss-loader"],
+                type: "css/auto",
+                use: ["postcss-loader"],
             },
             {
                 test: /\\.(eot|svg|ttf|woff|woff2|png|jpg|gif)$/i,
@@ -884,7 +793,6 @@ const config = {
 export default () => {
     if (isProduction) {
         config.mode = "production";
-        config.plugins?.push(new MiniCssExtractPlugin());
         config.plugins?.push(new WorkboxWebpackPlugin.GenerateSW());
     } else {
         config.mode = "development";
@@ -902,15 +810,11 @@ exports[`create-webpack-app cli should generate react template with typescript 1
     "@types/react-dom": "x.x.x",
     "@types/react-router-dom": "x.x.x",
     "autoprefixer": "x.x.x",
-    "css-loader": "x.x.x",
-    "html-webpack-plugin": "x.x.x",
-    "mini-css-extract-plugin": "x.x.x",
     "postcss": "x.x.x",
     "postcss-loader": "x.x.x",
     "react": "x.x.x",
     "react-dom": "x.x.x",
     "react-router-dom": "x.x.x",
-    "style-loader": "x.x.x",
     "ts-loader": "x.x.x",
     "typescript": "x.x.x",
     "webpack": "x.x.x",
@@ -937,28 +841,25 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { type Configuration } from "webpack";
 import "webpack-dev-server";
-import HtmlWebpackPlugin from "html-webpack-plugin";
-import MiniCssExtractPlugin from "mini-css-extract-plugin";
 import WorkboxWebpackPlugin from "workbox-webpack-plugin";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const isProduction = process.env.NODE_ENV === "production";
-const stylesHandler = isProduction ? MiniCssExtractPlugin.loader : "style-loader";
 
 /** @type {import("webpack").Configuration} */
 const config : Configuration = {
-    entry: "./src/index.tsx",
+    entry: "./index.html",
     output: {
         path: path.resolve(__dirname, "dist"),
     },
     devServer: {
         open: true,
     },
+    experiments: {
+        css: true,
+    },
     plugins: [
-        new HtmlWebpackPlugin({
-            template: "index.html",
-        }),
         // Add your plugins here
         // Learn more about plugins from https://webpack.js.org/configuration/plugins/
     ],
@@ -971,7 +872,8 @@ const config : Configuration = {
             },
             {
                 test: /\\.css$/i,
-                use: [stylesHandler, "css-loader", "postcss-loader"],
+                type: "css/auto",
+                use: ["postcss-loader"],
             },
             {
                 test: /\\.(eot|svg|ttf|woff|woff2|png|jpg|gif)$/i,
@@ -993,7 +895,6 @@ const config : Configuration = {
 export default () => {
     if (isProduction) {
         config.mode = "production";
-        config.plugins?.push(new MiniCssExtractPlugin());
         config.plugins?.push(new WorkboxWebpackPlugin.GenerateSW());
     } else {
         config.mode = "development";
@@ -1011,12 +912,8 @@ exports[`create-webpack-app cli should generate svelte template with prompt answ
     "@babel/preset-env": "x.x.x",
     "autoprefixer": "x.x.x",
     "babel-loader": "x.x.x",
-    "css-loader": "x.x.x",
-    "html-webpack-plugin": "x.x.x",
-    "mini-css-extract-plugin": "x.x.x",
     "postcss": "x.x.x",
     "postcss-loader": "x.x.x",
-    "style-loader": "x.x.x",
     "svelte": "x.x.x",
     "svelte-loader": "x.x.x",
     "webpack": "x.x.x",
@@ -1041,28 +938,25 @@ exports[`create-webpack-app cli should generate svelte template with prompt answ
 
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import HtmlWebpackPlugin from "html-webpack-plugin";
-import MiniCssExtractPlugin from "mini-css-extract-plugin";
 import WorkboxWebpackPlugin from "workbox-webpack-plugin";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const isProduction = process.env.NODE_ENV === "production";
-const stylesHandler = isProduction ? MiniCssExtractPlugin.loader : "style-loader";
 
 /** @type {import("webpack").Configuration} */
 const config = {
-    entry: "./src/main.js",
+    entry: "./index.html",
     output: {
         path: path.resolve(__dirname, "dist"),
     },
     devServer: {
         open: true,
     },
+    experiments: {
+        css: true,
+    },
     plugins: [
-        new HtmlWebpackPlugin({
-            template: "./index.html",
-        }),
         // Add your plugins here
         // Learn more about plugins from https://webpack.js.org/configuration/plugins/
     ],
@@ -1090,7 +984,8 @@ const config = {
             },
             {
                 test: /\\.css$/i,
-                use: [stylesHandler, "css-loader", "postcss-loader"],
+                type: "css/auto",
+                use: ["postcss-loader"],
             },
             {
                 test: /\\.(eot|svg|ttf|woff|woff2|png|jpg|gif)$/i,
@@ -1113,7 +1008,6 @@ const config = {
 export default () => {
     if (isProduction) {
         config.mode = "production";
-        config.plugins?.push(new MiniCssExtractPlugin());
         config.plugins?.push(new WorkboxWebpackPlugin.GenerateSW());
     } else {
         config.mode = "development";
@@ -1129,12 +1023,8 @@ exports[`create-webpack-app cli should generate svelte template with typescript 
   "devDependencies": {
     "@tsconfig/svelte": "x.x.x",
     "autoprefixer": "x.x.x",
-    "css-loader": "x.x.x",
-    "html-webpack-plugin": "x.x.x",
-    "mini-css-extract-plugin": "x.x.x",
     "postcss": "x.x.x",
     "postcss-loader": "x.x.x",
-    "style-loader": "x.x.x",
     "svelte": "x.x.x",
     "svelte-loader": "x.x.x",
     "ts-loader": "x.x.x",
@@ -1163,28 +1053,25 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { type Configuration } from "webpack";
 import "webpack-dev-server";
-import HtmlWebpackPlugin from "html-webpack-plugin";
-import MiniCssExtractPlugin from "mini-css-extract-plugin";
 import WorkboxWebpackPlugin from "workbox-webpack-plugin";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const isProduction = process.env.NODE_ENV === "production";
-const stylesHandler = isProduction ? MiniCssExtractPlugin.loader : "style-loader";
 
 /** @type {import("webpack").Configuration} */
 const config : Configuration = {
-    entry: "./src/main.ts",
+    entry: "./index.html",
     output: {
         path: path.resolve(__dirname, "dist"),
     },
     devServer: {
         open: true,
     },
+    experiments: {
+        css: true,
+    },
     plugins: [
-        new HtmlWebpackPlugin({
-            template: "./index.html",
-        }),
         // Add your plugins here
         // Learn more about plugins from https://webpack.js.org/configuration/plugins/
     ],
@@ -1210,7 +1097,8 @@ const config : Configuration = {
             },
             {
                 test: /\\.css$/i,
-                use: [stylesHandler, "css-loader", "postcss-loader"],
+                type: "css/auto",
+                use: ["postcss-loader"],
             },
             {
                 test: /\\.(eot|svg|ttf|woff|woff2|png|jpg|gif)$/i,
@@ -1233,7 +1121,6 @@ const config : Configuration = {
 export default () => {
     if (isProduction) {
         config.mode = "production";
-        config.plugins?.push(new MiniCssExtractPlugin());
         config.plugins?.push(new WorkboxWebpackPlugin.GenerateSW());
     } else {
         config.mode = "development";
@@ -1295,7 +1182,6 @@ const config : Configuration = {
                 test: /\\.(eot|svg|ttf|woff|woff2|png|jpg|gif)$/i,
                 type: "asset",
             },
-            
 
             // Add your rules for custom modules here
             // Learn more about loaders from https://webpack.js.org/loaders/
@@ -1326,17 +1212,12 @@ exports[`create-webpack-app cli should generate vue template with store and rout
     "@vue/compiler-sfc": "x.x.x",
     "autoprefixer": "x.x.x",
     "babel-loader": "x.x.x",
-    "css-loader": "x.x.x",
-    "html-webpack-plugin": "x.x.x",
-    "mini-css-extract-plugin": "x.x.x",
     "pinia": "x.x.x",
     "postcss": "x.x.x",
     "postcss-loader": "x.x.x",
-    "style-loader": "x.x.x",
     "vue": "x.x.x",
     "vue-loader": "x.x.x",
     "vue-router": "x.x.x",
-    "vue-style-loader": "x.x.x",
     "webpack": "x.x.x",
     "webpack-cli": "x.x.x",
     "webpack-dev-server": "x.x.x",
@@ -1360,29 +1241,27 @@ exports[`create-webpack-app cli should generate vue template with store and rout
 import { VueLoaderPlugin } from "vue-loader";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import HtmlWebpackPlugin from "html-webpack-plugin";
-import MiniCssExtractPlugin from "mini-css-extract-plugin";
 import WorkboxWebpackPlugin from "workbox-webpack-plugin";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const isProduction = process.env.NODE_ENV === "production";
-const stylesHandler = isProduction ? MiniCssExtractPlugin.loader : "vue-style-loader";
 
 /** @type {import("webpack").Configuration} */
 const config = {
-    entry: "./src/main.js",
+    entry: "./index.html",
     output: {
         path: path.resolve(__dirname, "dist"),
     },
     devServer: {
         open: true,
     },
+    experiments: {
+        css: true,
+        html: true,
+    },
     plugins: [
         new VueLoaderPlugin(),
-        new HtmlWebpackPlugin({
-            template: "index.html",
-        }),
         // Add your plugins here
         // Learn more about plugins from https://webpack.js.org/configuration/plugins/
     ],
@@ -1390,7 +1269,10 @@ const config = {
         rules: [
             {
                 test: /\\.vue$/,
-                loader: "vue-loader"
+                loader: "vue-loader",
+                options: {
+                    experimentalInlineMatchResource: true,
+                },
             },
             {
                 test: /\\.js$/,
@@ -1404,7 +1286,8 @@ const config = {
             },
             {
                 test: /\\.css$/i,
-                use: [stylesHandler, "css-loader", "postcss-loader"],
+                type: "css/auto",
+                use: ["postcss-loader"],
             },
             {
                 test: /\\.(eot|svg|ttf|woff|woff2|png|jpg|gif)$/i,
@@ -1424,7 +1307,6 @@ const config = {
 export default () => {
     if (isProduction) {
         config.mode = "production";
-        config.plugins?.push(new MiniCssExtractPlugin());
         config.plugins?.push(new WorkboxWebpackPlugin.GenerateSW());
     } else {
         config.mode = "development";
@@ -1440,19 +1322,14 @@ exports[`create-webpack-app cli should generate vue template with typescript 1`]
   "devDependencies": {
     "@vue/compiler-sfc": "x.x.x",
     "autoprefixer": "x.x.x",
-    "css-loader": "x.x.x",
-    "html-webpack-plugin": "x.x.x",
-    "mini-css-extract-plugin": "x.x.x",
     "pinia": "x.x.x",
     "postcss": "x.x.x",
     "postcss-loader": "x.x.x",
-    "style-loader": "x.x.x",
     "ts-loader": "x.x.x",
     "typescript": "x.x.x",
     "vue": "x.x.x",
     "vue-loader": "x.x.x",
     "vue-router": "x.x.x",
-    "vue-style-loader": "x.x.x",
     "webpack": "x.x.x",
     "webpack-cli": "x.x.x",
     "webpack-dev-server": "x.x.x",
@@ -1478,29 +1355,27 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { type Configuration } from "webpack";
 import "webpack-dev-server";
-import HtmlWebpackPlugin from "html-webpack-plugin";
-import MiniCssExtractPlugin from "mini-css-extract-plugin";
 import WorkboxWebpackPlugin from "workbox-webpack-plugin";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const isProduction = process.env.NODE_ENV === "production";
-const stylesHandler = isProduction ? MiniCssExtractPlugin.loader : "vue-style-loader";
 
 /** @type {import("webpack").Configuration} */
 const config : Configuration = {
-    entry: "./src/main.ts",
+    entry: "./index.html",
     output: {
         path: path.resolve(__dirname, "dist"),
     },
     devServer: {
         open: true,
     },
+    experiments: {
+        css: true,
+        html: true,
+    },
     plugins: [
         new VueLoaderPlugin(),
-        new HtmlWebpackPlugin({
-            template: "index.html",
-        }),
         // Add your plugins here
         // Learn more about plugins from https://webpack.js.org/configuration/plugins/
     ],
@@ -1508,7 +1383,10 @@ const config : Configuration = {
         rules: [
             {
                 test: /\\.vue$/,
-                loader: "vue-loader"
+                loader: "vue-loader",
+                options: {
+                    experimentalInlineMatchResource: true,
+                },
             },
             {
                 test: /\\.(ts|tsx)$/i,
@@ -1521,7 +1399,8 @@ const config : Configuration = {
             },
             {
                 test: /\\.css$/i,
-                use: [stylesHandler, "css-loader", "postcss-loader"],
+                type: "css/auto",
+                use: ["postcss-loader"],
             },
             {
                 test: /\\.(eot|svg|ttf|woff|woff2|png|jpg|gif)$/i,
@@ -1542,7 +1421,6 @@ const config : Configuration = {
 export default () => {
     if (isProduction) {
         config.mode = "production";
-        config.plugins?.push(new MiniCssExtractPlugin());
         config.plugins?.push(new WorkboxWebpackPlugin.GenerateSW());
     } else {
         config.mode = "development";
@@ -1557,13 +1435,10 @@ exports[`create-webpack-app cli should use css preprocessor and css with postcss
   "description": "My webpack project",
   "devDependencies": {
     "autoprefixer": "x.x.x",
-    "css-loader": "x.x.x",
-    "mini-css-extract-plugin": "x.x.x",
     "postcss": "x.x.x",
     "postcss-loader": "x.x.x",
     "sass": "x.x.x",
     "sass-loader": "x.x.x",
-    "style-loader": "x.x.x",
     "webpack": "x.x.x",
     "webpack-cli": "x.x.x",
   },
@@ -1583,18 +1458,19 @@ exports[`create-webpack-app cli should use css preprocessor and css with postcss
 
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import MiniCssExtractPlugin from "mini-css-extract-plugin";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const isProduction = process.env.NODE_ENV === "production";
-const stylesHandler = isProduction ? MiniCssExtractPlugin.loader : "style-loader";
 
 /** @type {import("webpack").Configuration} */
 const config = {
     entry: "./src/index.js",
     output: {
         path: path.resolve(__dirname, "dist"),
+    },
+    experiments: {
+        css: true,
     },
     plugins: [
         // Add your plugins here
@@ -1603,18 +1479,19 @@ const config = {
     module: {
         rules: [
             {
-                test: /\\.s[ac]ss$/i,
-                use: [stylesHandler, "css-loader", "postcss-loader", "sass-loader"],
+                test: /\\.css$/i,
+                type: "css/auto",
+                use: ["postcss-loader"],
             },
             {
-                test: /\\.css$/i,
-                use: [stylesHandler, "css-loader", "postcss-loader"],
+                test: /\\.s[ac]ss$/i,
+                type: "css/auto",
+                use: ["postcss-loader", "sass-loader"],
             },
             {
                 test: /\\.(eot|svg|ttf|woff|woff2|png|jpg|gif)$/i,
                 type: "asset",
             },
-            
 
             // Add your rules for custom modules here
             // Learn more about loaders from https://webpack.js.org/loaders/
@@ -1625,7 +1502,6 @@ const config = {
 export default () => {
     if (isProduction) {
         config.mode = "production";
-        config.plugins?.push(new MiniCssExtractPlugin());
     } else {
         config.mode = "development";
     }
@@ -1634,18 +1510,15 @@ export default () => {
 "
 `;
 
-exports[`create-webpack-app cli should use to use css preprocessor with postcss with mini-css-extract-plugin in project when selected 1`] = `
+exports[`create-webpack-app cli should use css preprocessor with postcss in project when selected 1`] = `
 {
   "description": "My webpack project",
   "devDependencies": {
     "autoprefixer": "x.x.x",
-    "css-loader": "x.x.x",
-    "mini-css-extract-plugin": "x.x.x",
     "postcss": "x.x.x",
     "postcss-loader": "x.x.x",
     "sass": "x.x.x",
     "sass-loader": "x.x.x",
-    "style-loader": "x.x.x",
     "webpack": "x.x.x",
     "webpack-cli": "x.x.x",
   },
@@ -1660,17 +1533,15 @@ exports[`create-webpack-app cli should use to use css preprocessor with postcss 
 }
 `;
 
-exports[`create-webpack-app cli should use to use css preprocessor with postcss with mini-css-extract-plugin in project when selected 2`] = `
+exports[`create-webpack-app cli should use css preprocessor with postcss in project when selected 2`] = `
 "// Generated using webpack-cli https://github.com/webpack/webpack-cli
 
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import MiniCssExtractPlugin from "mini-css-extract-plugin";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const isProduction = process.env.NODE_ENV === "production";
-const stylesHandler = isProduction ? MiniCssExtractPlugin.loader : "style-loader";
 
 /** @type {import("webpack").Configuration} */
 const config = {
@@ -1686,13 +1557,13 @@ const config = {
         rules: [
             {
                 test: /\\.s[ac]ss$/i,
-                use: [stylesHandler, "css-loader", "postcss-loader", "sass-loader"],
+                type: "css/auto",
+                use: ["postcss-loader", "sass-loader"],
             },
             {
                 test: /\\.(eot|svg|ttf|woff|woff2|png|jpg|gif)$/i,
                 type: "asset",
             },
-            
 
             // Add your rules for custom modules here
             // Learn more about loaders from https://webpack.js.org/loaders/
@@ -1703,7 +1574,6 @@ const config = {
 export default () => {
     if (isProduction) {
         config.mode = "production";
-        config.plugins?.push(new MiniCssExtractPlugin());
     } else {
         config.mode = "development";
     }
@@ -1716,8 +1586,6 @@ exports[`create-webpack-app cli should work with 'new' alias 1`] = `
 {
   "description": "My webpack project",
   "devDependencies": {
-    "html-loader": "x.x.x",
-    "html-webpack-plugin": "x.x.x",
     "webpack": "x.x.x",
     "webpack-cli": "x.x.x",
     "webpack-dev-server": "x.x.x",

--- a/test/create-webpack-app/init/init.test.js
+++ b/test/create-webpack-app/init/init.test.js
@@ -352,7 +352,7 @@ describe("create-webpack-app cli", () => {
     expect(readFromWebpackConfig(dir)).toMatchSnapshot();
   });
 
-  it("should use to use css preprocessor with postcss with mini-css-extract-plugin in project when selected", async () => {
+  it("should use css preprocessor with postcss in project when selected", async () => {
     const { stdout } = await runPromptWithAnswers(
       dir,
       ["init", "."],
@@ -441,7 +441,7 @@ describe("create-webpack-app cli", () => {
     expect(readFromWebpackConfig(dir)).toMatchSnapshot();
   });
 
-  it("should configure html-webpack-plugin as opted", async () => {
+  it("should configure native HTML support as opted", async () => {
     const { stdout } = await runPromptWithAnswers(
       dir,
       ["init", "."],


### PR DESCRIPTION
**Summary**

The `init` templates still scaffolded CSS and HTML through loaders and plugins that webpack now handles natively. This PR moves the four templates (`default`, `react`, `vue`, `svelte`) to webpack's built-in support:

- **CSS**: `experiments.css` replaces `css-loader`, `style-loader`, `vue-style-loader` and `mini-css-extract-plugin`. Sass/Less/Stylus and PostCSS are wired through `type: "css/auto"` rules.
- **HTML**: `index.html` becomes the entry point, handled by `experiments.html`, replacing `html-webpack-plugin` and `html-loader`.

Both experiments default to `"auto"` since webpack 5.109, so the generated configs only declare them where the auto detection would turn them off:

- a PostCSS rule for `.css` files registers a loader for CSS, which disables the auto default (without an explicit `experiments.css: true` the build fails with `No parser registered for css/auto`);
- the Vue template, where `VueLoaderPlugin` clones every non-vue rule with a catch-all `resource: () => true` matcher, and plugins are applied before webpack resolves the defaults, so the auto detection sees a loader for both `.css` and `.html`. The Vue template also sets `experimentalInlineMatchResource` in `vue-loader`, which that loader requires when `experiments.css` is enabled.

The "Do you want to extract CSS into separate files?" prompt is gone, since native CSS always emits separate files, and the `htmlWebpackPlugin` answer is now named `html`.

**What kind of change does this PR introduce?**

feat

**Did you add tests for your changes?**

The existing `test/create-webpack-app/init` suite covers this; its snapshots are updated for the new configs and dependency lists. Beyond the suite, I generated a project from each of the four templates and ran a production build: the emitted `index.html` gets the `<link>`/`<script>` tags injected and CSS is emitted as a separate file, and in the Vue app scoped SFC styles come out correctly (`.sfc-test[data-v-6493cde5]`).

**Does this PR introduce a breaking change?**

Not for existing projects, they are unaffected. Newly generated projects change: they no longer install the CSS/HTML loaders and plugins, `index.html` is the entry point, and the CSS extraction prompt is gone. The `htmlWebpackPlugin` answer key is renamed to `html`, which affects anyone driving the generator programmatically. Released as a minor for `create-webpack-app` (changeset included).

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

Nothing beyond the changeset in this PR.

**Use of AI**

Yes. I used Claude Code (Opus) to carry out the migration across the templates and generators, under my direction and step by step. Every claim in the description was verified by actually generating and building the projects rather than assumed, and I reviewed the final diff.
