### PR TITLE
chore: update webpack-dev-server to v6 and test against v5 and v6

### DIFF
--- a/.changeset/dev-server-6-types.md
+++ b/.changeset/dev-server-6-types.md
@@ -1,0 +1,5 @@
+---
+"webpack-cli": patch
+---
+
+fix: resolve the `webpack-dev-server` type from its default export, so the types work with both v5 and v6

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -63,7 +63,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         node-version: [20.x, 22.x, 24.x, 25.x]
         webpack-version: [latest]
-        dev-server-version: [latest]
+        dev-server-version: [5, latest]
 
     steps:
       - name: Checkout code
@@ -84,6 +84,10 @@ jobs:
 
       - name: Install dependencies
         run: npm ci --ignore-scripts
+
+      - name: Install webpack-dev-server ${{ matrix.dev-server-version }}
+        if: matrix.dev-server-version == '5'
+        run: npm install webpack-dev-server@${{ matrix.dev-server-version }} --no-save --ignore-scripts
 
       - name: Prepare environment for tests
         run: npm run build -- --sourceMap true

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "typescript": "^6.0.3",
         "webpack": "^5.107.2",
         "webpack-bundle-analyzer": "^5.3.0",
-        "webpack-dev-server": "^5.2.5"
+        "webpack-dev-server": "^6.0.0"
       },
       "engines": {
         "node": ">=20.9.0"
@@ -5823,14 +5823,14 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-core": {
-      "version": "4.56.11",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-core/-/fs-core-4.56.11.tgz",
-      "integrity": "sha512-wThHjzUp01ImIjfCwhs+UnFkeGPFAymwLEkOtenHewaKe2pTP12p6r1UuwikA9NEvNf9Vlck92r8fb8n/MWM5w==",
+      "version": "4.68.1",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-core/-/fs-core-4.68.1.tgz",
+      "integrity": "sha512-V5oZ4Gt9WJKyQef0n9cAd0N9qjSkIBm3E4MYsgNIWBk5aINCDPKxMPo1i29rBxqiT4Ixf1epklqV9VJMKIxwlw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-node-builtins": "4.56.11",
-        "@jsonjoy.com/fs-node-utils": "4.56.11",
+        "@jsonjoy.com/fs-node-builtins": "4.68.1",
+        "@jsonjoy.com/fs-node-utils": "4.68.1",
         "thingies": "^2.5.0"
       },
       "engines": {
@@ -5845,15 +5845,15 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-fsa": {
-      "version": "4.56.11",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-fsa/-/fs-fsa-4.56.11.tgz",
-      "integrity": "sha512-ZYlF3XbMayyp97xEN8ZvYutU99PCHjM64mMZvnCseXkCJXJDVLAwlF8Q/7q/xiWQRsv3pQBj1WXHd9eEyYcaCQ==",
+      "version": "4.68.1",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-fsa/-/fs-fsa-4.68.1.tgz",
+      "integrity": "sha512-HCG72UioncuO7Gw09XNVG+S85e3cq2hrUC/mexBrsWsa3mI7eePkkqWie3uVYbtsb64OR9YGQs5SqaufDRYBcg==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-core": "4.56.11",
-        "@jsonjoy.com/fs-node-builtins": "4.56.11",
-        "@jsonjoy.com/fs-node-utils": "4.56.11",
+        "@jsonjoy.com/fs-core": "4.68.1",
+        "@jsonjoy.com/fs-node-builtins": "4.68.1",
+        "@jsonjoy.com/fs-node-utils": "4.68.1",
         "thingies": "^2.5.0"
       },
       "engines": {
@@ -5868,17 +5868,17 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-node": {
-      "version": "4.56.11",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node/-/fs-node-4.56.11.tgz",
-      "integrity": "sha512-D65YrnP6wRuZyEWoSFnBJSr5zARVpVBGctnhie4rCsMuGXNzX7IHKaOt85/Aj7SSoG1N2+/xlNjWmkLvZ2H3Tg==",
+      "version": "4.68.1",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node/-/fs-node-4.68.1.tgz",
+      "integrity": "sha512-R5D9mWtqdURzcOWj1vdXr3APCwX0xchtFT+kmW7fXLNDifWdDrnh26jSID8pdnUfFBxTyfHtFtTL/NWKzIH7kQ==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-core": "4.56.11",
-        "@jsonjoy.com/fs-node-builtins": "4.56.11",
-        "@jsonjoy.com/fs-node-utils": "4.56.11",
-        "@jsonjoy.com/fs-print": "4.56.11",
-        "@jsonjoy.com/fs-snapshot": "4.56.11",
+        "@jsonjoy.com/fs-core": "4.68.1",
+        "@jsonjoy.com/fs-node-builtins": "4.68.1",
+        "@jsonjoy.com/fs-node-utils": "4.68.1",
+        "@jsonjoy.com/fs-print": "4.68.1",
+        "@jsonjoy.com/fs-snapshot": "4.68.1",
         "glob-to-regex.js": "^1.0.0",
         "thingies": "^2.5.0"
       },
@@ -5894,9 +5894,9 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-node-builtins": {
-      "version": "4.56.11",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-builtins/-/fs-node-builtins-4.56.11.tgz",
-      "integrity": "sha512-CNmt3a0zMCIhniFLXtzPWuUxXFU+U+2VyQiIrgt/rRVeEJNrMQUABaRbVxR0Ouw1LyR9RjaEkPM6nYpED+y43A==",
+      "version": "4.68.1",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-builtins/-/fs-node-builtins-4.68.1.tgz",
+      "integrity": "sha512-HK1BTksysokNZxNspqDH0yPaqN9YgR/AYIlYiIaU2Ys4BOk5CdybI7r6BgiZuiiPiV8n4sK/kZdice7Znpy2Kw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
@@ -5911,15 +5911,15 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-node-to-fsa": {
-      "version": "4.56.11",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-to-fsa/-/fs-node-to-fsa-4.56.11.tgz",
-      "integrity": "sha512-5OzGdvJDgZVo+xXWEYo72u81zpOWlxlbG4d4nL+hSiW+LKlua/dldNgPrpWxtvhgyntmdFQad2UTxFyGjJAGhA==",
+      "version": "4.68.1",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-to-fsa/-/fs-node-to-fsa-4.68.1.tgz",
+      "integrity": "sha512-lpKmU4X9e/oh8GIuAI7EXaS5QiLNM3KD15CkdhfS6PYmrGvoJqKQcyEfnLgnnaGslh/PFUMYSIZBCf2ejJGw8g==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-fsa": "4.56.11",
-        "@jsonjoy.com/fs-node-builtins": "4.56.11",
-        "@jsonjoy.com/fs-node-utils": "4.56.11"
+        "@jsonjoy.com/fs-fsa": "4.68.1",
+        "@jsonjoy.com/fs-node-builtins": "4.68.1",
+        "@jsonjoy.com/fs-node-utils": "4.68.1"
       },
       "engines": {
         "node": ">=10.0"
@@ -5933,13 +5933,14 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-node-utils": {
-      "version": "4.56.11",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-utils/-/fs-node-utils-4.56.11.tgz",
-      "integrity": "sha512-JADOZFDA3wRfsuxkT0+MYc4F9hJO2PYDaY66kRTG6NqGX3+bqmKu66YFYAbII/tEmQWPZeHoClUB23rtQM9UPg==",
+      "version": "4.68.1",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-utils/-/fs-node-utils-4.68.1.tgz",
+      "integrity": "sha512-/GxfW1DWm9SCdkfbvqevLO/P5duobQfmKkHXxdMIDbcZMQeAgooAstIfZhkXpATzq9QbCQsnoWFM/dGHdZfndw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-node-builtins": "4.56.11"
+        "@jsonjoy.com/fs-node-builtins": "4.68.1",
+        "glob-to-regex.js": "^1.0.1"
       },
       "engines": {
         "node": ">=10.0"
@@ -5953,13 +5954,13 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-print": {
-      "version": "4.56.11",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-print/-/fs-print-4.56.11.tgz",
-      "integrity": "sha512-rnaKRgCRIn8JGTjxhS0JPE38YM3Pj/H7SW4/tglhIPbfKEkky7dpPayNKV2qy25SZSL15oFVgH/62dMZ/z7cyA==",
+      "version": "4.68.1",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-print/-/fs-print-4.68.1.tgz",
+      "integrity": "sha512-oGeZOGPYKK9v1CgeVeEDsLomH1lCnslSpqUN5GmPzrmAVGQlsmsdcXNA2O4lV8Y4xkuSuynx2ITBkUHJVaTbow==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-node-utils": "4.56.11",
+        "@jsonjoy.com/fs-node-utils": "4.68.1",
         "tree-dump": "^1.1.0"
       },
       "engines": {
@@ -5974,14 +5975,14 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-snapshot": {
-      "version": "4.56.11",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-snapshot/-/fs-snapshot-4.56.11.tgz",
-      "integrity": "sha512-IIldPX+cIRQuUol9fQzSS3hqyECxVpYMJQMqdU3dCKZFRzEl1rkIkw4P6y7Oh493sI7YdxZlKr/yWdzEWZ1wGQ==",
+      "version": "4.68.1",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-snapshot/-/fs-snapshot-4.68.1.tgz",
+      "integrity": "sha512-XZfP0FDZN32bbc4t2bZN2qRrYHg5AktJnzk22HRoKGK4BprrbNRH2k5ceSNS/kupKYcofCs+O841+xaAbjnxwQ==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@jsonjoy.com/buffers": "^17.65.0",
-        "@jsonjoy.com/fs-node-utils": "4.56.11",
+        "@jsonjoy.com/fs-node-utils": "4.68.1",
         "@jsonjoy.com/json-pack": "^17.65.0",
         "@jsonjoy.com/util": "^17.65.0"
       },
@@ -7430,22 +7431,21 @@
       "license": "MIT"
     },
     "node_modules/@types/express": {
-      "version": "4.17.25",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
-      "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
+      "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^4.17.33",
-        "@types/qs": "*",
-        "@types/serve-static": "^1"
+        "@types/express-serve-static-core": "^5.0.0",
+        "@types/serve-static": "^2"
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "4.19.8",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.8.tgz",
-      "integrity": "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.3.tgz",
+      "integrity": "sha512-dPfW8NFiOF4wOHc7+N/QSxlY9cfSsenewGbAz8C8U/MULPd/YZ27LvJUIlzaXie7e6Ove9YunJGgC9tbHD2cKw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -7478,16 +7478,6 @@
       "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
       "devOptional": true,
       "license": "MIT"
-    },
-    "node_modules/@types/http-proxy": {
-      "version": "1.17.17",
-      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.17.tgz",
-      "integrity": "sha512-ED6LB+Z1AVylNTu7hdzuBqOgMnvG/ld6wGCG8wFnAzKX5uyW2K3WD52v0gnLCTK/VLpXtKckgWuyScYK6cSPaw==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/inquirer": {
       "version": "9.0.9",
@@ -7591,13 +7581,6 @@
         "@types/unist": "*"
       }
     },
-    "node_modules/@types/mime": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
-      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
-      "devOptional": true,
-      "license": "MIT"
-    },
     "node_modules/@types/ms": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
@@ -7644,13 +7627,6 @@
         "@types/interpret": "*"
       }
     },
-    "node_modules/@types/retry": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.2.tgz",
-      "integrity": "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==",
-      "devOptional": true,
-      "license": "MIT"
-    },
     "node_modules/@types/send": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
@@ -7672,35 +7648,13 @@
       }
     },
     "node_modules/@types/serve-static": {
-      "version": "1.15.10",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.10.tgz",
-      "integrity": "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/http-errors": "*",
-        "@types/node": "*",
-        "@types/send": "<1"
-      }
-    },
-    "node_modules/@types/serve-static/node_modules/@types/send": {
-      "version": "0.17.6",
-      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.6.tgz",
-      "integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/mime": "^1",
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/sockjs": {
-      "version": "0.3.36",
-      "resolved": "https://registry.npmjs.org/@types/sockjs/-/sockjs-0.3.36.tgz",
-      "integrity": "sha512-MK9V6NzAS1+Ud7JV9lJLFqW85VbC9dq3LmwZCuBe4wBDgKC0Kj/jd8Xl+nSviU+Qc3+m7umHHyHg//2KSa0a0Q==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
         "@types/node": "*"
       }
     },
@@ -8691,7 +8645,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -8705,7 +8659,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -8754,13 +8708,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/array-flatten": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
-      "devOptional": true,
-      "license": "MIT"
     },
     "node_modules/array-includes": {
       "version": "3.1.9",
@@ -9425,19 +9372,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/binary-extensions": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
-      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-      "devOptional": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -9488,59 +9422,43 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.5",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
-      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "bytes": "~3.1.2",
-        "content-type": "~1.0.5",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "~1.2.0",
-        "http-errors": "~2.0.1",
-        "iconv-lite": "~0.4.24",
-        "on-finished": "~2.4.1",
-        "qs": "~6.15.1",
-        "raw-body": "~2.5.3",
-        "type-is": "~1.6.18",
-        "unpipe": "~1.0.0"
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
       "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
-    "node_modules/body-parser/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/body-parser/node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "node": ">=18"
       },
-      "engines": {
-        "node": ">=0.10.0"
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/body-parser/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
       "devOptional": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/bonjour-service": {
       "version": "1.3.0",
@@ -10162,7 +10080,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
       "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "readdirp": "^5.0.0"
@@ -10607,16 +10525,17 @@
       }
     },
     "node_modules/content-disposition": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
-      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "devOptional": true,
       "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "5.2.1"
-      },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/content-type": {
@@ -10647,11 +10566,14 @@
       }
     },
     "node_modules/cookie-signature": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
-      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
       "devOptional": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
     },
     "node_modules/core-js-compat": {
       "version": "3.49.0",
@@ -10666,13 +10588,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
       }
-    },
-    "node_modules/core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "devOptional": true,
-      "license": "MIT"
     },
     "node_modules/create-require": {
       "version": "1.1.1",
@@ -11084,9 +10999,9 @@
       }
     },
     "node_modules/default-browser": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
-      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.1.tgz",
+      "integrity": "sha512-m1pAzaJgZ/gssEqlOhJkPJp8Xly7QyW6xcrkUa2KKcDeDSEMP7X8xipU3snUcfisTQx0w1AGae+9UtJSfVnXGw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -11295,17 +11210,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/destroy": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
-      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
-      "devOptional": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
     "node_modules/detect-indent": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
@@ -11336,13 +11240,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/detect-node": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
-      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
-      "devOptional": true,
-      "license": "MIT"
     },
     "node_modules/devlop": {
       "version": "1.1.0",
@@ -12968,68 +12865,120 @@
       }
     },
     "node_modules/express": {
-      "version": "4.22.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
-      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "accepts": "~1.3.8",
-        "array-flatten": "1.1.1",
-        "body-parser": "~1.20.5",
-        "content-disposition": "~0.5.4",
-        "content-type": "~1.0.4",
-        "cookie": "~0.7.1",
-        "cookie-signature": "~1.0.6",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "finalhandler": "~1.3.1",
-        "fresh": "~0.5.2",
-        "http-errors": "~2.0.0",
-        "merge-descriptors": "1.0.3",
-        "methods": "~1.1.2",
-        "on-finished": "~2.4.1",
-        "parseurl": "~1.3.3",
-        "path-to-regexp": "~0.1.12",
-        "proxy-addr": "~2.0.7",
-        "qs": "~6.15.1",
-        "range-parser": "~1.2.1",
-        "safe-buffer": "5.2.1",
-        "send": "~0.19.0",
-        "serve-static": "~1.16.2",
-        "setprototypeof": "1.2.0",
-        "statuses": "~2.0.1",
-        "type-is": "~1.6.18",
-        "utils-merge": "1.0.1",
-        "vary": "~1.1.2"
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
       },
       "engines": {
-        "node": ">= 0.10.0"
+        "node": ">= 18"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/express/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+    "node_modules/express/node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "ms": "2.0.0"
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
-    "node_modules/express/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+    "node_modules/express/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "devOptional": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express/node_modules/negotiator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.1.0.tgz",
+      "integrity": "sha512-NMPBRMJgiQHjbd8phG3Vebdx4kZ1H121rbl5IkMqeOsahptB9BKo/d7oJ3zTXqTgagn2bWlNSXkh0QUGM31RYg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express/node_modules/negotiator/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/extendable-error": {
       "version": "0.1.7",
@@ -13169,19 +13118,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/faye-websocket": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
-      "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
-      "devOptional": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "websocket-driver": ">=0.5.1"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
@@ -13252,40 +13188,26 @@
       }
     },
     "node_modules/finalhandler": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
-      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "debug": "2.6.9",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "on-finished": "~2.4.1",
-        "parseurl": "~1.3.3",
-        "statuses": "~2.0.2",
-        "unpipe": "~1.0.0"
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
-    },
-    "node_modules/finalhandler/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/finalhandler/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "devOptional": true,
-      "license": "MIT"
     },
     "node_modules/find-up": {
       "version": "4.1.0",
@@ -13343,27 +13265,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/follow-redirects": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
-      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
-      "devOptional": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -13417,13 +13318,13 @@
       }
     },
     "node_modules/fresh": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
       "devOptional": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 0.8"
       }
     },
     "node_modules/fs-extra": {
@@ -13465,6 +13366,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -13876,13 +13778,6 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
     },
-    "node_modules/handle-thing": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
-      "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==",
-      "devOptional": true,
-      "license": "MIT"
-    },
     "node_modules/handlebars": {
       "version": "4.7.9",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
@@ -14013,59 +13908,6 @@
         "hermes-estree": "0.25.1"
       }
     },
-    "node_modules/hpack.js": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
-      "integrity": "sha512-zJxVehUdMGIKsRaNt7apO2Gqp0BdqW5yaiGHXXmbpvxgBYVZnAql+BJb4RO5ad2MgpbZKn5G6nMnegrH1FcNYQ==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.1",
-        "obuf": "^1.0.0",
-        "readable-stream": "^2.0.1",
-        "wbuf": "^1.1.0"
-      }
-    },
-    "node_modules/hpack.js/node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "devOptional": true,
-      "license": "MIT"
-    },
-    "node_modules/hpack.js/node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/hpack.js/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "devOptional": true,
-      "license": "MIT"
-    },
-    "node_modules/hpack.js/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
     "node_modules/html-entities": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
@@ -14090,13 +13932,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/http-deceiver": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
-      "integrity": "sha512-LmpOGxTfbpgtGVxJrj5k7asXHCgNZp5nLfp+hWc8QQRqtb7fUy6kRY3BO1h9ddF6yIPYUARgxGOwB42DnxIaNw==",
-      "devOptional": true,
-      "license": "MIT"
-    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -14118,70 +13953,27 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/http-parser-js": {
-      "version": "0.5.10",
-      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
-      "integrity": "sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==",
-      "devOptional": true,
-      "license": "MIT"
-    },
-    "node_modules/http-proxy": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
-      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "eventemitter3": "^4.0.0",
-        "follow-redirects": "^1.0.0",
-        "requires-port": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/http-proxy-middleware": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.10.tgz",
-      "integrity": "sha512-RKzRWNPxUZqbuk3BC5mGVJbBnWgr+diEnjJexIOytFbBzDy88Fbh/YvBr3DsNrl1jYAfjWfpATEv0NO35FDuPQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-4.2.0.tgz",
+      "integrity": "sha512-ZA+oNOoM+GLoFTIzhkJptVQov73Srep2LBqhF8hG8CIPKO3nam1jonXVQ/QUH8RbwsmaaVz2SOJdzBNBHNtKbw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@types/http-proxy": "^1.17.8",
-        "http-proxy": "^1.18.1",
-        "is-glob": "^4.0.1",
-        "is-plain-obj": "^3.0.0",
-        "micromatch": "^4.0.2"
+        "debug": "^4.4.3",
+        "httpxy": "^0.5.4",
+        "is-glob": "^4.0.3",
+        "is-plain-obj": "^4.1.0",
+        "micromatch": "^4.0.8"
       },
       "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "@types/express": "^4.17.13"
-      },
-      "peerDependenciesMeta": {
-        "@types/express": {
-          "optional": true
-        }
+        "node": "^22.15.0 || ^24.0.0 || >=26.0.0"
       }
     },
-    "node_modules/http-proxy-middleware/node_modules/is-plain-obj": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
-      "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
-      "devOptional": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/http-proxy/node_modules/eventemitter3": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+    "node_modules/httpxy": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/httpxy/-/httpxy-0.5.5.tgz",
+      "integrity": "sha512-uDjmnPyp1q4Sgzf3w+J/Fc6UqcCEj0x4Wjp7OqK5dGhNeDgpyrAmnS6ey8QWrX3SWDon2DMKf9sBa5X9+CVyMA==",
       "devOptional": true,
       "license": "MIT"
     },
@@ -14597,19 +14389,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-binary-path": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "binary-extensions": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/is-boolean-object": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
@@ -14807,6 +14586,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-in-ssh": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
+      "integrity": "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-inside-container": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
@@ -14862,9 +14654,9 @@
       }
     },
     "node_modules/is-network-error": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.1.tgz",
-      "integrity": "sha512-6QCxa49rQbmUWLfk0nuGqzql9U8uaV2H6279bRErPBHe/109hCzsLUBUHfbEtvLIHBd6hyXbgedBSHevm43Edw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.2.tgz",
+      "integrity": "sha512-PhBY86zaxNZUuWP6h13Vu5oFe0XY6/UlKzQnYFELzGVHygP3MxmvTfYSG7GN3aIab/iWudSMgjSnG9Dq+nHrgA==",
       "devOptional": true,
       "license": "MIT",
       "engines": {
@@ -14931,7 +14723,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
       "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -14951,6 +14743,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/is-regex": {
       "version": "1.2.1",
@@ -18080,30 +17879,34 @@
       }
     },
     "node_modules/media-typer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
       "devOptional": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/memfs": {
-      "version": "4.56.11",
-      "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.56.11.tgz",
-      "integrity": "sha512-/GodtwVeKVIHZKLUSr2ZdOxKBC5hHki4JNCU22DoCGPEHr5o2PD5U721zvESKyWwCfTfavFl9WZYgA13OAYK0g==",
+      "version": "4.68.1",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.68.1.tgz",
+      "integrity": "sha512-OD+IDRUvIxu3QHL+nFm9gdyugInD27FDJ+sl4B5QgomPHXMlbw+GP918P8VNKu2FkNlVeqBkpzkwROpamVifRw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-core": "4.56.11",
-        "@jsonjoy.com/fs-fsa": "4.56.11",
-        "@jsonjoy.com/fs-node": "4.56.11",
-        "@jsonjoy.com/fs-node-builtins": "4.56.11",
-        "@jsonjoy.com/fs-node-to-fsa": "4.56.11",
-        "@jsonjoy.com/fs-node-utils": "4.56.11",
-        "@jsonjoy.com/fs-print": "4.56.11",
-        "@jsonjoy.com/fs-snapshot": "4.56.11",
+        "@jsonjoy.com/fs-core": "4.68.1",
+        "@jsonjoy.com/fs-fsa": "4.68.1",
+        "@jsonjoy.com/fs-node": "4.68.1",
+        "@jsonjoy.com/fs-node-builtins": "4.68.1",
+        "@jsonjoy.com/fs-node-to-fsa": "4.68.1",
+        "@jsonjoy.com/fs-node-utils": "4.68.1",
+        "@jsonjoy.com/fs-print": "4.68.1",
+        "@jsonjoy.com/fs-snapshot": "4.68.1",
         "@jsonjoy.com/json-pack": "^1.11.0",
         "@jsonjoy.com/util": "^1.9.0",
         "glob-to-regex.js": "^1.0.1",
@@ -18114,9 +17917,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/streamich"
-      },
-      "peerDependencies": {
-        "tslib": "2"
       }
     },
     "node_modules/meow": {
@@ -18133,11 +17933,14 @@
       }
     },
     "node_modules/merge-descriptors": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
-      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
       "devOptional": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
@@ -18156,16 +17959,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/methods": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
-      "devOptional": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/micromark": {
@@ -18823,19 +18616,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-      "devOptional": true,
-      "license": "MIT",
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -18901,13 +18681,6 @@
       "peerDependencies": {
         "webpack": "^5.0.0"
       }
-    },
-    "node_modules/minimalistic-assert": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
-      "devOptional": true,
-      "license": "ISC"
     },
     "node_modules/minimatch": {
       "version": "3.1.5",
@@ -19303,7 +19076,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -19469,13 +19242,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/obuf": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
-      "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
-      "devOptional": true,
-      "license": "MIT"
-    },
     "node_modules/obug": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
@@ -19517,7 +19283,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -19540,19 +19306,21 @@
       }
     },
     "node_modules/open": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
-      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/open/-/open-11.0.1.tgz",
+      "integrity": "sha512-NzwMUB6C1D0+Kd+9iMS/H4k+Ck3cTX6Ckyfr/gAGlmvSE1LUQZnEZvWBi4PYmMwH/S5SMeTXnE+9uAz8uF+pWw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "default-browser": "^5.2.1",
+        "default-browser": "^5.4.0",
         "define-lazy-prop": "^3.0.0",
+        "is-in-ssh": "^1.0.0",
         "is-inside-container": "^1.0.0",
-        "wsl-utils": "^0.1.0"
+        "powershell-utils": "^0.2.0",
+        "wsl-utils": "^1.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -19803,18 +19571,16 @@
       }
     },
     "node_modules/p-retry": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-6.2.1.tgz",
-      "integrity": "sha512-hEt02O4hUct5wtwg4H4KcWgDdm+l1bOaEy/hWzd8xtXB9BqxTWBBhb+2ImAtH4Cv4rPjV76xN3Zumqk3k3AhhQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-8.0.0.tgz",
+      "integrity": "sha512-kFVqH1HxOHp8LupNsOys7bSV09VYTRLxarH/mokO4Rqhk6wGi70E0jh4VzvVGXfEVNggHoHLAMWsQqHyU1Ey9A==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@types/retry": "0.12.2",
-        "is-network-error": "^1.0.0",
-        "retry": "^0.13.1"
+        "is-network-error": "^1.3.0"
       },
       "engines": {
-        "node": ">=16.17"
+        "node": ">=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -19964,11 +19730,15 @@
       "license": "ISC"
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
-      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "devOptional": true,
-      "license": "MIT"
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -20179,6 +19949,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/powershell-utils": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.2.0.tgz",
+      "integrity": "sha512-ZlsFlG7MtSFCoc5xreOvBAozCJ6Pf06opgJjh9ONEv418xpZSAzNjstD36C6+JwOnfSqOW/9uDkqKjezTdxZhw==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -20273,13 +20056,6 @@
         "node": ">= 0.6.0"
       }
     },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "devOptional": true,
-      "license": "MIT"
-    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -20371,13 +20147,14 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -20425,42 +20202,33 @@
       "license": "MIT"
     },
     "node_modules/range-parser": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
       "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/raw-body": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
-      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
         "http-errors": "~2.0.1",
-        "iconv-lite": "~0.4.24",
+        "iconv-lite": "~0.7.0",
         "unpipe": "~1.0.0"
       },
       "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/raw-body/node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
+        "node": ">= 0.10"
       }
     },
     "node_modules/react-is-18": {
@@ -20550,7 +20318,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
       "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.0"
@@ -20710,13 +20478,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/requires-port": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-      "devOptional": true,
-      "license": "MIT"
-    },
     "node_modules/reserved-identifiers": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/reserved-identifiers/-/reserved-identifiers-1.2.0.tgz",
@@ -20798,16 +20559,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/retry": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
-      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
-      "devOptional": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -20825,6 +20576,23 @@
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
     },
     "node_modules/run-applescript": {
       "version": "7.1.0",
@@ -21070,13 +20838,6 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
-    "node_modules/select-hose": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
-      "integrity": "sha512-mEugaLK+YfkijB4fx0e6kImuJdCIt2LxCRcbEYPqRGCs4F2ogyfZU5IAZRdjCP8JPq2AtdNoC/Dux63d9Kiryg==",
-      "devOptional": true,
-      "license": "MIT"
-    },
     "node_modules/selfsigned": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-5.5.0.tgz",
@@ -21102,46 +20863,58 @@
       }
     },
     "node_modules/send": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
-      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "fresh": "~0.5.2",
-        "http-errors": "~2.0.1",
-        "mime": "1.6.0",
-        "ms": "2.1.3",
-        "on-finished": "~2.4.1",
-        "range-parser": "~1.2.1",
-        "statuses": "~2.0.2"
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
       },
       "engines": {
-        "node": ">= 0.8.0"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/send/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+    "node_modules/send/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/send/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "ms": "2.0.0"
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
-    },
-    "node_modules/send/node_modules/debug/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "devOptional": true,
-      "license": "MIT"
     },
     "node_modules/serve-index": {
       "version": "1.9.2",
@@ -21221,19 +20994,23 @@
       }
     },
     "node_modules/serve-static": {
-      "version": "1.16.3",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
-      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "parseurl": "~1.3.3",
-        "send": "~0.19.1"
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
       },
       "engines": {
-        "node": ">= 0.8.0"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/set-function-length": {
@@ -21339,15 +21116,15 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -21359,14 +21136,14 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -21495,18 +21272,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/cyyynthia"
-      }
-    },
-    "node_modules/sockjs": {
-      "version": "0.3.24",
-      "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.24.tgz",
-      "integrity": "sha512-GJgLTZ7vYb/JtPSSZ10hsOYIvEYsjbNU+zPdIHcUaWVNUEPivzxku31865sSSud0Da0W4lEeOPlmw93zLQchuQ==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "faye-websocket": "^0.11.3",
-        "uuid": "^8.3.2",
-        "websocket-driver": "^0.7.4"
       }
     },
     "node_modules/sort-object-keys": {
@@ -21641,53 +21406,6 @@
       "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
       "dev": true,
       "license": "CC0-1.0"
-    },
-    "node_modules/spdy": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/spdy/-/spdy-4.0.2.tgz",
-      "integrity": "sha512-r46gZQZQV+Kl9oItvl1JZZqJKGr+oEkB08A6BzkiR7593/7IbtuncXHd2YoYeTsG4157ZssMu9KYvUHLcjcDoA==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.1.0",
-        "handle-thing": "^2.0.0",
-        "http-deceiver": "^1.2.7",
-        "select-hose": "^2.0.0",
-        "spdy-transport": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/spdy-transport": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-3.0.0.tgz",
-      "integrity": "sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.1.0",
-        "detect-node": "^2.0.4",
-        "hpack.js": "^2.1.6",
-        "obuf": "^1.1.2",
-        "readable-stream": "^3.0.6",
-        "wbuf": "^1.7.3"
-      }
-    },
-    "node_modules/spdy-transport/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
@@ -22245,9 +21963,9 @@
       }
     },
     "node_modules/thingies": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/thingies/-/thingies-2.5.0.tgz",
-      "integrity": "sha512-s+2Bwztg6PhWUD7XMfeYm5qliDdSiZm7M7n8KjTkIsm3l/2lgVRc2/Gx/v+ZX8lT4FMA+i8aQvhcWylldc+ZNw==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/thingies/-/thingies-2.6.1.tgz",
+      "integrity": "sha512-cV/CMGTK3M4MlnJ/0At6ismOw/A0EEniDNScajjz/Br3c1sqE72YD01rGpPTKwd27wAxI5Pr+6+0w8yofzFRYw==",
       "devOptional": true,
       "license": "MIT",
       "engines": {
@@ -22623,17 +22341,63 @@
       }
     },
     "node_modules/type-is": {
-      "version": "1.6.18",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
-      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "media-typer": "0.3.0",
-        "mime-types": "~2.1.24"
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
       },
       "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typed-array-buffer": {
@@ -23055,26 +22819,6 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
-    "node_modules/utils-merge": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
-      "devOptional": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "devOptional": true,
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -23141,16 +22885,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/wbuf": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
-      "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimalistic-assert": "^1.0.0"
       }
     },
     "node_modules/wcwidth": {
@@ -23264,28 +22998,26 @@
       "link": true
     },
     "node_modules/webpack-dev-middleware": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-7.4.5.tgz",
-      "integrity": "sha512-uxQ6YqGdE4hgDKNf7hUiPXOdtkXvBJXrfEGYSx7P7LC8hnUYGK70X6xQXUvXeNyBDDcsiQXpG2m3G9vxowaEuA==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-8.1.1.tgz",
+      "integrity": "sha512-JrxAE/HwNmEnTkzkUGHFItHpGalzuEIUDifXhjAkIEHZzHK/ZJFVoTQF5ubZQlgeRireqLdr2lZttrrmOH61IA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "colorette": "^2.0.10",
-        "memfs": "^4.43.1",
-        "mime-types": "^3.0.1",
-        "on-finished": "^2.4.1",
+        "memfs": "^4.56.10",
+        "mime-types": "^3.0.2",
         "range-parser": "^1.2.1",
-        "schema-utils": "^4.0.0"
+        "schema-utils": "^4.3.3"
       },
       "engines": {
-        "node": ">= 18.12.0"
+        "node": ">= 20.9.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       },
       "peerDependencies": {
-        "webpack": "^5.0.0"
+        "webpack": "^5.101.0"
       },
       "peerDependenciesMeta": {
         "webpack": {
@@ -23321,53 +23053,50 @@
       }
     },
     "node_modules/webpack-dev-server": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.5.tgz",
-      "integrity": "sha512-4wZtCquSuv9CKX8oybo+mqxtxZqWz47uM1Ch94lxowBztOhWCbhqvRbfC/mODOwxgV2brY+JGZpHq58/SuVFYg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-6.0.0.tgz",
+      "integrity": "sha512-q9SD4ItOGhZLeU6EGT10caDZdHjF50Pz1DtkRZZOPsfluMXOkacWKKOtSBSLVkPqKiF67eFUC0rI88U/tSFPEw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/bonjour": "^3.5.13",
         "@types/connect-history-api-fallback": "^1.5.4",
-        "@types/express": "^4.17.25",
-        "@types/express-serve-static-core": "^4.17.21",
+        "@types/express": "^5.0.6",
+        "@types/express-serve-static-core": "^5.1.1",
         "@types/serve-index": "^1.9.4",
-        "@types/serve-static": "^1.15.5",
-        "@types/sockjs": "^0.3.36",
-        "@types/ws": "^8.5.10",
+        "@types/serve-static": "^2.2.0",
+        "@types/ws": "^8.18.1",
         "ansi-html-community": "^0.0.8",
-        "bonjour-service": "^1.2.1",
-        "chokidar": "^3.6.0",
-        "colorette": "^2.0.10",
+        "bonjour-service": "^1.3.0",
+        "chokidar": "^5.0.0",
         "compression": "^1.8.1",
         "connect-history-api-fallback": "^2.0.0",
-        "express": "^4.22.1",
-        "graceful-fs": "^4.2.6",
-        "http-proxy-middleware": "^2.0.9",
-        "ipaddr.js": "^2.1.0",
-        "launch-editor": "^2.6.1",
-        "open": "^10.0.3",
-        "p-retry": "^6.2.0",
-        "schema-utils": "^4.2.0",
+        "express": "^5.2.1",
+        "graceful-fs": "^4.2.11",
+        "http-proxy-middleware": "^4.1.1",
+        "ipaddr.js": "^2.3.0",
+        "launch-editor": "^2.14.1",
+        "open": "^11.0.0",
+        "p-retry": "^8.0.0",
+        "schema-utils": "^4.3.3",
         "selfsigned": "^5.5.0",
-        "serve-index": "^1.9.1",
-        "sockjs": "^0.3.24",
-        "spdy": "^4.0.2",
-        "webpack-dev-middleware": "^7.4.2",
-        "ws": "^8.18.0"
+        "serve-index": "^1.9.2",
+        "tinyglobby": "^0.2.15",
+        "webpack-dev-middleware": "^8.0.3",
+        "ws": "^8.20.0"
       },
       "bin": {
         "webpack-dev-server": "bin/webpack-dev-server.js"
       },
       "engines": {
-        "node": ">= 18.12.0"
+        "node": ">= 22.15.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       },
       "peerDependencies": {
-        "webpack": "^5.0.0"
+        "webpack": "^5.101.0"
       },
       "peerDependenciesMeta": {
         "webpack": {
@@ -23376,70 +23105,6 @@
         "webpack-cli": {
           "optional": true
         }
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/chokidar": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
-      },
-      "engines": {
-        "node": ">= 8.10.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "devOptional": true,
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "devOptional": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "picomatch": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8.10.0"
       }
     },
     "node_modules/webpack-merge": {
@@ -23494,31 +23159,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/websocket-driver": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
-      "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
-      "devOptional": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "http-parser-js": ">=0.5.1",
-        "safe-buffer": ">=5.1.0",
-        "websocket-extensions": ">=0.1.1"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/websocket-extensions": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
-      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
-      "devOptional": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "node_modules/whatwg-url": {
@@ -23776,7 +23416,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {
@@ -23816,16 +23456,30 @@
       }
     },
     "node_modules/wsl-utils": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
-      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-1.0.0.tgz",
+      "integrity": "sha512-Hl0ZOAs672vg+06kfujwRhoS6/jehvULrlFkuF2dRu6pHgA8U06h3xqNIqNNU1LTXPcedxByAR4GS6pwQK0mgA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "is-wsl": "^3.1.0"
+        "is-wsl": "^3.1.0",
+        "powershell-utils": "^0.1.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/wsl-utils/node_modules/powershell-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
+      "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "typescript": "^6.0.3",
     "webpack": "^5.107.2",
     "webpack-bundle-analyzer": "^5.3.0",
-    "webpack-dev-server": "^5.2.5"
+    "webpack-dev-server": "^6.0.0"
   },
   "peerDependencies": {
     "webpack": "5.x.x"

--- a/packages/webpack-cli/src/webpack-cli.ts
+++ b/packages/webpack-cli/src/webpack-cli.ts
@@ -41,6 +41,14 @@ const WEBPACK_DEV_SERVER_PACKAGE = WEBPACK_DEV_SERVER_PACKAGE_IS_CUSTOM
   ? (process.env.WEBPACK_DEV_SERVER_PACKAGE as string)
   : "webpack-dev-server";
 
+// `webpack-dev-server` v6 is ESM and exposes the server as its `default` export,
+// while v5 exports it directly
+type DevServerConstructor = typeof import("webpack-dev-server") extends {
+  default: infer Server;
+}
+  ? Server
+  : typeof import("webpack-dev-server");
+
 const EXIT_SIGNALS = ["SIGINT", "SIGTERM"];
 const DEFAULT_CONFIGURATION_FILES = [
   "webpack.config",
@@ -134,7 +142,7 @@ interface WebpackContext {
 }
 
 interface WebpackDevServerContext {
-  devServer: typeof import("webpack-dev-server");
+  devServer: DevServerConstructor;
 }
 
 interface KnownWebpackCLICommands {
@@ -1907,7 +1915,7 @@ class WebpackCLI {
     return this.#loadPackage(WEBPACK_PACKAGE, WEBPACK_PACKAGE_IS_CUSTOM);
   }
 
-  async loadWebpackDevServer(): Promise<typeof import("webpack-dev-server")> {
+  async loadWebpackDevServer(): Promise<DevServerConstructor> {
     return this.#loadPackage(WEBPACK_DEV_SERVER_PACKAGE, WEBPACK_DEV_SERVER_PACKAGE_IS_CUSTOM);
   }
 
@@ -2205,8 +2213,6 @@ class WebpackCLI {
         if (!compiler) {
           return;
         }
-
-        type DevServerConstructor = typeof import("webpack-dev-server");
 
         const DevServer: DevServerConstructor = cmd.context.devServer;
         const servers: InstanceType<DevServerConstructor>[] = [];

--- a/test/build/error/invalid-schema/invalid-schema.test.js
+++ b/test/build/error/invalid-schema/invalid-schema.test.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const [devServerVersion] = require("webpack-dev-server/package.json").version;
 const { run } = require("../../../utils/test-utils");
 
 describe("invalid schema", () => {
@@ -148,7 +149,11 @@ describe("invalid schema", () => {
 
     expect(exitCode).toBe(2);
     expect(stderr).toContain("Invalid value 'Yukihira' for the '--server-type' option");
-    expect(stderr).toContain("Expected: 'http | https | spdy | http2'");
+    expect(stderr).toContain(
+      devServerVersion === "5"
+        ? "Expected: 'http | https | spdy | http2'"
+        : "Expected: 'http | https | http2'",
+    );
     expect(stdout).toBeFalsy();
   });
 

--- a/test/help/__snapshots__/help.test.js.snap.devServer6.webpack5
+++ b/test/help/__snapshots__/help.test.js.snap.devServer6.webpack5
@@ -1,0 +1,3162 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`help should log error for invalid command using command syntax #3: stderr 1`] = `
+"[webpack-cli] ✖ Incorrect use of help
+[webpack-cli] ✖ Please use: 'webpack help [command] [option]' | 'webpack [command] --help'
+[webpack-cli] ✖ Run 'webpack --help' to see available commands and options"
+`;
+
+exports[`help should log error for invalid command using command syntax #3: stdout 1`] = `""`;
+
+exports[`help should log error for invalid command using command syntax #4: stderr 1`] = `
+"[webpack-cli] ✖ Incorrect use of help
+[webpack-cli] ✖ Please use: 'webpack help [command] [option]' | 'webpack [command] --help'
+[webpack-cli] ✖ Run 'webpack --help' to see available commands and options"
+`;
+
+exports[`help should log error for invalid command using command syntax #4: stdout 1`] = `""`;
+
+exports[`help should log error for invalid command using the "--help" option #2: stderr 1`] = `
+"[webpack-cli] ✖ Incorrect use of help
+[webpack-cli] ✖ Please use: 'webpack help [command] [option]' | 'webpack [command] --help'
+[webpack-cli] ✖ Run 'webpack --help' to see available commands and options"
+`;
+
+exports[`help should log error for invalid command using the "--help" option #2: stdout 1`] = `""`;
+
+exports[`help should log error for invalid command using the "--help" option #3: stderr 1`] = `
+"[webpack-cli] ✖ Incorrect use of help
+[webpack-cli] ✖ Please use: 'webpack help [command] [option]' | 'webpack [command] --help'
+[webpack-cli] ✖ Run 'webpack --help' to see available commands and options"
+`;
+
+exports[`help should log error for invalid command using the "--help" option #3: stdout 1`] = `""`;
+
+exports[`help should log error for invalid command using the "--help" option: stderr 1`] = `"[webpack-cli] ✖ Unknown value for '--help' option, please use '--help=verbose'"`;
+
+exports[`help should log error for invalid command using the "--help" option: stdout 1`] = `""`;
+
+exports[`help should log error for invalid flag with the "--help" option #2: stderr 1`] = `"[webpack-cli] ✖ Unknown value for '--help' option, please use '--help=verbose'"`;
+
+exports[`help should log error for invalid flag with the "--help" option #2: stdout 1`] = `""`;
+
+exports[`help should log error for invalid flag with the "--help" option #3 1`] = `"[webpack-cli] ✖ Unknown value for '--help' option, please use '--help=verbose'"`;
+
+exports[`help should log error for invalid flag with the "--help" option #4 1`] = `
+"[webpack-cli] ✖ Can't find and load command 'unknown'
+[webpack-cli] ✖ Run 'webpack --help' to see available commands and options"
+`;
+
+exports[`help should log error for invalid flag with the "--help" option: stderr 1`] = `
+"[webpack-cli] ✖ Incorrect use of help
+[webpack-cli] ✖ Please use: 'webpack help [command] [option]' | 'webpack [command] --help'
+[webpack-cli] ✖ Run 'webpack --help' to see available commands and options"
+`;
+
+exports[`help should log error for invalid flag with the "--help" option: stdout 1`] = `""`;
+
+exports[`help should log error for unknown command using command syntax #2: stderr 1`] = `
+"[webpack-cli] ✖ Can't find and load command 'verbose'
+[webpack-cli] ✖ Run 'webpack --help' to see available commands and options."
+`;
+
+exports[`help should log error for unknown command using command syntax #2: stdout 1`] = `""`;
+
+exports[`help should log error for unknown command using command syntax: stderr 1`] = `
+"[webpack-cli] ✖ Can't find and load command 'myCommand'
+[webpack-cli] ✖ Run 'webpack --help' to see available commands and options."
+`;
+
+exports[`help should log error for unknown command using command syntax: stdout 1`] = `""`;
+
+exports[`help should log error for unknown option using command syntax #2: stderr 1`] = `
+"[webpack-cli] ✖ Unknown option '--made'
+[webpack-cli] ✖ Run 'webpack --help' to see available commands and options"
+`;
+
+exports[`help should log error for unknown option using command syntax #2: stdout 1`] = `""`;
+
+exports[`help should log error for unknown option using command syntax #3: stderr 1`] = `
+"[webpack-cli] ✖ Unknown option '--made'
+[webpack-cli] ✖ Run 'webpack --help' to see available commands and options"
+`;
+
+exports[`help should log error for unknown option using command syntax #3: stdout 1`] = `""`;
+
+exports[`help should log error for unknown option using command syntax #4: stderr 1`] = `
+"[webpack-cli] ✖ Can't find and load command 'bui'
+[webpack-cli] ✖ Run 'webpack --help' to see available commands and options"
+`;
+
+exports[`help should log error for unknown option using command syntax #4: stdout 1`] = `""`;
+
+exports[`help should show help information and respect the "--color" flag using the "--help" option: stderr 1`] = `""`;
+
+exports[`help should show help information and respect the "--color" flag using the "--help" option: stdout 1`] = `
+"
+⬡ webpack
+────────────────────────────────────────────────────────────────────────
+The build tool for modern web applications.
+
+Usage: webpack [entries...] [options] | webpack [command] [options]
+
+Options
+────────────────────────────────────────────────────────────────────────
+  -c, --config <pathToConfigFile...>     Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
+  --config-name <name...>                Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
+  -m, --merge                            Merge two or more configurations using 'webpack-merge'.
+  --env <value...>                       Environment variables passed to the configuration when it is a function, e.g. "myvar" or "myvar=myval".
+  --config-node-env <value>              Sets process.env.NODE_ENV to the specified value for access within the configuration.
+  --analyze                              It invokes webpack-bundle-analyzer plugin to get bundle information.
+  --progress [value]                     Print compilation progress during build.
+  -j, --json [pathToJsonFile]            Prints result as JSON or store it in a file.
+  --fail-on-warnings                     Stop webpack-cli process with non-zero exit code on warnings from webpack.
+  --disable-interpret                    Disable interpret for loading the config file.
+  -d, --devtool <value>                  A developer tool to enhance debugging (false | eval | [inline-|hidden-|eval-][nosources-][cheap-[module-]]source-map).
+  --no-devtool                           Negative 'devtool' option.
+  --entry <value...>                     A module that is loaded upon startup. Only the last one is exported.
+  -e, --extends <value...>               Path to the configuration to be extended (only works when using webpack-cli).
+  --mode <value>                         Enable production optimizations or development hints.
+  --name <value>                         Name of the configuration. Used when loading multiple configurations.
+  -o, --output-path <value>              The output directory as **absolute path** (required).
+  --stats [value]                        Stats options object or preset name.
+  -t, --target <value...>                Specific environment, runtime, or syntax. Environment to build for. An array of environments to build for all of them when possible.
+  -w, --watch                            Enter watch mode, which rebuilds on file change.
+  --watch-options-stdin                  Stop watching when stdin stream has ended.
+
+Global options
+────────────────────────────────────────────────────────────────────────
+  --color                                Enable colors on console.
+  --no-color                             Disable colors on console.
+  -v, --version                          Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
+  -h, --help [verbose]                   Display help for commands and options.
+
+Commands
+────────────────────────────────────────────────────────────────────────
+  build|bundle|b [entries...] [options]  Run webpack (default command, can be omitted).
+  configtest|t [config-path]             Validate a webpack configuration.
+  help|h [command] [option]              Display help for commands and options.
+  info|i [options]                       Outputs information about your system.
+  serve|server|s [entries...] [options]  Run the webpack dev server and watch for source file changes while serving.
+  version|v [options]                    Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
+  watch|w [entries...] [options]         Run webpack and watch for files changes.
+
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information and respect the "--no-color" flag using the "--help" option: stderr 1`] = `""`;
+
+exports[`help should show help information and respect the "--no-color" flag using the "--help" option: stdout 1`] = `
+"
+⬡ webpack
+────────────────────────────────────────────────────────────────────────
+The build tool for modern web applications.
+
+Usage: webpack [entries...] [options] | webpack [command] [options]
+
+Options
+────────────────────────────────────────────────────────────────────────
+  -c, --config <pathToConfigFile...>     Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
+  --config-name <name...>                Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
+  -m, --merge                            Merge two or more configurations using 'webpack-merge'.
+  --env <value...>                       Environment variables passed to the configuration when it is a function, e.g. "myvar" or "myvar=myval".
+  --config-node-env <value>              Sets process.env.NODE_ENV to the specified value for access within the configuration.
+  --analyze                              It invokes webpack-bundle-analyzer plugin to get bundle information.
+  --progress [value]                     Print compilation progress during build.
+  -j, --json [pathToJsonFile]            Prints result as JSON or store it in a file.
+  --fail-on-warnings                     Stop webpack-cli process with non-zero exit code on warnings from webpack.
+  --disable-interpret                    Disable interpret for loading the config file.
+  -d, --devtool <value>                  A developer tool to enhance debugging (false | eval | [inline-|hidden-|eval-][nosources-][cheap-[module-]]source-map).
+  --no-devtool                           Negative 'devtool' option.
+  --entry <value...>                     A module that is loaded upon startup. Only the last one is exported.
+  -e, --extends <value...>               Path to the configuration to be extended (only works when using webpack-cli).
+  --mode <value>                         Enable production optimizations or development hints.
+  --name <value>                         Name of the configuration. Used when loading multiple configurations.
+  -o, --output-path <value>              The output directory as **absolute path** (required).
+  --stats [value]                        Stats options object or preset name.
+  -t, --target <value...>                Specific environment, runtime, or syntax. Environment to build for. An array of environments to build for all of them when possible.
+  -w, --watch                            Enter watch mode, which rebuilds on file change.
+  --watch-options-stdin                  Stop watching when stdin stream has ended.
+
+Global options
+────────────────────────────────────────────────────────────────────────
+  --color                                Enable colors on console.
+  --no-color                             Disable colors on console.
+  -v, --version                          Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
+  -h, --help [verbose]                   Display help for commands and options.
+
+Commands
+────────────────────────────────────────────────────────────────────────
+  build|bundle|b [entries...] [options]  Run webpack (default command, can be omitted).
+  configtest|t [config-path]             Validate a webpack configuration.
+  help|h [command] [option]              Display help for commands and options.
+  info|i [options]                       Outputs information about your system.
+  serve|server|s [entries...] [options]  Run the webpack dev server and watch for source file changes while serving.
+  version|v [options]                    Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
+  watch|w [entries...] [options]         Run webpack and watch for files changes.
+
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information and taking precedence when "--help" and "--version" option using together: stderr 1`] = `""`;
+
+exports[`help should show help information and taking precedence when "--help" and "--version" option using together: stdout 1`] = `
+"
+⬡ webpack
+────────────────────────────────────────────────────────────────────────
+The build tool for modern web applications.
+
+Usage: webpack [entries...] [options] | webpack [command] [options]
+
+Options
+────────────────────────────────────────────────────────────────────────
+  -c, --config <pathToConfigFile...>     Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
+  --config-name <name...>                Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
+  -m, --merge                            Merge two or more configurations using 'webpack-merge'.
+  --env <value...>                       Environment variables passed to the configuration when it is a function, e.g. "myvar" or "myvar=myval".
+  --config-node-env <value>              Sets process.env.NODE_ENV to the specified value for access within the configuration.
+  --analyze                              It invokes webpack-bundle-analyzer plugin to get bundle information.
+  --progress [value]                     Print compilation progress during build.
+  -j, --json [pathToJsonFile]            Prints result as JSON or store it in a file.
+  --fail-on-warnings                     Stop webpack-cli process with non-zero exit code on warnings from webpack.
+  --disable-interpret                    Disable interpret for loading the config file.
+  -d, --devtool <value>                  A developer tool to enhance debugging (false | eval | [inline-|hidden-|eval-][nosources-][cheap-[module-]]source-map).
+  --no-devtool                           Negative 'devtool' option.
+  --entry <value...>                     A module that is loaded upon startup. Only the last one is exported.
+  -e, --extends <value...>               Path to the configuration to be extended (only works when using webpack-cli).
+  --mode <value>                         Enable production optimizations or development hints.
+  --name <value>                         Name of the configuration. Used when loading multiple configurations.
+  -o, --output-path <value>              The output directory as **absolute path** (required).
+  --stats [value]                        Stats options object or preset name.
+  -t, --target <value...>                Specific environment, runtime, or syntax. Environment to build for. An array of environments to build for all of them when possible.
+  -w, --watch                            Enter watch mode, which rebuilds on file change.
+  --watch-options-stdin                  Stop watching when stdin stream has ended.
+
+Global options
+────────────────────────────────────────────────────────────────────────
+  --color                                Enable colors on console.
+  --no-color                             Disable colors on console.
+  -v, --version                          Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
+  -h, --help [verbose]                   Display help for commands and options.
+
+Commands
+────────────────────────────────────────────────────────────────────────
+  build|bundle|b [entries...] [options]  Run webpack (default command, can be omitted).
+  configtest|t [config-path]             Validate a webpack configuration.
+  help|h [command] [option]              Display help for commands and options.
+  info|i [options]                       Outputs information about your system.
+  serve|server|s [entries...] [options]  Run the webpack dev server and watch for source file changes while serving.
+  version|v [options]                    Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
+  watch|w [entries...] [options]         Run webpack and watch for files changes.
+
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information for 'b' command using command syntax: stderr 1`] = `""`;
+
+exports[`help should show help information for 'b' command using command syntax: stdout 1`] = `
+"
+⬡ webpack build
+────────────────────────────────────────────────────────────────────────
+Run webpack (default command, can be omitted).
+
+Usage: webpack build|bundle|b [entries...] [options]
+
+Options
+────────────────────────────────────────────────────────────────────────
+  -c, --config <pathToConfigFile...>  Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
+  --config-name <name...>             Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
+  -m, --merge                         Merge two or more configurations using 'webpack-merge'.
+  --env <value...>                    Environment variables passed to the configuration when it is a function, e.g. "myvar" or "myvar=myval".
+  --config-node-env <value>           Sets process.env.NODE_ENV to the specified value for access within the configuration.
+  --analyze                           It invokes webpack-bundle-analyzer plugin to get bundle information.
+  --progress [value]                  Print compilation progress during build.
+  -j, --json [pathToJsonFile]         Prints result as JSON or store it in a file.
+  --fail-on-warnings                  Stop webpack-cli process with non-zero exit code on warnings from webpack.
+  --disable-interpret                 Disable interpret for loading the config file.
+  -d, --devtool <value>               A developer tool to enhance debugging (false | eval | [inline-|hidden-|eval-][nosources-][cheap-[module-]]source-map).
+  --no-devtool                        Negative 'devtool' option.
+  --entry <value...>                  A module that is loaded upon startup. Only the last one is exported.
+  -e, --extends <value...>            Path to the configuration to be extended (only works when using webpack-cli).
+  --mode <value>                      Enable production optimizations or development hints.
+  --name <value>                      Name of the configuration. Used when loading multiple configurations.
+  -o, --output-path <value>           The output directory as **absolute path** (required).
+  --stats [value]                     Stats options object or preset name.
+  -t, --target <value...>             Specific environment, runtime, or syntax. Environment to build for. An array of environments to build for all of them when possible.
+  -w, --watch                         Enter watch mode, which rebuilds on file change.
+  --watch-options-stdin               Stop watching when stdin stream has ended.
+
+Global options
+────────────────────────────────────────────────────────────────────────
+  --color                             Enable colors on console.
+  --no-color                          Disable colors on console.
+  -v, --version                       Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
+  -h, --help [verbose]                Display help for commands and options.
+
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information for 'b' command using the "--help verbose" option: stderr 1`] = `""`;
+
+exports[`help should show help information for 'b' command using the "--help verbose" option: stdout 1`] = `
+"
+⬡ webpack build
+────────────────────────────────────────────────────────────────────────
+Run webpack (default command, can be omitted).
+
+Usage: webpack build|bundle|b [entries...] [options]
+
+Options
+────────────────────────────────────────────────────────────────────────
+  -c, --config <pathToConfigFile...>                                                 Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
+  --config-name <name...>                                                            Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
+  -m, --merge                                                                        Merge two or more configurations using 'webpack-merge'.
+  --env <value...>                                                                   Environment variables passed to the configuration when it is a function, e.g. "myvar" or "myvar=myval".
+  --config-node-env <value>                                                          Sets process.env.NODE_ENV to the specified value for access within the configuration.
+  --analyze                                                                          It invokes webpack-bundle-analyzer plugin to get bundle information.
+  --progress [value]                                                                 Print compilation progress during build.
+  -j, --json [pathToJsonFile]                                                        Prints result as JSON or store it in a file.
+  --fail-on-warnings                                                                 Stop webpack-cli process with non-zero exit code on warnings from webpack.
+  --disable-interpret                                                                Disable interpret for loading the config file.
+  --no-amd                                                                           Negative 'amd' option.
+  --bail                                                                             Report the first error as a hard error instead of tolerating it.
+  --no-bail                                                                          Negative 'bail' option.
+  --cache                                                                            Enable in memory caching. Disable caching.
+  --no-cache                                                                         Negative 'cache' option.
+  --cache-cache-unaffected                                                           Additionally cache computation of modules that are unchanged and reference only unchanged modules.
+  --no-cache-cache-unaffected                                                        Negative 'cache-cache-unaffected' option.
+  --cache-max-generations <value>                                                    Number of generations unused cache entries stay in memory cache
+    at stack.
+  --watch-options-poll [value]                                                       \`number\`: use polling with specified interval. \`true\`: use polling.
+  --no-watch-options-poll                                                            Negative 'watch-options-poll' option.
+  --watch-options-stdin                                                              Stop watching when stdin stream has ended.
+  --no-watch-options-stdin                                                           Negative 'watch-options-stdin' option.
+
+Global options
+────────────────────────────────────────────────────────────────────────
+  --color                                                                            Enable colors on console.
+  --no-color                                                                         Disable colors on console.
+  -v, --version                                                                      Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
+  -h, --help [verbose]                                                               Display help for commands and options.
+
+────────────────────────────────────────────────────────────────────────
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information for 'b' command using the "--help" option: stderr 1`] = `""`;
+
+exports[`help should show help information for 'b' command using the "--help" option: stdout 1`] = `
+"
+⬡ webpack build
+────────────────────────────────────────────────────────────────────────
+Run webpack (default command, can be omitted).
+
+Usage: webpack build|bundle|b [entries...] [options]
+
+Options
+────────────────────────────────────────────────────────────────────────
+  -c, --config <pathToConfigFile...>  Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
+  --config-name <name...>             Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
+  -m, --merge                         Merge two or more configurations using 'webpack-merge'.
+  --env <value...>                    Environment variables passed to the configuration when it is a function, e.g. "myvar" or "myvar=myval".
+  --config-node-env <value>           Sets process.env.NODE_ENV to the specified value for access within the configuration.
+  --analyze                           It invokes webpack-bundle-analyzer plugin to get bundle information.
+  --progress [value]                  Print compilation progress during build.
+  -j, --json [pathToJsonFile]         Prints result as JSON or store it in a file.
+  --fail-on-warnings                  Stop webpack-cli process with non-zero exit code on warnings from webpack.
+  --disable-interpret                 Disable interpret for loading the config file.
+  -d, --devtool <value>               A developer tool to enhance debugging (false | eval | [inline-|hidden-|eval-][nosources-][cheap-[module-]]source-map).
+  --no-devtool                        Negative 'devtool' option.
+  --entry <value...>                  A module that is loaded upon startup. Only the last one is exported.
+  -e, --extends <value...>            Path to the configuration to be extended (only works when using webpack-cli).
+  --mode <value>                      Enable production optimizations or development hints.
+  --name <value>                      Name of the configuration. Used when loading multiple configurations.
+  -o, --output-path <value>           The output directory as **absolute path** (required).
+  --stats [value]                     Stats options object or preset name.
+  -t, --target <value...>             Specific environment, runtime, or syntax. Environment to build for. An array of environments to build for all of them when possible.
+  -w, --watch                         Enter watch mode, which rebuilds on file change.
+  --watch-options-stdin               Stop watching when stdin stream has ended.
+
+Global options
+────────────────────────────────────────────────────────────────────────
+  --color                             Enable colors on console.
+  --no-color                          Disable colors on console.
+  -v, --version                       Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
+  -h, --help [verbose]                Display help for commands and options.
+
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information for 'build' and respect the "--color" flag using the "--help" option: stderr 1`] = `""`;
+
+exports[`help should show help information for 'build' and respect the "--color" flag using the "--help" option: stdout 1`] = `
+"
+⬡ webpack build
+────────────────────────────────────────────────────────────────────────
+Run webpack (default command, can be omitted).
+
+Usage: webpack build|bundle|b [entries...] [options]
+
+Options
+────────────────────────────────────────────────────────────────────────
+  -c, --config <pathToConfigFile...>  Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
+  --config-name <name...>             Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
+  -m, --merge                         Merge two or more configurations using 'webpack-merge'.
+  --env <value...>                    Environment variables passed to the configuration when it is a function, e.g. "myvar" or "myvar=myval".
+  --config-node-env <value>           Sets process.env.NODE_ENV to the specified value for access within the configuration.
+  --analyze                           It invokes webpack-bundle-analyzer plugin to get bundle information.
+  --progress [value]                  Print compilation progress during build.
+  -j, --json [pathToJsonFile]         Prints result as JSON or store it in a file.
+  --fail-on-warnings                  Stop webpack-cli process with non-zero exit code on warnings from webpack.
+  --disable-interpret                 Disable interpret for loading the config file.
+  -d, --devtool <value>               A developer tool to enhance debugging (false | eval | [inline-|hidden-|eval-][nosources-][cheap-[module-]]source-map).
+  --no-devtool                        Negative 'devtool' option.
+  --entry <value...>                  A module that is loaded upon startup. Only the last one is exported.
+  -e, --extends <value...>            Path to the configuration to be extended (only works when using webpack-cli).
+  --mode <value>                      Enable production optimizations or development hints.
+  --name <value>                      Name of the configuration. Used when loading multiple configurations.
+  -o, --output-path <value>           The output directory as **absolute path** (required).
+  --stats [value]                     Stats options object or preset name.
+  -t, --target <value...>             Specific environment, runtime, or syntax. Environment to build for. An array of environments to build for all of them when possible.
+  -w, --watch                         Enter watch mode, which rebuilds on file change.
+  --watch-options-stdin               Stop watching when stdin stream has ended.
+
+Global options
+────────────────────────────────────────────────────────────────────────
+  --color                             Enable colors on console.
+  --no-color                          Disable colors on console.
+  -v, --version                       Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
+  -h, --help [verbose]                Display help for commands and options.
+
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information for 'build' and respect the "--no-color" flag using the "--help" option: stderr 1`] = `""`;
+
+exports[`help should show help information for 'build' and respect the "--no-color" flag using the "--help" option: stdout 1`] = `
+"
+⬡ webpack build
+────────────────────────────────────────────────────────────────────────
+Run webpack (default command, can be omitted).
+
+Usage: webpack build|bundle|b [entries...] [options]
+
+Options
+────────────────────────────────────────────────────────────────────────
+  -c, --config <pathToConfigFile...>  Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
+  --config-name <name...>             Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
+  -m, --merge                         Merge two or more configurations using 'webpack-merge'.
+  --env <value...>                    Environment variables passed to the configuration when it is a function, e.g. "myvar" or "myvar=myval".
+  --config-node-env <value>           Sets process.env.NODE_ENV to the specified value for access within the configuration.
+  --analyze                           It invokes webpack-bundle-analyzer plugin to get bundle information.
+  --progress [value]                  Print compilation progress during build.
+  -j, --json [pathToJsonFile]         Prints result as JSON or store it in a file.
+  --fail-on-warnings                  Stop webpack-cli process with non-zero exit code on warnings from webpack.
+  --disable-interpret                 Disable interpret for loading the config file.
+  -d, --devtool <value>               A developer tool to enhance debugging (false | eval | [inline-|hidden-|eval-][nosources-][cheap-[module-]]source-map).
+  --no-devtool                        Negative 'devtool' option.
+  --entry <value...>                  A module that is loaded upon startup. Only the last one is exported.
+  -e, --extends <value...>            Path to the configuration to be extended (only works when using webpack-cli).
+  --mode <value>                      Enable production optimizations or development hints.
+  --name <value>                      Name of the configuration. Used when loading multiple configurations.
+  -o, --output-path <value>           The output directory as **absolute path** (required).
+  --stats [value]                     Stats options object or preset name.
+  -t, --target <value...>             Specific environment, runtime, or syntax. Environment to build for. An array of environments to build for all of them when possible.
+  -w, --watch                         Enter watch mode, which rebuilds on file change.
+  --watch-options-stdin               Stop watching when stdin stream has ended.
+
+Global options
+────────────────────────────────────────────────────────────────────────
+  --color                             Enable colors on console.
+  --no-color                          Disable colors on console.
+  -v, --version                       Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
+  -h, --help [verbose]                Display help for commands and options.
+
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information for 'build' command using command syntax: stderr 1`] = `""`;
+
+exports[`help should show help information for 'build' command using command syntax: stdout 1`] = `
+"
+⬡ webpack build
+────────────────────────────────────────────────────────────────────────
+Run webpack (default command, can be omitted).
+
+Usage: webpack build|bundle|b [entries...] [options]
+
+Options
+────────────────────────────────────────────────────────────────────────
+  -c, --config <pathToConfigFile...>  Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
+  --config-name <name...>             Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
+  -m, --merge                         Merge two or more configurations using 'webpack-merge'.
+  --env <value...>                    Environment variables passed to the configuration when it is a function, e.g. "myvar" or "myvar=myval".
+  --config-node-env <value>           Sets process.env.NODE_ENV to the specified value for access within the configuration.
+  --analyze                           It invokes webpack-bundle-analyzer plugin to get bundle information.
+  --progress [value]                  Print compilation progress during build.
+  -j, --json [pathToJsonFile]         Prints result as JSON or store it in a file.
+  --fail-on-warnings                  Stop webpack-cli process with non-zero exit code on warnings from webpack.
+  --disable-interpret                 Disable interpret for loading the config file.
+  -d, --devtool <value>               A developer tool to enhance debugging (false | eval | [inline-|hidden-|eval-][nosources-][cheap-[module-]]source-map).
+  --no-devtool                        Negative 'devtool' option.
+  --entry <value...>                  A module that is loaded upon startup. Only the last one is exported.
+  -e, --extends <value...>            Path to the configuration to be extended (only works when using webpack-cli).
+  --mode <value>                      Enable production optimizations or development hints.
+  --name <value>                      Name of the configuration. Used when loading multiple configurations.
+  -o, --output-path <value>           The output directory as **absolute path** (required).
+  --stats [value]                     Stats options object or preset name.
+  -t, --target <value...>             Specific environment, runtime, or syntax. Environment to build for. An array of environments to build for all of them when possible.
+  -w, --watch                         Enter watch mode, which rebuilds on file change.
+  --watch-options-stdin               Stop watching when stdin stream has ended.
+
+Global options
+────────────────────────────────────────────────────────────────────────
+  --color                             Enable colors on console.
+  --no-color                          Disable colors on console.
+  -v, --version                       Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
+  -h, --help [verbose]                Display help for commands and options.
+
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information for 'build' command using the "--help verbose" option: stderr 1`] = `""`;
+
+exports[`help should show help information for 'build' command using the "--help verbose" option: stdout 1`] = `
+"
+⬡ webpack build
+────────────────────────────────────────────────────────────────────────
+Run webpack (default command, can be omitted).
+
+Usage: webpack build|bundle|b [entries...] [options]
+
+Options
+────────────────────────────────────────────────────────────────────────
+  -c, --config <pathToConfigFile...>                                                 Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
+  --config-name <name...>                                                            Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
+  -m, --merge                                                                        Merge two or more configurations using 'webpack-merge'.
+  --env <value...>                                                                   Environment variables passed to the configuration when it is a function, e.g. "myvar" or "myvar=myval".
+  --config-node-env <value>                                                          Sets process.env.NODE_ENV to the specified value for access within the configuration.
+  --analyze                                                                          It invokes webpack-bundle-analyzer plugin to get bundle information.
+  --progress [value]                                                                 Print compilation progress during build.
+  -j, --json [pathToJsonFile]                                                        Prints result as JSON or store it in a file.
+  --fail-on-warnings                                                                 Stop webpack-cli process with non-zero exit code on warnings from webpack.
+  --disable-interpret                                                                Disable interpret for loading the config file.
+  --no-amd                                                                           Negative 'amd' option.
+  --bail                                                                             Report the first error as a hard error instead of tolerating it.
+  --no-bail                                                                          Negative 'bail' option.
+  --cache                                                                            Enable in memory caching. Disable caching.
+  --no-cache                                                                         Negative 'cache' option.
+  --cache-cache-unaffected                                                           Additionally cache computation of modules that are unchanged and reference only unchanged modules.
+  --no-cache-cache-unaffected                                                        Negative 'cache-cache-unaffected' option.
+  --cache-max-generations <value>                                                    Number of generations unused cache entries stay in memory cache
+    at stack.
+  --watch-options-poll [value]                                                       \`number\`: use polling with specified interval. \`true\`: use polling.
+  --no-watch-options-poll                                                            Negative 'watch-options-poll' option.
+  --watch-options-stdin                                                              Stop watching when stdin stream has ended.
+  --no-watch-options-stdin                                                           Negative 'watch-options-stdin' option.
+
+Global options
+────────────────────────────────────────────────────────────────────────
+  --color                                                                            Enable colors on console.
+  --no-color                                                                         Disable colors on console.
+  -v, --version                                                                      Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
+  -h, --help [verbose]                                                               Display help for commands and options.
+
+────────────────────────────────────────────────────────────────────────
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information for 'build' command using the "--help" option: stderr 1`] = `""`;
+
+exports[`help should show help information for 'build' command using the "--help" option: stdout 1`] = `
+"
+⬡ webpack build
+────────────────────────────────────────────────────────────────────────
+Run webpack (default command, can be omitted).
+
+Usage: webpack build|bundle|b [entries...] [options]
+
+Options
+────────────────────────────────────────────────────────────────────────
+  -c, --config <pathToConfigFile...>  Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
+  --config-name <name...>             Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
+  -m, --merge                         Merge two or more configurations using 'webpack-merge'.
+  --env <value...>                    Environment variables passed to the configuration when it is a function, e.g. "myvar" or "myvar=myval".
+  --config-node-env <value>           Sets process.env.NODE_ENV to the specified value for access within the configuration.
+  --analyze                           It invokes webpack-bundle-analyzer plugin to get bundle information.
+  --progress [value]                  Print compilation progress during build.
+  -j, --json [pathToJsonFile]         Prints result as JSON or store it in a file.
+  --fail-on-warnings                  Stop webpack-cli process with non-zero exit code on warnings from webpack.
+  --disable-interpret                 Disable interpret for loading the config file.
+  -d, --devtool <value>               A developer tool to enhance debugging (false | eval | [inline-|hidden-|eval-][nosources-][cheap-[module-]]source-map).
+  --no-devtool                        Negative 'devtool' option.
+  --entry <value...>                  A module that is loaded upon startup. Only the last one is exported.
+  -e, --extends <value...>            Path to the configuration to be extended (only works when using webpack-cli).
+  --mode <value>                      Enable production optimizations or development hints.
+  --name <value>                      Name of the configuration. Used when loading multiple configurations.
+  -o, --output-path <value>           The output directory as **absolute path** (required).
+  --stats [value]                     Stats options object or preset name.
+  -t, --target <value...>             Specific environment, runtime, or syntax. Environment to build for. An array of environments to build for all of them when possible.
+  -w, --watch                         Enter watch mode, which rebuilds on file change.
+  --watch-options-stdin               Stop watching when stdin stream has ended.
+
+Global options
+────────────────────────────────────────────────────────────────────────
+  --color                             Enable colors on console.
+  --no-color                          Disable colors on console.
+  -v, --version                       Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
+  -h, --help [verbose]                Display help for commands and options.
+
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information for 'configtest' and respect the "--color" flag using the "--help" option: stderr 1`] = `""`;
+
+exports[`help should show help information for 'configtest' and respect the "--color" flag using the "--help" option: stdout 1`] = `
+"
+⬡ webpack configtest
+────────────────────────────────────────────────────────────────────────
+Validate a webpack configuration.
+
+Usage: webpack configtest|t [config-path]
+
+Global options
+────────────────────────────────────────────────────────────────────────
+  --color               Enable colors on console.
+  --no-color            Disable colors on console.
+  -v, --version         Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
+  -h, --help [verbose]  Display help for commands and options.
+
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information for 'configtest' and respect the "--no-color" flag using the "--help" option: stderr 1`] = `""`;
+
+exports[`help should show help information for 'configtest' and respect the "--no-color" flag using the "--help" option: stdout 1`] = `
+"
+⬡ webpack configtest
+────────────────────────────────────────────────────────────────────────
+Validate a webpack configuration.
+
+Usage: webpack configtest|t [config-path]
+
+Global options
+────────────────────────────────────────────────────────────────────────
+  --color               Enable colors on console.
+  --no-color            Disable colors on console.
+  -v, --version         Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
+  -h, --help [verbose]  Display help for commands and options.
+
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information for 'configtest' command using command syntax: stderr 1`] = `""`;
+
+exports[`help should show help information for 'configtest' command using command syntax: stdout 1`] = `
+"
+⬡ webpack configtest
+────────────────────────────────────────────────────────────────────────
+Validate a webpack configuration.
+
+Usage: webpack configtest|t [config-path]
+
+Global options
+────────────────────────────────────────────────────────────────────────
+  --color               Enable colors on console.
+  --no-color            Disable colors on console.
+  -v, --version         Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
+  -h, --help [verbose]  Display help for commands and options.
+
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information for 'configtest' command using the "--help verbose" option: stderr 1`] = `""`;
+
+exports[`help should show help information for 'configtest' command using the "--help verbose" option: stdout 1`] = `
+"
+⬡ webpack configtest
+────────────────────────────────────────────────────────────────────────
+Validate a webpack configuration.
+
+Usage: webpack configtest|t [config-path]
+
+Global options
+────────────────────────────────────────────────────────────────────────
+  --color               Enable colors on console.
+  --no-color            Disable colors on console.
+  -v, --version         Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
+  -h, --help [verbose]  Display help for commands and options.
+
+────────────────────────────────────────────────────────────────────────
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information for 'configtest' command using the "--help" option: stderr 1`] = `""`;
+
+exports[`help should show help information for 'configtest' command using the "--help" option: stdout 1`] = `
+"
+⬡ webpack configtest
+────────────────────────────────────────────────────────────────────────
+Validate a webpack configuration.
+
+Usage: webpack configtest|t [config-path]
+
+Global options
+────────────────────────────────────────────────────────────────────────
+  --color               Enable colors on console.
+  --no-color            Disable colors on console.
+  -v, --version         Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
+  -h, --help [verbose]  Display help for commands and options.
+
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information for 'i' command using command syntax: stderr 1`] = `""`;
+
+exports[`help should show help information for 'i' command using command syntax: stdout 1`] = `
+"
+⬡ webpack info
+────────────────────────────────────────────────────────────────────────
+Outputs information about your system.
+
+Usage: webpack info|i [options]
+
+Options
+────────────────────────────────────────────────────────────────────────
+  -o, --output <value>                 To get the output in a specified format (accept json or markdown)
+  -a, --additional-package <value...>  Adds additional packages to the output
+
+Global options
+────────────────────────────────────────────────────────────────────────
+  --color                              Enable colors on console.
+  --no-color                           Disable colors on console.
+  -v, --version                        Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
+  -h, --help [verbose]                 Display help for commands and options.
+
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information for 'i' command using the "--help verbose" option: stderr 1`] = `""`;
+
+exports[`help should show help information for 'i' command using the "--help verbose" option: stdout 1`] = `
+"
+⬡ webpack info
+────────────────────────────────────────────────────────────────────────
+Outputs information about your system.
+
+Usage: webpack info|i [options]
+
+Options
+────────────────────────────────────────────────────────────────────────
+  -o, --output <value>                 To get the output in a specified format (accept json or markdown)
+  -a, --additional-package <value...>  Adds additional packages to the output
+
+Global options
+────────────────────────────────────────────────────────────────────────
+  --color                              Enable colors on console.
+  --no-color                           Disable colors on console.
+  -v, --version                        Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
+  -h, --help [verbose]                 Display help for commands and options.
+
+────────────────────────────────────────────────────────────────────────
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information for 'i' command using the "--help" option: stderr 1`] = `""`;
+
+exports[`help should show help information for 'i' command using the "--help" option: stdout 1`] = `
+"
+⬡ webpack info
+────────────────────────────────────────────────────────────────────────
+Outputs information about your system.
+
+Usage: webpack info|i [options]
+
+Options
+────────────────────────────────────────────────────────────────────────
+  -o, --output <value>                 To get the output in a specified format (accept json or markdown)
+  -a, --additional-package <value...>  Adds additional packages to the output
+
+Global options
+────────────────────────────────────────────────────────────────────────
+  --color                              Enable colors on console.
+  --no-color                           Disable colors on console.
+  -v, --version                        Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
+  -h, --help [verbose]                 Display help for commands and options.
+
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information for 'info' and respect the "--color" flag using the "--help" option: stderr 1`] = `""`;
+
+exports[`help should show help information for 'info' and respect the "--color" flag using the "--help" option: stdout 1`] = `
+"
+⬡ webpack info
+────────────────────────────────────────────────────────────────────────
+Outputs information about your system.
+
+Usage: webpack info|i [options]
+
+Options
+────────────────────────────────────────────────────────────────────────
+  -o, --output <value>                 To get the output in a specified format (accept json or markdown)
+  -a, --additional-package <value...>  Adds additional packages to the output
+
+Global options
+────────────────────────────────────────────────────────────────────────
+  --color                              Enable colors on console.
+  --no-color                           Disable colors on console.
+  -v, --version                        Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
+  -h, --help [verbose]                 Display help for commands and options.
+
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information for 'info' and respect the "--no-color" flag using the "--help" option: stderr 1`] = `""`;
+
+exports[`help should show help information for 'info' and respect the "--no-color" flag using the "--help" option: stdout 1`] = `
+"
+⬡ webpack info
+────────────────────────────────────────────────────────────────────────
+Outputs information about your system.
+
+Usage: webpack info|i [options]
+
+Options
+────────────────────────────────────────────────────────────────────────
+  -o, --output <value>                 To get the output in a specified format (accept json or markdown)
+  -a, --additional-package <value...>  Adds additional packages to the output
+
+Global options
+────────────────────────────────────────────────────────────────────────
+  --color                              Enable colors on console.
+  --no-color                           Disable colors on console.
+  -v, --version                        Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
+  -h, --help [verbose]                 Display help for commands and options.
+
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information for 'info' command using command syntax: stderr 1`] = `""`;
+
+exports[`help should show help information for 'info' command using command syntax: stdout 1`] = `
+"
+⬡ webpack info
+────────────────────────────────────────────────────────────────────────
+Outputs information about your system.
+
+Usage: webpack info|i [options]
+
+Options
+────────────────────────────────────────────────────────────────────────
+  -o, --output <value>                 To get the output in a specified format (accept json or markdown)
+  -a, --additional-package <value...>  Adds additional packages to the output
+
+Global options
+────────────────────────────────────────────────────────────────────────
+  --color                              Enable colors on console.
+  --no-color                           Disable colors on console.
+  -v, --version                        Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
+  -h, --help [verbose]                 Display help for commands and options.
+
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information for 'info' command using the "--help verbose" option: stderr 1`] = `""`;
+
+exports[`help should show help information for 'info' command using the "--help verbose" option: stdout 1`] = `
+"
+⬡ webpack info
+────────────────────────────────────────────────────────────────────────
+Outputs information about your system.
+
+Usage: webpack info|i [options]
+
+Options
+────────────────────────────────────────────────────────────────────────
+  -o, --output <value>                 To get the output in a specified format (accept json or markdown)
+  -a, --additional-package <value...>  Adds additional packages to the output
+
+Global options
+────────────────────────────────────────────────────────────────────────
+  --color                              Enable colors on console.
+  --no-color                           Disable colors on console.
+  -v, --version                        Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
+  -h, --help [verbose]                 Display help for commands and options.
+
+────────────────────────────────────────────────────────────────────────
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information for 'info' command using the "--help" option: stderr 1`] = `""`;
+
+exports[`help should show help information for 'info' command using the "--help" option: stdout 1`] = `
+"
+⬡ webpack info
+────────────────────────────────────────────────────────────────────────
+Outputs information about your system.
+
+Usage: webpack info|i [options]
+
+Options
+────────────────────────────────────────────────────────────────────────
+  -o, --output <value>                 To get the output in a specified format (accept json or markdown)
+  -a, --additional-package <value...>  Adds additional packages to the output
+
+Global options
+────────────────────────────────────────────────────────────────────────
+  --color                              Enable colors on console.
+  --no-color                           Disable colors on console.
+  -v, --version                        Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
+  -h, --help [verbose]                 Display help for commands and options.
+
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information for 's' command using command syntax: stderr 1`] = `""`;
+
+exports[`help should show help information for 's' command using command syntax: stdout 1`] = `
+"
+⬡ webpack serve
+────────────────────────────────────────────────────────────────────────
+Run the webpack dev server and watch for source file changes while serving.
+
+Usage: webpack serve|server|s [entries...] [options]
+
+Options
+────────────────────────────────────────────────────────────────────────
+  -c, --config <pathToConfigFile...>                  Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
+  --config-name <name...>                             Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
+  -m, --merge                                         Merge two or more configurations using 'webpack-merge'.
+  --env <value...>                                    Environment variables passed to the configuration when it is a function, e.g. "myvar" or "myvar=myval".
+  --config-node-env <value>                           Sets process.env.NODE_ENV to the specified value for access within the configuration.
+  --analyze                                           It invokes webpack-bundle-analyzer plugin to get bundle information.
+  --progress [value]                                  Print compilation progress during build.
+  -j, --json [pathToJsonFile]                         Prints result as JSON or store it in a file.
+  --fail-on-warnings                                  Stop webpack-cli process with non-zero exit code on warnings from webpack.
+  --disable-interpret                                 Disable interpret for loading the config file.
+  -d, --devtool <value>                               A developer tool to enhance debugging (false | eval | [inline-|hidden-|eval-][nosources-][cheap-[module-]]source-map).
+  --no-devtool                                        Negative 'devtool' option.
+  --entry <value...>                                  A module that is loaded upon startup. Only the last one is exported.
+  -e, --extends <value...>                            Path to the configuration to be extended (only works when using webpack-cli).
+  --mode <value>                                      Enable production optimizations or development hints.
+  --name <value>                                      Name of the configuration. Used when loading multiple configurations.
+  -o, --output-path <value>                           The output directory as **absolute path** (required).
+  --stats [value]                                     Stats options object or preset name.
+  -t, --target <value...>                             Specific environment, runtime, or syntax. Environment to build for. An array of environments to build for all of them when possible.
+  -w, --watch                                         Enter watch mode, which rebuilds on file change.
+  --watch-options-stdin                               Stop watching when stdin stream has ended.
+  --allowed-hosts <value...>                          Allows to enumerate the hosts from which access to the dev server are allowed (useful when you are proxying dev server, by default is 'auto').
+  --allowed-hosts-reset                               Clear all items provided in 'allowedHosts' configuration. Allows to enumerate the hosts from which access to the dev server are allowed (useful when you are proxying dev server, by default is 'auto').
+  --bonjour                                           Allows to broadcasts dev server via ZeroConf networking on start.
+  --no-bonjour                                        Disallows to broadcasts dev server via ZeroConf networking on start.
+  --no-client                                         Disables client script.
+  --client-logging <value>                            Allows to set log level in the browser.
+  --client-overlay                                    Enables a full-screen overlay in the browser when there are compiler errors or warnings.
+  --no-client-overlay                                 Disables the full-screen overlay in the browser when there are compiler errors or warnings.
+  --client-overlay-errors                             Enables a full-screen overlay in the browser when there are compiler errors.
+  --no-client-overlay-errors                          Disables the full-screen overlay in the browser when there are compiler errors.
+  --client-overlay-warnings                           Enables a full-screen overlay in the browser when there are compiler warnings.
+  --no-client-overlay-warnings                        Disables the full-screen overlay in the browser when there are compiler warnings.
+  --client-overlay-runtime-errors                     Enables a full-screen overlay in the browser when there are uncaught runtime errors.
+  --no-client-overlay-runtime-errors                  Disables the full-screen overlay in the browser when there are uncaught runtime errors.
+  --client-overlay-trusted-types-policy-name <value>  The name of a Trusted Types policy for the overlay. Defaults to 'webpack-dev-server#overlay'.
+  --client-progress [value]                           Displays compilation progress in the browser. Options include 'linear' and 'circular' for visual indicators.
+  --no-client-progress                                Does not display compilation progress in the browser.
+  --client-reconnect [value]                          Tells dev-server the number of times it should try to reconnect the client.
+  --no-client-reconnect                               Tells dev-server to not to try to reconnect the client.
+  --client-web-socket-transport <value>               Allows to set custom web socket transport to communicate with dev server.
+  --client-web-socket-url <value>                     Allows to specify URL to web socket server (useful when you're proxying dev server and client script does not always know where to connect to).
+  --client-web-socket-url-hostname <value>            Tells clients connected to devServer to use the provided hostname.
+  --client-web-socket-url-pathname <value>            Tells clients connected to devServer to use the provided path to connect.
+  --client-web-socket-url-password <value>            Tells clients connected to devServer to use the provided password to authenticate.
+  --client-web-socket-url-port <value>                Tells clients connected to devServer to use the provided port.
+  --client-web-socket-url-protocol <value>            Tells clients connected to devServer to use the provided protocol.
+  --client-web-socket-url-username <value>            Tells clients connected to devServer to use the provided username to authenticate.
+  --compress                                          Enables gzip compression for everything served.
+  --no-compress                                       Disables gzip compression for everything served.
+  --history-api-fallback                              Allows to proxy requests through a specified index page (by default 'index.html'), useful for Single Page Applications that utilise the HTML5 History API.
+  --no-history-api-fallback                           Disallows to proxy requests through a specified index page.
+  --host <value>                                      Allows to specify a hostname to use.
+  --hot [value]                                       Enables Hot Module Replacement.
+  --no-hot                                            Disables Hot Module Replacement.
+  --ipc [value]                                       Listen to a unix socket.
+  --live-reload                                       Enables reload/refresh the page(s) when file changes are detected (enabled by default).
+  --no-live-reload                                    Disables reload/refresh the page(s) when file changes are detected (enabled by default).
+  --open [value...]                                   Allows to configure dev server to open the browser(s) and page(s) after server had been started (set it to true to open your default browser).
+  --no-open                                           Does not open the default browser.
+  --open-target <value...>                            Opens specified page in browser.
+  --open-app-name <value...>                          Open specified browser.
+  --open-reset                                        Clear all items provided in 'open' configuration. Allows to configure dev server to open the browser(s) and page(s) after server had been started (set it to true to open your default browser).
+  --open-target-reset                                 Clear all items provided in 'open.target' configuration. Opens specified page in browser.
+  --open-app-name-reset                               Clear all items provided in 'open.app.name' configuration. Open specified browser.
+  --port <value>                                      Allows to specify a port to use.
+  --server-type <value>                               Allows to set server and options (by default 'http').
+  --server-options-passphrase <value>                 Passphrase for a pfx file.
+  --server-options-request-cert                       Request for an SSL certificate.
+  --no-server-options-request-cert                    Does not request for an SSL certificate.
+  --server-options-ca <value...>                      Path to an SSL CA certificate or content of an SSL CA certificate.
+  --server-options-ca-reset                           Clear all items provided in 'server.options.ca' configuration. Path to an SSL CA certificate or content of an SSL CA certificate.
+  --server-options-cert <value...>                    Path to an SSL certificate or content of an SSL certificate.
+  --server-options-cert-reset                         Clear all items provided in 'server.options.cert' configuration. Path to an SSL certificate or content of an SSL certificate.
+  --server-options-crl <value...>                     Path to PEM formatted CRLs (Certificate Revocation Lists) or content of PEM formatted CRLs (Certificate Revocation Lists).
+  --server-options-crl-reset                          Clear all items provided in 'server.options.crl' configuration. Path to PEM formatted CRLs (Certificate Revocation Lists) or content of PEM formatted CRLs (Certificate Revocation Lists).
+  --server-options-key <value...>                     Path to an SSL key or content of an SSL key.
+  --server-options-key-reset                          Clear all items provided in 'server.options.key' configuration. Path to an SSL key or content of an SSL key.
+  --server-options-pfx <value...>                     Path to an SSL pfx file or content of an SSL pfx file.
+  --server-options-pfx-reset                          Clear all items provided in 'server.options.pfx' configuration. Path to an SSL pfx file or content of an SSL pfx file.
+  --static [value...]                                 Allows to configure options for serving static files from directory (by default 'public' directory).
+  --no-static                                         Disallows to configure options for serving static files from directory.
+  --static-directory <value...>                       Directory for static contents.
+  --static-public-path <value...>                     The static files will be available in the browser under this public path.
+  --static-serve-index                                Tells dev server to use serveIndex middleware when enabled.
+  --no-static-serve-index                             Does not tell dev server to use serveIndex middleware.
+  --static-watch                                      Watches for files in static content directory.
+  --no-static-watch                                   Does not watch for files in static content directory.
+  --static-reset                                      Clear all items provided in 'static' configuration. Allows to configure options for serving static files from directory (by default 'public' directory).
+  --static-public-path-reset                          Clear all items provided in 'static.publicPath' configuration. The static files will be available in the browser under this public path.
+  --watch-files <value...>                            Allows to configure list of globs/directories/files to watch for file changes.
+  --watch-files-reset                                 Clear all items provided in 'watchFiles' configuration. Allows to configure list of globs/directories/files to watch for file changes.
+  --no-web-socket-server                              Disallows to set web socket server and options.
+  --web-socket-server-type <value>                    Allows to set web socket server and options (by default 'ws').
+
+Global options
+────────────────────────────────────────────────────────────────────────
+  --color                                             Enable colors on console.
+  --no-color                                          Disable colors on console.
+  -v, --version                                       Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
+  -h, --help [verbose]                                Display help for commands and options.
+
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information for 's' command using the "--help verbose" option: stderr 1`] = `""`;
+
+exports[`help should show help information for 's' command using the "--help verbose" option: stdout 1`] = `
+"
+⬡ webpack serve
+────────────────────────────────────────────────────────────────────────
+Run the webpack dev server and watch for source file changes while serving.
+
+Usage: webpack serve|server|s [entries...] [options]
+
+Options
+────────────────────────────────────────────────────────────────────────
+  -c, --config <pathToConfigFile...>                                                 Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
+  --config-name <name...>                                                            Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
+  -m, --merge                                                                        Merge two or more configurations using 'webpack-merge'.
+  --env <value...>                                                                   Environment variables passed to the configuration when it is a function, e.g. "myvar" or "myvar=myval".
+  --config-node-env <value>                                                          Sets process.env.NODE_ENV to the specified value for access within the configuration.
+  --analyze                                                                          It invokes webpack-bundle-analyzer plugin to get bundle information.
+  --progress [value]                                                                 Print compilation progress during build.
+  -j, --json [pathToJsonFile]                                                        Prints result as JSON or store it in a file.
+  --fail-on-warnings                                                                 Stop webpack-cli process with non-zero exit code on warnings from webpack.
+  --disable-interpret                                                                Disable interpret for loading the config file.
+  --no-amd                                                                           Negative 'amd' option.
+  --bail                                                                             Report the first error as a hard error instead of tolerating it.
+  --no-bail                                                                          Negative 'bail' option.
+  --cache                                                                            Enable in memory caching. Disable caching.
+  --no-cache                                                                         Negative 'cache' option.
+  --cache-cache-unaffected                                                           Additionally cache computation of modules that are unchanged and reference only unchanged modules.
+  --no-cache-cache-unaffected                                                        Negative 'cache-cache-unaffected' option.
+  --cache-max-generations <value>                                                    Number of generations unused cache entries stay in memory cache
+    at stack.
+
+Global options
+────────────────────────────────────────────────────────────────────────
+  --color                                                                            Enable colors on console.
+  --no-color                                                                         Disable colors on console.
+  -v, --version                                                                      Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
+  -h, --help [verbose]                                                               Display help for commands and options.
+
+────────────────────────────────────────────────────────────────────────
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information for 's' command using the "--help" option: stderr 1`] = `""`;
+
+exports[`help should show help information for 's' command using the "--help" option: stdout 1`] = `
+"
+⬡ webpack serve
+────────────────────────────────────────────────────────────────────────
+Run the webpack dev server and watch for source file changes while serving.
+
+Usage: webpack serve|server|s [entries...] [options]
+
+Options
+────────────────────────────────────────────────────────────────────────
+  -c, --config <pathToConfigFile...>                  Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
+  --config-name <name...>                             Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
+  -m, --merge                                         Merge two or more configurations using 'webpack-merge'.
+  --env <value...>                                    Environment variables passed to the configuration when it is a function, e.g. "myvar" or "myvar=myval".
+  --config-node-env <value>                           Sets process.env.NODE_ENV to the specified value for access within the configuration.
+  --analyze                                           It invokes webpack-bundle-analyzer plugin to get bundle information.
+  --progress [value]                                  Print compilation progress during build.
+  -j, --json [pathToJsonFile]                         Prints result as JSON or store it in a file.
+  --fail-on-warnings                                  Stop webpack-cli process with non-zero exit code on warnings from webpack.
+  --disable-interpret                                 Disable interpret for loading the config file.
+  -d, --devtool <value>                               A developer tool to enhance debugging (false | eval | [inline-|hidden-|eval-][nosources-][cheap-[module-]]source-map).
+  --no-devtool                                        Negative 'devtool' option.
+  --entry <value...>                                  A module that is loaded upon startup. Only the last one is exported.
+  -e, --extends <value...>                            Path to the configuration to be extended (only works when using webpack-cli).
+  --mode <value>                                      Enable production optimizations or development hints.
+  --name <value>                                      Name of the configuration. Used when loading multiple configurations.
+  -o, --output-path <value>                           The output directory as **absolute path** (required).
+  --stats [value]                                     Stats options object or preset name.
+  -t, --target <value...>                             Specific environment, runtime, or syntax. Environment to build for. An array of environments to build for all of them when possible.
+  -w, --watch                                         Enter watch mode, which rebuilds on file change.
+  --watch-options-stdin                               Stop watching when stdin stream has ended.
+  --allowed-hosts <value...>                          Allows to enumerate the hosts from which access to the dev server are allowed (useful when you are proxying dev server, by default is 'auto').
+  --allowed-hosts-reset                               Clear all items provided in 'allowedHosts' configuration. Allows to enumerate the hosts from which access to the dev server are allowed (useful when you are proxying dev server, by default is 'auto').
+  --bonjour                                           Allows to broadcasts dev server via ZeroConf networking on start.
+  --no-bonjour                                        Disallows to broadcasts dev server via ZeroConf networking on start.
+  --no-client                                         Disables client script.
+  --client-logging <value>                            Allows to set log level in the browser.
+  --client-overlay                                    Enables a full-screen overlay in the browser when there are compiler errors or warnings.
+  --no-client-overlay                                 Disables the full-screen overlay in the browser when there are compiler errors or warnings.
+  --client-overlay-errors                             Enables a full-screen overlay in the browser when there are compiler errors.
+  --no-client-overlay-errors                          Disables the full-screen overlay in the browser when there are compiler errors.
+  --client-overlay-warnings                           Enables a full-screen overlay in the browser when there are compiler warnings.
+  --no-client-overlay-warnings                        Disables the full-screen overlay in the browser when there are compiler warnings.
+  --client-overlay-runtime-errors                     Enables a full-screen overlay in the browser when there are uncaught runtime errors.
+  --no-client-overlay-runtime-errors                  Disables the full-screen overlay in the browser when there are uncaught runtime errors.
+  --client-overlay-trusted-types-policy-name <value>  The name of a Trusted Types policy for the overlay. Defaults to 'webpack-dev-server#overlay'.
+  --client-progress [value]                           Displays compilation progress in the browser. Options include 'linear' and 'circular' for visual indicators.
+  --no-client-progress                                Does not display compilation progress in the browser.
+  --client-reconnect [value]                          Tells dev-server the number of times it should try to reconnect the client.
+  --no-client-reconnect                               Tells dev-server to not to try to reconnect the client.
+  --client-web-socket-transport <value>               Allows to set custom web socket transport to communicate with dev server.
+  --client-web-socket-url <value>                     Allows to specify URL to web socket server (useful when you're proxying dev server and client script does not always know where to connect to).
+  --client-web-socket-url-hostname <value>            Tells clients connected to devServer to use the provided hostname.
+  --client-web-socket-url-pathname <value>            Tells clients connected to devServer to use the provided path to connect.
+  --client-web-socket-url-password <value>            Tells clients connected to devServer to use the provided password to authenticate.
+  --client-web-socket-url-port <value>                Tells clients connected to devServer to use the provided port.
+  --client-web-socket-url-protocol <value>            Tells clients connected to devServer to use the provided protocol.
+  --client-web-socket-url-username <value>            Tells clients connected to devServer to use the provided username to authenticate.
+  --compress                                          Enables gzip compression for everything served.
+  --no-compress                                       Disables gzip compression for everything served.
+  --history-api-fallback                              Allows to proxy requests through a specified index page (by default 'index.html'), useful for Single Page Applications that utilise the HTML5 History API.
+  --no-history-api-fallback                           Disallows to proxy requests through a specified index page.
+  --host <value>                                      Allows to specify a hostname to use.
+  --hot [value]                                       Enables Hot Module Replacement.
+  --no-hot                                            Disables Hot Module Replacement.
+  --ipc [value]                                       Listen to a unix socket.
+  --live-reload                                       Enables reload/refresh the page(s) when file changes are detected (enabled by default).
+  --no-live-reload                                    Disables reload/refresh the page(s) when file changes are detected (enabled by default).
+  --open [value...]                                   Allows to configure dev server to open the browser(s) and page(s) after server had been started (set it to true to open your default browser).
+  --no-open                                           Does not open the default browser.
+  --open-target <value...>                            Opens specified page in browser.
+  --open-app-name <value...>                          Open specified browser.
+  --open-reset                                        Clear all items provided in 'open' configuration. Allows to configure dev server to open the browser(s) and page(s) after server had been started (set it to true to open your default browser).
+  --open-target-reset                                 Clear all items provided in 'open.target' configuration. Opens specified page in browser.
+  --open-app-name-reset                               Clear all items provided in 'open.app.name' configuration. Open specified browser.
+  --port <value>                                      Allows to specify a port to use.
+  --server-type <value>                               Allows to set server and options (by default 'http').
+  --server-options-passphrase <value>                 Passphrase for a pfx file.
+  --server-options-request-cert                       Request for an SSL certificate.
+  --no-server-options-request-cert                    Does not request for an SSL certificate.
+  --server-options-ca <value...>                      Path to an SSL CA certificate or content of an SSL CA certificate.
+  --server-options-ca-reset                           Clear all items provided in 'server.options.ca' configuration. Path to an SSL CA certificate or content of an SSL CA certificate.
+  --server-options-cert <value...>                    Path to an SSL certificate or content of an SSL certificate.
+  --server-options-cert-reset                         Clear all items provided in 'server.options.cert' configuration. Path to an SSL certificate or content of an SSL certificate.
+  --server-options-crl <value...>                     Path to PEM formatted CRLs (Certificate Revocation Lists) or content of PEM formatted CRLs (Certificate Revocation Lists).
+  --server-options-crl-reset                          Clear all items provided in 'server.options.crl' configuration. Path to PEM formatted CRLs (Certificate Revocation Lists) or content of PEM formatted CRLs (Certificate Revocation Lists).
+  --server-options-key <value...>                     Path to an SSL key or content of an SSL key.
+  --server-options-key-reset                          Clear all items provided in 'server.options.key' configuration. Path to an SSL key or content of an SSL key.
+  --server-options-pfx <value...>                     Path to an SSL pfx file or content of an SSL pfx file.
+  --server-options-pfx-reset                          Clear all items provided in 'server.options.pfx' configuration. Path to an SSL pfx file or content of an SSL pfx file.
+  --static [value...]                                 Allows to configure options for serving static files from directory (by default 'public' directory).
+  --no-static                                         Disallows to configure options for serving static files from directory.
+  --static-directory <value...>                       Directory for static contents.
+  --static-public-path <value...>                     The static files will be available in the browser under this public path.
+  --static-serve-index                                Tells dev server to use serveIndex middleware when enabled.
+  --no-static-serve-index                             Does not tell dev server to use serveIndex middleware.
+  --static-watch                                      Watches for files in static content directory.
+  --no-static-watch                                   Does not watch for files in static content directory.
+  --static-reset                                      Clear all items provided in 'static' configuration. Allows to configure options for serving static files from directory (by default 'public' directory).
+  --static-public-path-reset                          Clear all items provided in 'static.publicPath' configuration. The static files will be available in the browser under this public path.
+  --watch-files <value...>                            Allows to configure list of globs/directories/files to watch for file changes.
+  --watch-files-reset                                 Clear all items provided in 'watchFiles' configuration. Allows to configure list of globs/directories/files to watch for file changes.
+  --no-web-socket-server                              Disallows to set web socket server and options.
+  --web-socket-server-type <value>                    Allows to set web socket server and options (by default 'ws').
+
+Global options
+────────────────────────────────────────────────────────────────────────
+  --color                                             Enable colors on console.
+  --no-color                                          Disable colors on console.
+  -v, --version                                       Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
+  -h, --help [verbose]                                Display help for commands and options.
+
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information for 'serve' and respect the "--color" flag using the "--help" option: stderr 1`] = `""`;
+
+exports[`help should show help information for 'serve' and respect the "--color" flag using the "--help" option: stdout 1`] = `
+"
+⬡ webpack serve
+────────────────────────────────────────────────────────────────────────
+Run the webpack dev server and watch for source file changes while serving.
+
+Usage: webpack serve|server|s [entries...] [options]
+
+Options
+────────────────────────────────────────────────────────────────────────
+  -c, --config <pathToConfigFile...>                  Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
+  --config-name <name...>                             Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
+  -m, --merge                                         Merge two or more configurations using 'webpack-merge'.
+  --env <value...>                                    Environment variables passed to the configuration when it is a function, e.g. "myvar" or "myvar=myval".
+  --config-node-env <value>                           Sets process.env.NODE_ENV to the specified value for access within the configuration.
+  --analyze                                           It invokes webpack-bundle-analyzer plugin to get bundle information.
+  --progress [value]                                  Print compilation progress during build.
+  -j, --json [pathToJsonFile]                         Prints result as JSON or store it in a file.
+  --fail-on-warnings                                  Stop webpack-cli process with non-zero exit code on warnings from webpack.
+  --disable-interpret                                 Disable interpret for loading the config file.
+  -d, --devtool <value>                               A developer tool to enhance debugging (false | eval | [inline-|hidden-|eval-][nosources-][cheap-[module-]]source-map).
+  --no-devtool                                        Negative 'devtool' option.
+  --entry <value...>                                  A module that is loaded upon startup. Only the last one is exported.
+  -e, --extends <value...>                            Path to the configuration to be extended (only works when using webpack-cli).
+  --mode <value>                                      Enable production optimizations or development hints.
+  --name <value>                                      Name of the configuration. Used when loading multiple configurations.
+  -o, --output-path <value>                           The output directory as **absolute path** (required).
+  --stats [value]                                     Stats options object or preset name.
+  -t, --target <value...>                             Specific environment, runtime, or syntax. Environment to build for. An array of environments to build for all of them when possible.
+  -w, --watch                                         Enter watch mode, which rebuilds on file change.
+  --watch-options-stdin                               Stop watching when stdin stream has ended.
+  --allowed-hosts <value...>                          Allows to enumerate the hosts from which access to the dev server are allowed (useful when you are proxying dev server, by default is 'auto').
+  --allowed-hosts-reset                               Clear all items provided in 'allowedHosts' configuration. Allows to enumerate the hosts from which access to the dev server are allowed (useful when you are proxying dev server, by default is 'auto').
+  --bonjour                                           Allows to broadcasts dev server via ZeroConf networking on start.
+  --no-bonjour                                        Disallows to broadcasts dev server via ZeroConf networking on start.
+  --no-client                                         Disables client script.
+  --client-logging <value>                            Allows to set log level in the browser.
+  --client-overlay                                    Enables a full-screen overlay in the browser when there are compiler errors or warnings.
+  --no-client-overlay                                 Disables the full-screen overlay in the browser when there are compiler errors or warnings.
+  --client-overlay-errors                             Enables a full-screen overlay in the browser when there are compiler errors.
+  --no-client-overlay-errors                          Disables the full-screen overlay in the browser when there are compiler errors.
+  --client-overlay-warnings                           Enables a full-screen overlay in the browser when there are compiler warnings.
+  --no-client-overlay-warnings                        Disables the full-screen overlay in the browser when there are compiler warnings.
+  --client-overlay-runtime-errors                     Enables a full-screen overlay in the browser when there are uncaught runtime errors.
+  --no-client-overlay-runtime-errors                  Disables the full-screen overlay in the browser when there are uncaught runtime errors.
+  --client-overlay-trusted-types-policy-name <value>  The name of a Trusted Types policy for the overlay. Defaults to 'webpack-dev-server#overlay'.
+  --client-progress [value]                           Displays compilation progress in the browser. Options include 'linear' and 'circular' for visual indicators.
+  --no-client-progress                                Does not display compilation progress in the browser.
+  --client-reconnect [value]                          Tells dev-server the number of times it should try to reconnect the client.
+  --no-client-reconnect                               Tells dev-server to not to try to reconnect the client.
+  --client-web-socket-transport <value>               Allows to set custom web socket transport to communicate with dev server.
+  --client-web-socket-url <value>                     Allows to specify URL to web socket server (useful when you're proxying dev server and client script does not always know where to connect to).
+  --client-web-socket-url-hostname <value>            Tells clients connected to devServer to use the provided hostname.
+  --client-web-socket-url-pathname <value>            Tells clients connected to devServer to use the provided path to connect.
+  --client-web-socket-url-password <value>            Tells clients connected to devServer to use the provided password to authenticate.
+  --client-web-socket-url-port <value>                Tells clients connected to devServer to use the provided port.
+  --client-web-socket-url-protocol <value>            Tells clients connected to devServer to use the provided protocol.
+  --client-web-socket-url-username <value>            Tells clients connected to devServer to use the provided username to authenticate.
+  --compress                                          Enables gzip compression for everything served.
+  --no-compress                                       Disables gzip compression for everything served.
+  --history-api-fallback                              Allows to proxy requests through a specified index page (by default 'index.html'), useful for Single Page Applications that utilise the HTML5 History API.
+  --no-history-api-fallback                           Disallows to proxy requests through a specified index page.
+  --host <value>                                      Allows to specify a hostname to use.
+  --hot [value]                                       Enables Hot Module Replacement.
+  --no-hot                                            Disables Hot Module Replacement.
+  --ipc [value]                                       Listen to a unix socket.
+  --live-reload                                       Enables reload/refresh the page(s) when file changes are detected (enabled by default).
+  --no-live-reload                                    Disables reload/refresh the page(s) when file changes are detected (enabled by default).
+  --open [value...]                                   Allows to configure dev server to open the browser(s) and page(s) after server had been started (set it to true to open your default browser).
+  --no-open                                           Does not open the default browser.
+  --open-target <value...>                            Opens specified page in browser.
+  --open-app-name <value...>                          Open specified browser.
+  --open-reset                                        Clear all items provided in 'open' configuration. Allows to configure dev server to open the browser(s) and page(s) after server had been started (set it to true to open your default browser).
+  --open-target-reset                                 Clear all items provided in 'open.target' configuration. Opens specified page in browser.
+  --open-app-name-reset                               Clear all items provided in 'open.app.name' configuration. Open specified browser.
+  --port <value>                                      Allows to specify a port to use.
+  --server-type <value>                               Allows to set server and options (by default 'http').
+  --server-options-passphrase <value>                 Passphrase for a pfx file.
+  --server-options-request-cert                       Request for an SSL certificate.
+  --no-server-options-request-cert                    Does not request for an SSL certificate.
+  --server-options-ca <value...>                      Path to an SSL CA certificate or content of an SSL CA certificate.
+  --server-options-ca-reset                           Clear all items provided in 'server.options.ca' configuration. Path to an SSL CA certificate or content of an SSL CA certificate.
+  --server-options-cert <value...>                    Path to an SSL certificate or content of an SSL certificate.
+  --server-options-cert-reset                         Clear all items provided in 'server.options.cert' configuration. Path to an SSL certificate or content of an SSL certificate.
+  --server-options-crl <value...>                     Path to PEM formatted CRLs (Certificate Revocation Lists) or content of PEM formatted CRLs (Certificate Revocation Lists).
+  --server-options-crl-reset                          Clear all items provided in 'server.options.crl' configuration. Path to PEM formatted CRLs (Certificate Revocation Lists) or content of PEM formatted CRLs (Certificate Revocation Lists).
+  --server-options-key <value...>                     Path to an SSL key or content of an SSL key.
+  --server-options-key-reset                          Clear all items provided in 'server.options.key' configuration. Path to an SSL key or content of an SSL key.
+  --server-options-pfx <value...>                     Path to an SSL pfx file or content of an SSL pfx file.
+  --server-options-pfx-reset                          Clear all items provided in 'server.options.pfx' configuration. Path to an SSL pfx file or content of an SSL pfx file.
+  --static [value...]                                 Allows to configure options for serving static files from directory (by default 'public' directory).
+  --no-static                                         Disallows to configure options for serving static files from directory.
+  --static-directory <value...>                       Directory for static contents.
+  --static-public-path <value...>                     The static files will be available in the browser under this public path.
+  --static-serve-index                                Tells dev server to use serveIndex middleware when enabled.
+  --no-static-serve-index                             Does not tell dev server to use serveIndex middleware.
+  --static-watch                                      Watches for files in static content directory.
+  --no-static-watch                                   Does not watch for files in static content directory.
+  --static-reset                                      Clear all items provided in 'static' configuration. Allows to configure options for serving static files from directory (by default 'public' directory).
+  --static-public-path-reset                          Clear all items provided in 'static.publicPath' configuration. The static files will be available in the browser under this public path.
+  --watch-files <value...>                            Allows to configure list of globs/directories/files to watch for file changes.
+  --watch-files-reset                                 Clear all items provided in 'watchFiles' configuration. Allows to configure list of globs/directories/files to watch for file changes.
+  --no-web-socket-server                              Disallows to set web socket server and options.
+  --web-socket-server-type <value>                    Allows to set web socket server and options (by default 'ws').
+
+Global options
+────────────────────────────────────────────────────────────────────────
+  --color                                             Enable colors on console.
+  --no-color                                          Disable colors on console.
+  -v, --version                                       Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
+  -h, --help [verbose]                                Display help for commands and options.
+
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information for 'serve' and respect the "--no-color" flag using the "--help" option: stderr 1`] = `""`;
+
+exports[`help should show help information for 'serve' and respect the "--no-color" flag using the "--help" option: stdout 1`] = `
+"
+⬡ webpack serve
+────────────────────────────────────────────────────────────────────────
+Run the webpack dev server and watch for source file changes while serving.
+
+Usage: webpack serve|server|s [entries...] [options]
+
+Options
+────────────────────────────────────────────────────────────────────────
+  -c, --config <pathToConfigFile...>                  Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
+  --config-name <name...>                             Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
+  -m, --merge                                         Merge two or more configurations using 'webpack-merge'.
+  --env <value...>                                    Environment variables passed to the configuration when it is a function, e.g. "myvar" or "myvar=myval".
+  --config-node-env <value>                           Sets process.env.NODE_ENV to the specified value for access within the configuration.
+  --analyze                                           It invokes webpack-bundle-analyzer plugin to get bundle information.
+  --progress [value]                                  Print compilation progress during build.
+  -j, --json [pathToJsonFile]                         Prints result as JSON or store it in a file.
+  --fail-on-warnings                                  Stop webpack-cli process with non-zero exit code on warnings from webpack.
+  --disable-interpret                                 Disable interpret for loading the config file.
+  -d, --devtool <value>                               A developer tool to enhance debugging (false | eval | [inline-|hidden-|eval-][nosources-][cheap-[module-]]source-map).
+  --no-devtool                                        Negative 'devtool' option.
+  --entry <value...>                                  A module that is loaded upon startup. Only the last one is exported.
+  -e, --extends <value...>                            Path to the configuration to be extended (only works when using webpack-cli).
+  --mode <value>                                      Enable production optimizations or development hints.
+  --name <value>                                      Name of the configuration. Used when loading multiple configurations.
+  -o, --output-path <value>                           The output directory as **absolute path** (required).
+  --stats [value]                                     Stats options object or preset name.
+  -t, --target <value...>                             Specific environment, runtime, or syntax. Environment to build for. An array of environments to build for all of them when possible.
+  -w, --watch                                         Enter watch mode, which rebuilds on file change.
+  --watch-options-stdin                               Stop watching when stdin stream has ended.
+  --allowed-hosts <value...>                          Allows to enumerate the hosts from which access to the dev server are allowed (useful when you are proxying dev server, by default is 'auto').
+  --allowed-hosts-reset                               Clear all items provided in 'allowedHosts' configuration. Allows to enumerate the hosts from which access to the dev server are allowed (useful when you are proxying dev server, by default is 'auto').
+  --bonjour                                           Allows to broadcasts dev server via ZeroConf networking on start.
+  --no-bonjour                                        Disallows to broadcasts dev server via ZeroConf networking on start.
+  --no-client                                         Disables client script.
+  --client-logging <value>                            Allows to set log level in the browser.
+  --client-overlay                                    Enables a full-screen overlay in the browser when there are compiler errors or warnings.
+  --no-client-overlay                                 Disables the full-screen overlay in the browser when there are compiler errors or warnings.
+  --client-overlay-errors                             Enables a full-screen overlay in the browser when there are compiler errors.
+  --no-client-overlay-errors                          Disables the full-screen overlay in the browser when there are compiler errors.
+  --client-overlay-warnings                           Enables a full-screen overlay in the browser when there are compiler warnings.
+  --no-client-overlay-warnings                        Disables the full-screen overlay in the browser when there are compiler warnings.
+  --client-overlay-runtime-errors                     Enables a full-screen overlay in the browser when there are uncaught runtime errors.
+  --no-client-overlay-runtime-errors                  Disables the full-screen overlay in the browser when there are uncaught runtime errors.
+  --client-overlay-trusted-types-policy-name <value>  The name of a Trusted Types policy for the overlay. Defaults to 'webpack-dev-server#overlay'.
+  --client-progress [value]                           Displays compilation progress in the browser. Options include 'linear' and 'circular' for visual indicators.
+  --no-client-progress                                Does not display compilation progress in the browser.
+  --client-reconnect [value]                          Tells dev-server the number of times it should try to reconnect the client.
+  --no-client-reconnect                               Tells dev-server to not to try to reconnect the client.
+  --client-web-socket-transport <value>               Allows to set custom web socket transport to communicate with dev server.
+  --client-web-socket-url <value>                     Allows to specify URL to web socket server (useful when you're proxying dev server and client script does not always know where to connect to).
+  --client-web-socket-url-hostname <value>            Tells clients connected to devServer to use the provided hostname.
+  --client-web-socket-url-pathname <value>            Tells clients connected to devServer to use the provided path to connect.
+  --client-web-socket-url-password <value>            Tells clients connected to devServer to use the provided password to authenticate.
+  --client-web-socket-url-port <value>                Tells clients connected to devServer to use the provided port.
+  --client-web-socket-url-protocol <value>            Tells clients connected to devServer to use the provided protocol.
+  --client-web-socket-url-username <value>            Tells clients connected to devServer to use the provided username to authenticate.
+  --compress                                          Enables gzip compression for everything served.
+  --no-compress                                       Disables gzip compression for everything served.
+  --history-api-fallback                              Allows to proxy requests through a specified index page (by default 'index.html'), useful for Single Page Applications that utilise the HTML5 History API.
+  --no-history-api-fallback                           Disallows to proxy requests through a specified index page.
+  --host <value>                                      Allows to specify a hostname to use.
+  --hot [value]                                       Enables Hot Module Replacement.
+  --no-hot                                            Disables Hot Module Replacement.
+  --ipc [value]                                       Listen to a unix socket.
+  --live-reload                                       Enables reload/refresh the page(s) when file changes are detected (enabled by default).
+  --no-live-reload                                    Disables reload/refresh the page(s) when file changes are detected (enabled by default).
+  --open [value...]                                   Allows to configure dev server to open the browser(s) and page(s) after server had been started (set it to true to open your default browser).
+  --no-open                                           Does not open the default browser.
+  --open-target <value...>                            Opens specified page in browser.
+  --open-app-name <value...>                          Open specified browser.
+  --open-reset                                        Clear all items provided in 'open' configuration. Allows to configure dev server to open the browser(s) and page(s) after server had been started (set it to true to open your default browser).
+  --open-target-reset                                 Clear all items provided in 'open.target' configuration. Opens specified page in browser.
+  --open-app-name-reset                               Clear all items provided in 'open.app.name' configuration. Open specified browser.
+  --port <value>                                      Allows to specify a port to use.
+  --server-type <value>                               Allows to set server and options (by default 'http').
+  --server-options-passphrase <value>                 Passphrase for a pfx file.
+  --server-options-request-cert                       Request for an SSL certificate.
+  --no-server-options-request-cert                    Does not request for an SSL certificate.
+  --server-options-ca <value...>                      Path to an SSL CA certificate or content of an SSL CA certificate.
+  --server-options-ca-reset                           Clear all items provided in 'server.options.ca' configuration. Path to an SSL CA certificate or content of an SSL CA certificate.
+  --server-options-cert <value...>                    Path to an SSL certificate or content of an SSL certificate.
+  --server-options-cert-reset                         Clear all items provided in 'server.options.cert' configuration. Path to an SSL certificate or content of an SSL certificate.
+  --server-options-crl <value...>                     Path to PEM formatted CRLs (Certificate Revocation Lists) or content of PEM formatted CRLs (Certificate Revocation Lists).
+  --server-options-crl-reset                          Clear all items provided in 'server.options.crl' configuration. Path to PEM formatted CRLs (Certificate Revocation Lists) or content of PEM formatted CRLs (Certificate Revocation Lists).
+  --server-options-key <value...>                     Path to an SSL key or content of an SSL key.
+  --server-options-key-reset                          Clear all items provided in 'server.options.key' configuration. Path to an SSL key or content of an SSL key.
+  --server-options-pfx <value...>                     Path to an SSL pfx file or content of an SSL pfx file.
+  --server-options-pfx-reset                          Clear all items provided in 'server.options.pfx' configuration. Path to an SSL pfx file or content of an SSL pfx file.
+  --static [value...]                                 Allows to configure options for serving static files from directory (by default 'public' directory).
+  --no-static                                         Disallows to configure options for serving static files from directory.
+  --static-directory <value...>                       Directory for static contents.
+  --static-public-path <value...>                     The static files will be available in the browser under this public path.
+  --static-serve-index                                Tells dev server to use serveIndex middleware when enabled.
+  --no-static-serve-index                             Does not tell dev server to use serveIndex middleware.
+  --static-watch                                      Watches for files in static content directory.
+  --no-static-watch                                   Does not watch for files in static content directory.
+  --static-reset                                      Clear all items provided in 'static' configuration. Allows to configure options for serving static files from directory (by default 'public' directory).
+  --static-public-path-reset                          Clear all items provided in 'static.publicPath' configuration. The static files will be available in the browser under this public path.
+  --watch-files <value...>                            Allows to configure list of globs/directories/files to watch for file changes.
+  --watch-files-reset                                 Clear all items provided in 'watchFiles' configuration. Allows to configure list of globs/directories/files to watch for file changes.
+  --no-web-socket-server                              Disallows to set web socket server and options.
+  --web-socket-server-type <value>                    Allows to set web socket server and options (by default 'ws').
+
+Global options
+────────────────────────────────────────────────────────────────────────
+  --color                                             Enable colors on console.
+  --no-color                                          Disable colors on console.
+  -v, --version                                       Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
+  -h, --help [verbose]                                Display help for commands and options.
+
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information for 'serve' command using command syntax: stderr 1`] = `""`;
+
+exports[`help should show help information for 'serve' command using command syntax: stdout 1`] = `
+"
+⬡ webpack serve
+────────────────────────────────────────────────────────────────────────
+Run the webpack dev server and watch for source file changes while serving.
+
+Usage: webpack serve|server|s [entries...] [options]
+
+Options
+────────────────────────────────────────────────────────────────────────
+  -c, --config <pathToConfigFile...>                  Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
+  --config-name <name...>                             Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
+  -m, --merge                                         Merge two or more configurations using 'webpack-merge'.
+  --env <value...>                                    Environment variables passed to the configuration when it is a function, e.g. "myvar" or "myvar=myval".
+  --config-node-env <value>                           Sets process.env.NODE_ENV to the specified value for access within the configuration.
+  --analyze                                           It invokes webpack-bundle-analyzer plugin to get bundle information.
+  --progress [value]                                  Print compilation progress during build.
+  -j, --json [pathToJsonFile]                         Prints result as JSON or store it in a file.
+  --fail-on-warnings                                  Stop webpack-cli process with non-zero exit code on warnings from webpack.
+  --disable-interpret                                 Disable interpret for loading the config file.
+  -d, --devtool <value>                               A developer tool to enhance debugging (false | eval | [inline-|hidden-|eval-][nosources-][cheap-[module-]]source-map).
+  --no-devtool                                        Negative 'devtool' option.
+  --entry <value...>                                  A module that is loaded upon startup. Only the last one is exported.
+  -e, --extends <value...>                            Path to the configuration to be extended (only works when using webpack-cli).
+  --mode <value>                                      Enable production optimizations or development hints.
+  --name <value>                                      Name of the configuration. Used when loading multiple configurations.
+  -o, --output-path <value>                           The output directory as **absolute path** (required).
+  --stats [value]                                     Stats options object or preset name.
+  -t, --target <value...>                             Specific environment, runtime, or syntax. Environment to build for. An array of environments to build for all of them when possible.
+  -w, --watch                                         Enter watch mode, which rebuilds on file change.
+  --watch-options-stdin                               Stop watching when stdin stream has ended.
+  --allowed-hosts <value...>                          Allows to enumerate the hosts from which access to the dev server are allowed (useful when you are proxying dev server, by default is 'auto').
+  --allowed-hosts-reset                               Clear all items provided in 'allowedHosts' configuration. Allows to enumerate the hosts from which access to the dev server are allowed (useful when you are proxying dev server, by default is 'auto').
+  --bonjour                                           Allows to broadcasts dev server via ZeroConf networking on start.
+  --no-bonjour                                        Disallows to broadcasts dev server via ZeroConf networking on start.
+  --no-client                                         Disables client script.
+  --client-logging <value>                            Allows to set log level in the browser.
+  --client-overlay                                    Enables a full-screen overlay in the browser when there are compiler errors or warnings.
+  --no-client-overlay                                 Disables the full-screen overlay in the browser when there are compiler errors or warnings.
+  --client-overlay-errors                             Enables a full-screen overlay in the browser when there are compiler errors.
+  --no-client-overlay-errors                          Disables the full-screen overlay in the browser when there are compiler errors.
+  --client-overlay-warnings                           Enables a full-screen overlay in the browser when there are compiler warnings.
+  --no-client-overlay-warnings                        Disables the full-screen overlay in the browser when there are compiler warnings.
+  --client-overlay-runtime-errors                     Enables a full-screen overlay in the browser when there are uncaught runtime errors.
+  --no-client-overlay-runtime-errors                  Disables the full-screen overlay in the browser when there are uncaught runtime errors.
+  --client-overlay-trusted-types-policy-name <value>  The name of a Trusted Types policy for the overlay. Defaults to 'webpack-dev-server#overlay'.
+  --client-progress [value]                           Displays compilation progress in the browser. Options include 'linear' and 'circular' for visual indicators.
+  --no-client-progress                                Does not display compilation progress in the browser.
+  --client-reconnect [value]                          Tells dev-server the number of times it should try to reconnect the client.
+  --no-client-reconnect                               Tells dev-server to not to try to reconnect the client.
+  --client-web-socket-transport <value>               Allows to set custom web socket transport to communicate with dev server.
+  --client-web-socket-url <value>                     Allows to specify URL to web socket server (useful when you're proxying dev server and client script does not always know where to connect to).
+  --client-web-socket-url-hostname <value>            Tells clients connected to devServer to use the provided hostname.
+  --client-web-socket-url-pathname <value>            Tells clients connected to devServer to use the provided path to connect.
+  --client-web-socket-url-password <value>            Tells clients connected to devServer to use the provided password to authenticate.
+  --client-web-socket-url-port <value>                Tells clients connected to devServer to use the provided port.
+  --client-web-socket-url-protocol <value>            Tells clients connected to devServer to use the provided protocol.
+  --client-web-socket-url-username <value>            Tells clients connected to devServer to use the provided username to authenticate.
+  --compress                                          Enables gzip compression for everything served.
+  --no-compress                                       Disables gzip compression for everything served.
+  --history-api-fallback                              Allows to proxy requests through a specified index page (by default 'index.html'), useful for Single Page Applications that utilise the HTML5 History API.
+  --no-history-api-fallback                           Disallows to proxy requests through a specified index page.
+  --host <value>                                      Allows to specify a hostname to use.
+  --hot [value]                                       Enables Hot Module Replacement.
+  --no-hot                                            Disables Hot Module Replacement.
+  --ipc [value]                                       Listen to a unix socket.
+  --live-reload                                       Enables reload/refresh the page(s) when file changes are detected (enabled by default).
+  --no-live-reload                                    Disables reload/refresh the page(s) when file changes are detected (enabled by default).
+  --open [value...]                                   Allows to configure dev server to open the browser(s) and page(s) after server had been started (set it to true to open your default browser).
+  --no-open                                           Does not open the default browser.
+  --open-target <value...>                            Opens specified page in browser.
+  --open-app-name <value...>                          Open specified browser.
+  --open-reset                                        Clear all items provided in 'open' configuration. Allows to configure dev server to open the browser(s) and page(s) after server had been started (set it to true to open your default browser).
+  --open-target-reset                                 Clear all items provided in 'open.target' configuration. Opens specified page in browser.
+  --open-app-name-reset                               Clear all items provided in 'open.app.name' configuration. Open specified browser.
+  --port <value>                                      Allows to specify a port to use.
+  --server-type <value>                               Allows to set server and options (by default 'http').
+  --server-options-passphrase <value>                 Passphrase for a pfx file.
+  --server-options-request-cert                       Request for an SSL certificate.
+  --no-server-options-request-cert                    Does not request for an SSL certificate.
+  --server-options-ca <value...>                      Path to an SSL CA certificate or content of an SSL CA certificate.
+  --server-options-ca-reset                           Clear all items provided in 'server.options.ca' configuration. Path to an SSL CA certificate or content of an SSL CA certificate.
+  --server-options-cert <value...>                    Path to an SSL certificate or content of an SSL certificate.
+  --server-options-cert-reset                         Clear all items provided in 'server.options.cert' configuration. Path to an SSL certificate or content of an SSL certificate.
+  --server-options-crl <value...>                     Path to PEM formatted CRLs (Certificate Revocation Lists) or content of PEM formatted CRLs (Certificate Revocation Lists).
+  --server-options-crl-reset                          Clear all items provided in 'server.options.crl' configuration. Path to PEM formatted CRLs (Certificate Revocation Lists) or content of PEM formatted CRLs (Certificate Revocation Lists).
+  --server-options-key <value...>                     Path to an SSL key or content of an SSL key.
+  --server-options-key-reset                          Clear all items provided in 'server.options.key' configuration. Path to an SSL key or content of an SSL key.
+  --server-options-pfx <value...>                     Path to an SSL pfx file or content of an SSL pfx file.
+  --server-options-pfx-reset                          Clear all items provided in 'server.options.pfx' configuration. Path to an SSL pfx file or content of an SSL pfx file.
+  --static [value...]                                 Allows to configure options for serving static files from directory (by default 'public' directory).
+  --no-static                                         Disallows to configure options for serving static files from directory.
+  --static-directory <value...>                       Directory for static contents.
+  --static-public-path <value...>                     The static files will be available in the browser under this public path.
+  --static-serve-index                                Tells dev server to use serveIndex middleware when enabled.
+  --no-static-serve-index                             Does not tell dev server to use serveIndex middleware.
+  --static-watch                                      Watches for files in static content directory.
+  --no-static-watch                                   Does not watch for files in static content directory.
+  --static-reset                                      Clear all items provided in 'static' configuration. Allows to configure options for serving static files from directory (by default 'public' directory).
+  --static-public-path-reset                          Clear all items provided in 'static.publicPath' configuration. The static files will be available in the browser under this public path.
+  --watch-files <value...>                            Allows to configure list of globs/directories/files to watch for file changes.
+  --watch-files-reset                                 Clear all items provided in 'watchFiles' configuration. Allows to configure list of globs/directories/files to watch for file changes.
+  --no-web-socket-server                              Disallows to set web socket server and options.
+  --web-socket-server-type <value>                    Allows to set web socket server and options (by default 'ws').
+
+Global options
+────────────────────────────────────────────────────────────────────────
+  --color                                             Enable colors on console.
+  --no-color                                          Disable colors on console.
+  -v, --version                                       Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
+  -h, --help [verbose]                                Display help for commands and options.
+
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information for 'serve' command using the "--help verbose" option: stderr 1`] = `""`;
+
+exports[`help should show help information for 'serve' command using the "--help verbose" option: stdout 1`] = `
+"
+⬡ webpack serve
+────────────────────────────────────────────────────────────────────────
+Run the webpack dev server and watch for source file changes while serving.
+
+Usage: webpack serve|server|s [entries...] [options]
+
+Options
+────────────────────────────────────────────────────────────────────────
+  -c, --config <pathToConfigFile...>                                                 Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
+  --config-name <name...>                                                            Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
+  -m, --merge                                                                        Merge two or more configurations using 'webpack-merge'.
+  --env <value...>                                                                   Environment variables passed to the configuration when it is a function, e.g. "myvar" or "myvar=myval".
+  --config-node-env <value>                                                          Sets process.env.NODE_ENV to the specified value for access within the configuration.
+  --analyze                                                                          It invokes webpack-bundle-analyzer plugin to get bundle information.
+  --progress [value]                                                                 Print compilation progress during build.
+  -j, --json [pathToJsonFile]                                                        Prints result as JSON or store it in a file.
+  --fail-on-warnings                                                                 Stop webpack-cli process with non-zero exit code on warnings from webpack.
+  --disable-interpret                                                                Disable interpret for loading the config file.
+  --no-amd                                                                           Negative 'amd' option.
+  --bail                                                                             Report the first error as a hard error instead of tolerating it.
+  --no-bail                                                                          Negative 'bail' option.
+  --cache                                                                            Enable in memory caching. Disable caching.
+  --no-cache                                                                         Negative 'cache' option.
+  --cache-cache-unaffected                                                           Additionally cache computation of modules that are unchanged and reference only unchanged modules.
+  --no-cache-cache-unaffected                                                        Negative 'cache-cache-unaffected' option.
+  --cache-max-generations <value>                                                    Number of generations unused cache entries stay in memory cache
+    at stack.
+
+Global options
+────────────────────────────────────────────────────────────────────────
+  --color                                                                            Enable colors on console.
+  --no-color                                                                         Disable colors on console.
+  -v, --version                                                                      Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
+  -h, --help [verbose]                                                               Display help for commands and options.
+
+────────────────────────────────────────────────────────────────────────
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information for 'serve' command using the "--help" option: stderr 1`] = `""`;
+
+exports[`help should show help information for 'serve' command using the "--help" option: stdout 1`] = `
+"
+⬡ webpack serve
+────────────────────────────────────────────────────────────────────────
+Run the webpack dev server and watch for source file changes while serving.
+
+Usage: webpack serve|server|s [entries...] [options]
+
+Options
+────────────────────────────────────────────────────────────────────────
+  -c, --config <pathToConfigFile...>                  Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
+  --config-name <name...>                             Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
+  -m, --merge                                         Merge two or more configurations using 'webpack-merge'.
+  --env <value...>                                    Environment variables passed to the configuration when it is a function, e.g. "myvar" or "myvar=myval".
+  --config-node-env <value>                           Sets process.env.NODE_ENV to the specified value for access within the configuration.
+  --analyze                                           It invokes webpack-bundle-analyzer plugin to get bundle information.
+  --progress [value]                                  Print compilation progress during build.
+  -j, --json [pathToJsonFile]                         Prints result as JSON or store it in a file.
+  --fail-on-warnings                                  Stop webpack-cli process with non-zero exit code on warnings from webpack.
+  --disable-interpret                                 Disable interpret for loading the config file.
+  -d, --devtool <value>                               A developer tool to enhance debugging (false | eval | [inline-|hidden-|eval-][nosources-][cheap-[module-]]source-map).
+  --no-devtool                                        Negative 'devtool' option.
+  --entry <value...>                                  A module that is loaded upon startup. Only the last one is exported.
+  -e, --extends <value...>                            Path to the configuration to be extended (only works when using webpack-cli).
+  --mode <value>                                      Enable production optimizations or development hints.
+  --name <value>                                      Name of the configuration. Used when loading multiple configurations.
+  -o, --output-path <value>                           The output directory as **absolute path** (required).
+  --stats [value]                                     Stats options object or preset name.
+  -t, --target <value...>                             Specific environment, runtime, or syntax. Environment to build for. An array of environments to build for all of them when possible.
+  -w, --watch                                         Enter watch mode, which rebuilds on file change.
+  --watch-options-stdin                               Stop watching when stdin stream has ended.
+  --allowed-hosts <value...>                          Allows to enumerate the hosts from which access to the dev server are allowed (useful when you are proxying dev server, by default is 'auto').
+  --allowed-hosts-reset                               Clear all items provided in 'allowedHosts' configuration. Allows to enumerate the hosts from which access to the dev server are allowed (useful when you are proxying dev server, by default is 'auto').
+  --bonjour                                           Allows to broadcasts dev server via ZeroConf networking on start.
+  --no-bonjour                                        Disallows to broadcasts dev server via ZeroConf networking on start.
+  --no-client                                         Disables client script.
+  --client-logging <value>                            Allows to set log level in the browser.
+  --client-overlay                                    Enables a full-screen overlay in the browser when there are compiler errors or warnings.
+  --no-client-overlay                                 Disables the full-screen overlay in the browser when there are compiler errors or warnings.
+  --client-overlay-errors                             Enables a full-screen overlay in the browser when there are compiler errors.
+  --no-client-overlay-errors                          Disables the full-screen overlay in the browser when there are compiler errors.
+  --client-overlay-warnings                           Enables a full-screen overlay in the browser when there are compiler warnings.
+  --no-client-overlay-warnings                        Disables the full-screen overlay in the browser when there are compiler warnings.
+  --client-overlay-runtime-errors                     Enables a full-screen overlay in the browser when there are uncaught runtime errors.
+  --no-client-overlay-runtime-errors                  Disables the full-screen overlay in the browser when there are uncaught runtime errors.
+  --client-overlay-trusted-types-policy-name <value>  The name of a Trusted Types policy for the overlay. Defaults to 'webpack-dev-server#overlay'.
+  --client-progress [value]                           Displays compilation progress in the browser. Options include 'linear' and 'circular' for visual indicators.
+  --no-client-progress                                Does not display compilation progress in the browser.
+  --client-reconnect [value]                          Tells dev-server the number of times it should try to reconnect the client.
+  --no-client-reconnect                               Tells dev-server to not to try to reconnect the client.
+  --client-web-socket-transport <value>               Allows to set custom web socket transport to communicate with dev server.
+  --client-web-socket-url <value>                     Allows to specify URL to web socket server (useful when you're proxying dev server and client script does not always know where to connect to).
+  --client-web-socket-url-hostname <value>            Tells clients connected to devServer to use the provided hostname.
+  --client-web-socket-url-pathname <value>            Tells clients connected to devServer to use the provided path to connect.
+  --client-web-socket-url-password <value>            Tells clients connected to devServer to use the provided password to authenticate.
+  --client-web-socket-url-port <value>                Tells clients connected to devServer to use the provided port.
+  --client-web-socket-url-protocol <value>            Tells clients connected to devServer to use the provided protocol.
+  --client-web-socket-url-username <value>            Tells clients connected to devServer to use the provided username to authenticate.
+  --compress                                          Enables gzip compression for everything served.
+  --no-compress                                       Disables gzip compression for everything served.
+  --history-api-fallback                              Allows to proxy requests through a specified index page (by default 'index.html'), useful for Single Page Applications that utilise the HTML5 History API.
+  --no-history-api-fallback                           Disallows to proxy requests through a specified index page.
+  --host <value>                                      Allows to specify a hostname to use.
+  --hot [value]                                       Enables Hot Module Replacement.
+  --no-hot                                            Disables Hot Module Replacement.
+  --ipc [value]                                       Listen to a unix socket.
+  --live-reload                                       Enables reload/refresh the page(s) when file changes are detected (enabled by default).
+  --no-live-reload                                    Disables reload/refresh the page(s) when file changes are detected (enabled by default).
+  --open [value...]                                   Allows to configure dev server to open the browser(s) and page(s) after server had been started (set it to true to open your default browser).
+  --no-open                                           Does not open the default browser.
+  --open-target <value...>                            Opens specified page in browser.
+  --open-app-name <value...>                          Open specified browser.
+  --open-reset                                        Clear all items provided in 'open' configuration. Allows to configure dev server to open the browser(s) and page(s) after server had been started (set it to true to open your default browser).
+  --open-target-reset                                 Clear all items provided in 'open.target' configuration. Opens specified page in browser.
+  --open-app-name-reset                               Clear all items provided in 'open.app.name' configuration. Open specified browser.
+  --port <value>                                      Allows to specify a port to use.
+  --server-type <value>                               Allows to set server and options (by default 'http').
+  --server-options-passphrase <value>                 Passphrase for a pfx file.
+  --server-options-request-cert                       Request for an SSL certificate.
+  --no-server-options-request-cert                    Does not request for an SSL certificate.
+  --server-options-ca <value...>                      Path to an SSL CA certificate or content of an SSL CA certificate.
+  --server-options-ca-reset                           Clear all items provided in 'server.options.ca' configuration. Path to an SSL CA certificate or content of an SSL CA certificate.
+  --server-options-cert <value...>                    Path to an SSL certificate or content of an SSL certificate.
+  --server-options-cert-reset                         Clear all items provided in 'server.options.cert' configuration. Path to an SSL certificate or content of an SSL certificate.
+  --server-options-crl <value...>                     Path to PEM formatted CRLs (Certificate Revocation Lists) or content of PEM formatted CRLs (Certificate Revocation Lists).
+  --server-options-crl-reset                          Clear all items provided in 'server.options.crl' configuration. Path to PEM formatted CRLs (Certificate Revocation Lists) or content of PEM formatted CRLs (Certificate Revocation Lists).
+  --server-options-key <value...>                     Path to an SSL key or content of an SSL key.
+  --server-options-key-reset                          Clear all items provided in 'server.options.key' configuration. Path to an SSL key or content of an SSL key.
+  --server-options-pfx <value...>                     Path to an SSL pfx file or content of an SSL pfx file.
+  --server-options-pfx-reset                          Clear all items provided in 'server.options.pfx' configuration. Path to an SSL pfx file or content of an SSL pfx file.
+  --static [value...]                                 Allows to configure options for serving static files from directory (by default 'public' directory).
+  --no-static                                         Disallows to configure options for serving static files from directory.
+  --static-directory <value...>                       Directory for static contents.
+  --static-public-path <value...>                     The static files will be available in the browser under this public path.
+  --static-serve-index                                Tells dev server to use serveIndex middleware when enabled.
+  --no-static-serve-index                             Does not tell dev server to use serveIndex middleware.
+  --static-watch                                      Watches for files in static content directory.
+  --no-static-watch                                   Does not watch for files in static content directory.
+  --static-reset                                      Clear all items provided in 'static' configuration. Allows to configure options for serving static files from directory (by default 'public' directory).
+  --static-public-path-reset                          Clear all items provided in 'static.publicPath' configuration. The static files will be available in the browser under this public path.
+  --watch-files <value...>                            Allows to configure list of globs/directories/files to watch for file changes.
+  --watch-files-reset                                 Clear all items provided in 'watchFiles' configuration. Allows to configure list of globs/directories/files to watch for file changes.
+  --no-web-socket-server                              Disallows to set web socket server and options.
+  --web-socket-server-type <value>                    Allows to set web socket server and options (by default 'ws').
+
+Global options
+────────────────────────────────────────────────────────────────────────
+  --color                                             Enable colors on console.
+  --no-color                                          Disable colors on console.
+  -v, --version                                       Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
+  -h, --help [verbose]                                Display help for commands and options.
+
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information for 'server' command using command syntax: stderr 1`] = `""`;
+
+exports[`help should show help information for 'server' command using command syntax: stdout 1`] = `
+"
+⬡ webpack serve
+────────────────────────────────────────────────────────────────────────
+Run the webpack dev server and watch for source file changes while serving.
+
+Usage: webpack serve|server|s [entries...] [options]
+
+Options
+────────────────────────────────────────────────────────────────────────
+  -c, --config <pathToConfigFile...>                  Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
+  --config-name <name...>                             Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
+  -m, --merge                                         Merge two or more configurations using 'webpack-merge'.
+  --env <value...>                                    Environment variables passed to the configuration when it is a function, e.g. "myvar" or "myvar=myval".
+  --config-node-env <value>                           Sets process.env.NODE_ENV to the specified value for access within the configuration.
+  --analyze                                           It invokes webpack-bundle-analyzer plugin to get bundle information.
+  --progress [value]                                  Print compilation progress during build.
+  -j, --json [pathToJsonFile]                         Prints result as JSON or store it in a file.
+  --fail-on-warnings                                  Stop webpack-cli process with non-zero exit code on warnings from webpack.
+  --disable-interpret                                 Disable interpret for loading the config file.
+  -d, --devtool <value>                               A developer tool to enhance debugging (false | eval | [inline-|hidden-|eval-][nosources-][cheap-[module-]]source-map).
+  --no-devtool                                        Negative 'devtool' option.
+  --entry <value...>                                  A module that is loaded upon startup. Only the last one is exported.
+  -e, --extends <value...>                            Path to the configuration to be extended (only works when using webpack-cli).
+  --mode <value>                                      Enable production optimizations or development hints.
+  --name <value>                                      Name of the configuration. Used when loading multiple configurations.
+  -o, --output-path <value>                           The output directory as **absolute path** (required).
+  --stats [value]                                     Stats options object or preset name.
+  -t, --target <value...>                             Specific environment, runtime, or syntax. Environment to build for. An array of environments to build for all of them when possible.
+  -w, --watch                                         Enter watch mode, which rebuilds on file change.
+  --watch-options-stdin                               Stop watching when stdin stream has ended.
+  --allowed-hosts <value...>                          Allows to enumerate the hosts from which access to the dev server are allowed (useful when you are proxying dev server, by default is 'auto').
+  --allowed-hosts-reset                               Clear all items provided in 'allowedHosts' configuration. Allows to enumerate the hosts from which access to the dev server are allowed (useful when you are proxying dev server, by default is 'auto').
+  --bonjour                                           Allows to broadcasts dev server via ZeroConf networking on start.
+  --no-bonjour                                        Disallows to broadcasts dev server via ZeroConf networking on start.
+  --no-client                                         Disables client script.
+  --client-logging <value>                            Allows to set log level in the browser.
+  --client-overlay                                    Enables a full-screen overlay in the browser when there are compiler errors or warnings.
+  --no-client-overlay                                 Disables the full-screen overlay in the browser when there are compiler errors or warnings.
+  --client-overlay-errors                             Enables a full-screen overlay in the browser when there are compiler errors.
+  --no-client-overlay-errors                          Disables the full-screen overlay in the browser when there are compiler errors.
+  --client-overlay-warnings                           Enables a full-screen overlay in the browser when there are compiler warnings.
+  --no-client-overlay-warnings                        Disables the full-screen overlay in the browser when there are compiler warnings.
+  --client-overlay-runtime-errors                     Enables a full-screen overlay in the browser when there are uncaught runtime errors.
+  --no-client-overlay-runtime-errors                  Disables the full-screen overlay in the browser when there are uncaught runtime errors.
+  --client-overlay-trusted-types-policy-name <value>  The name of a Trusted Types policy for the overlay. Defaults to 'webpack-dev-server#overlay'.
+  --client-progress [value]                           Displays compilation progress in the browser. Options include 'linear' and 'circular' for visual indicators.
+  --no-client-progress                                Does not display compilation progress in the browser.
+  --client-reconnect [value]                          Tells dev-server the number of times it should try to reconnect the client.
+  --no-client-reconnect                               Tells dev-server to not to try to reconnect the client.
+  --client-web-socket-transport <value>               Allows to set custom web socket transport to communicate with dev server.
+  --client-web-socket-url <value>                     Allows to specify URL to web socket server (useful when you're proxying dev server and client script does not always know where to connect to).
+  --client-web-socket-url-hostname <value>            Tells clients connected to devServer to use the provided hostname.
+  --client-web-socket-url-pathname <value>            Tells clients connected to devServer to use the provided path to connect.
+  --client-web-socket-url-password <value>            Tells clients connected to devServer to use the provided password to authenticate.
+  --client-web-socket-url-port <value>                Tells clients connected to devServer to use the provided port.
+  --client-web-socket-url-protocol <value>            Tells clients connected to devServer to use the provided protocol.
+  --client-web-socket-url-username <value>            Tells clients connected to devServer to use the provided username to authenticate.
+  --compress                                          Enables gzip compression for everything served.
+  --no-compress                                       Disables gzip compression for everything served.
+  --history-api-fallback                              Allows to proxy requests through a specified index page (by default 'index.html'), useful for Single Page Applications that utilise the HTML5 History API.
+  --no-history-api-fallback                           Disallows to proxy requests through a specified index page.
+  --host <value>                                      Allows to specify a hostname to use.
+  --hot [value]                                       Enables Hot Module Replacement.
+  --no-hot                                            Disables Hot Module Replacement.
+  --ipc [value]                                       Listen to a unix socket.
+  --live-reload                                       Enables reload/refresh the page(s) when file changes are detected (enabled by default).
+  --no-live-reload                                    Disables reload/refresh the page(s) when file changes are detected (enabled by default).
+  --open [value...]                                   Allows to configure dev server to open the browser(s) and page(s) after server had been started (set it to true to open your default browser).
+  --no-open                                           Does not open the default browser.
+  --open-target <value...>                            Opens specified page in browser.
+  --open-app-name <value...>                          Open specified browser.
+  --open-reset                                        Clear all items provided in 'open' configuration. Allows to configure dev server to open the browser(s) and page(s) after server had been started (set it to true to open your default browser).
+  --open-target-reset                                 Clear all items provided in 'open.target' configuration. Opens specified page in browser.
+  --open-app-name-reset                               Clear all items provided in 'open.app.name' configuration. Open specified browser.
+  --port <value>                                      Allows to specify a port to use.
+  --server-type <value>                               Allows to set server and options (by default 'http').
+  --server-options-passphrase <value>                 Passphrase for a pfx file.
+  --server-options-request-cert                       Request for an SSL certificate.
+  --no-server-options-request-cert                    Does not request for an SSL certificate.
+  --server-options-ca <value...>                      Path to an SSL CA certificate or content of an SSL CA certificate.
+  --server-options-ca-reset                           Clear all items provided in 'server.options.ca' configuration. Path to an SSL CA certificate or content of an SSL CA certificate.
+  --server-options-cert <value...>                    Path to an SSL certificate or content of an SSL certificate.
+  --server-options-cert-reset                         Clear all items provided in 'server.options.cert' configuration. Path to an SSL certificate or content of an SSL certificate.
+  --server-options-crl <value...>                     Path to PEM formatted CRLs (Certificate Revocation Lists) or content of PEM formatted CRLs (Certificate Revocation Lists).
+  --server-options-crl-reset                          Clear all items provided in 'server.options.crl' configuration. Path to PEM formatted CRLs (Certificate Revocation Lists) or content of PEM formatted CRLs (Certificate Revocation Lists).
+  --server-options-key <value...>                     Path to an SSL key or content of an SSL key.
+  --server-options-key-reset                          Clear all items provided in 'server.options.key' configuration. Path to an SSL key or content of an SSL key.
+  --server-options-pfx <value...>                     Path to an SSL pfx file or content of an SSL pfx file.
+  --server-options-pfx-reset                          Clear all items provided in 'server.options.pfx' configuration. Path to an SSL pfx file or content of an SSL pfx file.
+  --static [value...]                                 Allows to configure options for serving static files from directory (by default 'public' directory).
+  --no-static                                         Disallows to configure options for serving static files from directory.
+  --static-directory <value...>                       Directory for static contents.
+  --static-public-path <value...>                     The static files will be available in the browser under this public path.
+  --static-serve-index                                Tells dev server to use serveIndex middleware when enabled.
+  --no-static-serve-index                             Does not tell dev server to use serveIndex middleware.
+  --static-watch                                      Watches for files in static content directory.
+  --no-static-watch                                   Does not watch for files in static content directory.
+  --static-reset                                      Clear all items provided in 'static' configuration. Allows to configure options for serving static files from directory (by default 'public' directory).
+  --static-public-path-reset                          Clear all items provided in 'static.publicPath' configuration. The static files will be available in the browser under this public path.
+  --watch-files <value...>                            Allows to configure list of globs/directories/files to watch for file changes.
+  --watch-files-reset                                 Clear all items provided in 'watchFiles' configuration. Allows to configure list of globs/directories/files to watch for file changes.
+  --no-web-socket-server                              Disallows to set web socket server and options.
+  --web-socket-server-type <value>                    Allows to set web socket server and options (by default 'ws').
+
+Global options
+────────────────────────────────────────────────────────────────────────
+  --color                                             Enable colors on console.
+  --no-color                                          Disable colors on console.
+  -v, --version                                       Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
+  -h, --help [verbose]                                Display help for commands and options.
+
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information for 'server' command using the "--help verbose" option: stderr 1`] = `""`;
+
+exports[`help should show help information for 'server' command using the "--help verbose" option: stdout 1`] = `
+"
+⬡ webpack serve
+────────────────────────────────────────────────────────────────────────
+Run the webpack dev server and watch for source file changes while serving.
+
+Usage: webpack serve|server|s [entries...] [options]
+
+Options
+────────────────────────────────────────────────────────────────────────
+  -c, --config <pathToConfigFile...>                                                 Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
+  --config-name <name...>                                                            Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
+  -m, --merge                                                                        Merge two or more configurations using 'webpack-merge'.
+  --env <value...>                                                                   Environment variables passed to the configuration when it is a function, e.g. "myvar" or "myvar=myval".
+  --config-node-env <value>                                                          Sets process.env.NODE_ENV to the specified value for access within the configuration.
+  --analyze                                                                          It invokes webpack-bundle-analyzer plugin to get bundle information.
+  --progress [value]                                                                 Print compilation progress during build.
+  -j, --json [pathToJsonFile]                                                        Prints result as JSON or store it in a file.
+  --fail-on-warnings                                                                 Stop webpack-cli process with non-zero exit code on warnings from webpack.
+  --disable-interpret                                                                Disable interpret for loading the config file.
+  --no-amd                                                                           Negative 'amd' option.
+  --bail                                                                             Report the first error as a hard error instead of tolerating it.
+  --no-bail                                                                          Negative 'bail' option.
+  --cache                                                                            Enable in memory caching. Disable caching.
+  --no-cache                                                                         Negative 'cache' option.
+  --cache-cache-unaffected                                                           Additionally cache computation of modules that are unchanged and reference only unchanged modules.
+  --no-cache-cache-unaffected                                                        Negative 'cache-cache-unaffected' option.
+  --cache-max-generations <value>                                                    Number of generations unused cache entries stay in memory cache
+    at stack.
+
+Global options
+────────────────────────────────────────────────────────────────────────
+  --color                                                                            Enable colors on console.
+  --no-color                                                                         Disable colors on console.
+  -v, --version                                                                      Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
+  -h, --help [verbose]                                                               Display help for commands and options.
+
+────────────────────────────────────────────────────────────────────────
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information for 'server' command using the "--help" option: stderr 1`] = `""`;
+
+exports[`help should show help information for 'server' command using the "--help" option: stdout 1`] = `
+"
+⬡ webpack serve
+────────────────────────────────────────────────────────────────────────
+Run the webpack dev server and watch for source file changes while serving.
+
+Usage: webpack serve|server|s [entries...] [options]
+
+Options
+────────────────────────────────────────────────────────────────────────
+  -c, --config <pathToConfigFile...>                  Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
+  --config-name <name...>                             Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
+  -m, --merge                                         Merge two or more configurations using 'webpack-merge'.
+  --env <value...>                                    Environment variables passed to the configuration when it is a function, e.g. "myvar" or "myvar=myval".
+  --config-node-env <value>                           Sets process.env.NODE_ENV to the specified value for access within the configuration.
+  --analyze                                           It invokes webpack-bundle-analyzer plugin to get bundle information.
+  --progress [value]                                  Print compilation progress during build.
+  -j, --json [pathToJsonFile]                         Prints result as JSON or store it in a file.
+  --fail-on-warnings                                  Stop webpack-cli process with non-zero exit code on warnings from webpack.
+  --disable-interpret                                 Disable interpret for loading the config file.
+  -d, --devtool <value>                               A developer tool to enhance debugging (false | eval | [inline-|hidden-|eval-][nosources-][cheap-[module-]]source-map).
+  --no-devtool                                        Negative 'devtool' option.
+  --entry <value...>                                  A module that is loaded upon startup. Only the last one is exported.
+  -e, --extends <value...>                            Path to the configuration to be extended (only works when using webpack-cli).
+  --mode <value>                                      Enable production optimizations or development hints.
+  --name <value>                                      Name of the configuration. Used when loading multiple configurations.
+  -o, --output-path <value>                           The output directory as **absolute path** (required).
+  --stats [value]                                     Stats options object or preset name.
+  -t, --target <value...>                             Specific environment, runtime, or syntax. Environment to build for. An array of environments to build for all of them when possible.
+  -w, --watch                                         Enter watch mode, which rebuilds on file change.
+  --watch-options-stdin                               Stop watching when stdin stream has ended.
+  --allowed-hosts <value...>                          Allows to enumerate the hosts from which access to the dev server are allowed (useful when you are proxying dev server, by default is 'auto').
+  --allowed-hosts-reset                               Clear all items provided in 'allowedHosts' configuration. Allows to enumerate the hosts from which access to the dev server are allowed (useful when you are proxying dev server, by default is 'auto').
+  --bonjour                                           Allows to broadcasts dev server via ZeroConf networking on start.
+  --no-bonjour                                        Disallows to broadcasts dev server via ZeroConf networking on start.
+  --no-client                                         Disables client script.
+  --client-logging <value>                            Allows to set log level in the browser.
+  --client-overlay                                    Enables a full-screen overlay in the browser when there are compiler errors or warnings.
+  --no-client-overlay                                 Disables the full-screen overlay in the browser when there are compiler errors or warnings.
+  --client-overlay-errors                             Enables a full-screen overlay in the browser when there are compiler errors.
+  --no-client-overlay-errors                          Disables the full-screen overlay in the browser when there are compiler errors.
+  --client-overlay-warnings                           Enables a full-screen overlay in the browser when there are compiler warnings.
+  --no-client-overlay-warnings                        Disables the full-screen overlay in the browser when there are compiler warnings.
+  --client-overlay-runtime-errors                     Enables a full-screen overlay in the browser when there are uncaught runtime errors.
+  --no-client-overlay-runtime-errors                  Disables the full-screen overlay in the browser when there are uncaught runtime errors.
+  --client-overlay-trusted-types-policy-name <value>  The name of a Trusted Types policy for the overlay. Defaults to 'webpack-dev-server#overlay'.
+  --client-progress [value]                           Displays compilation progress in the browser. Options include 'linear' and 'circular' for visual indicators.
+  --no-client-progress                                Does not display compilation progress in the browser.
+  --client-reconnect [value]                          Tells dev-server the number of times it should try to reconnect the client.
+  --no-client-reconnect                               Tells dev-server to not to try to reconnect the client.
+  --client-web-socket-transport <value>               Allows to set custom web socket transport to communicate with dev server.
+  --client-web-socket-url <value>                     Allows to specify URL to web socket server (useful when you're proxying dev server and client script does not always know where to connect to).
+  --client-web-socket-url-hostname <value>            Tells clients connected to devServer to use the provided hostname.
+  --client-web-socket-url-pathname <value>            Tells clients connected to devServer to use the provided path to connect.
+  --client-web-socket-url-password <value>            Tells clients connected to devServer to use the provided password to authenticate.
+  --client-web-socket-url-port <value>                Tells clients connected to devServer to use the provided port.
+  --client-web-socket-url-protocol <value>            Tells clients connected to devServer to use the provided protocol.
+  --client-web-socket-url-username <value>            Tells clients connected to devServer to use the provided username to authenticate.
+  --compress                                          Enables gzip compression for everything served.
+  --no-compress                                       Disables gzip compression for everything served.
+  --history-api-fallback                              Allows to proxy requests through a specified index page (by default 'index.html'), useful for Single Page Applications that utilise the HTML5 History API.
+  --no-history-api-fallback                           Disallows to proxy requests through a specified index page.
+  --host <value>                                      Allows to specify a hostname to use.
+  --hot [value]                                       Enables Hot Module Replacement.
+  --no-hot                                            Disables Hot Module Replacement.
+  --ipc [value]                                       Listen to a unix socket.
+  --live-reload                                       Enables reload/refresh the page(s) when file changes are detected (enabled by default).
+  --no-live-reload                                    Disables reload/refresh the page(s) when file changes are detected (enabled by default).
+  --open [value...]                                   Allows to configure dev server to open the browser(s) and page(s) after server had been started (set it to true to open your default browser).
+  --no-open                                           Does not open the default browser.
+  --open-target <value...>                            Opens specified page in browser.
+  --open-app-name <value...>                          Open specified browser.
+  --open-reset                                        Clear all items provided in 'open' configuration. Allows to configure dev server to open the browser(s) and page(s) after server had been started (set it to true to open your default browser).
+  --open-target-reset                                 Clear all items provided in 'open.target' configuration. Opens specified page in browser.
+  --open-app-name-reset                               Clear all items provided in 'open.app.name' configuration. Open specified browser.
+  --port <value>                                      Allows to specify a port to use.
+  --server-type <value>                               Allows to set server and options (by default 'http').
+  --server-options-passphrase <value>                 Passphrase for a pfx file.
+  --server-options-request-cert                       Request for an SSL certificate.
+  --no-server-options-request-cert                    Does not request for an SSL certificate.
+  --server-options-ca <value...>                      Path to an SSL CA certificate or content of an SSL CA certificate.
+  --server-options-ca-reset                           Clear all items provided in 'server.options.ca' configuration. Path to an SSL CA certificate or content of an SSL CA certificate.
+  --server-options-cert <value...>                    Path to an SSL certificate or content of an SSL certificate.
+  --server-options-cert-reset                         Clear all items provided in 'server.options.cert' configuration. Path to an SSL certificate or content of an SSL certificate.
+  --server-options-crl <value...>                     Path to PEM formatted CRLs (Certificate Revocation Lists) or content of PEM formatted CRLs (Certificate Revocation Lists).
+  --server-options-crl-reset                          Clear all items provided in 'server.options.crl' configuration. Path to PEM formatted CRLs (Certificate Revocation Lists) or content of PEM formatted CRLs (Certificate Revocation Lists).
+  --server-options-key <value...>                     Path to an SSL key or content of an SSL key.
+  --server-options-key-reset                          Clear all items provided in 'server.options.key' configuration. Path to an SSL key or content of an SSL key.
+  --server-options-pfx <value...>                     Path to an SSL pfx file or content of an SSL pfx file.
+  --server-options-pfx-reset                          Clear all items provided in 'server.options.pfx' configuration. Path to an SSL pfx file or content of an SSL pfx file.
+  --static [value...]                                 Allows to configure options for serving static files from directory (by default 'public' directory).
+  --no-static                                         Disallows to configure options for serving static files from directory.
+  --static-directory <value...>                       Directory for static contents.
+  --static-public-path <value...>                     The static files will be available in the browser under this public path.
+  --static-serve-index                                Tells dev server to use serveIndex middleware when enabled.
+  --no-static-serve-index                             Does not tell dev server to use serveIndex middleware.
+  --static-watch                                      Watches for files in static content directory.
+  --no-static-watch                                   Does not watch for files in static content directory.
+  --static-reset                                      Clear all items provided in 'static' configuration. Allows to configure options for serving static files from directory (by default 'public' directory).
+  --static-public-path-reset                          Clear all items provided in 'static.publicPath' configuration. The static files will be available in the browser under this public path.
+  --watch-files <value...>                            Allows to configure list of globs/directories/files to watch for file changes.
+  --watch-files-reset                                 Clear all items provided in 'watchFiles' configuration. Allows to configure list of globs/directories/files to watch for file changes.
+  --no-web-socket-server                              Disallows to set web socket server and options.
+  --web-socket-server-type <value>                    Allows to set web socket server and options (by default 'ws').
+
+Global options
+────────────────────────────────────────────────────────────────────────
+  --color                                             Enable colors on console.
+  --no-color                                          Disable colors on console.
+  -v, --version                                       Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
+  -h, --help [verbose]                                Display help for commands and options.
+
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information for 't' command using command syntax: stderr 1`] = `""`;
+
+exports[`help should show help information for 't' command using command syntax: stdout 1`] = `
+"
+⬡ webpack configtest
+────────────────────────────────────────────────────────────────────────
+Validate a webpack configuration.
+
+Usage: webpack configtest|t [config-path]
+
+Global options
+────────────────────────────────────────────────────────────────────────
+  --color               Enable colors on console.
+  --no-color            Disable colors on console.
+  -v, --version         Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
+  -h, --help [verbose]  Display help for commands and options.
+
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information for 't' command using the "--help verbose" option: stderr 1`] = `""`;
+
+exports[`help should show help information for 't' command using the "--help verbose" option: stdout 1`] = `
+"
+⬡ webpack configtest
+────────────────────────────────────────────────────────────────────────
+Validate a webpack configuration.
+
+Usage: webpack configtest|t [config-path]
+
+Global options
+────────────────────────────────────────────────────────────────────────
+  --color               Enable colors on console.
+  --no-color            Disable colors on console.
+  -v, --version         Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
+  -h, --help [verbose]  Display help for commands and options.
+
+────────────────────────────────────────────────────────────────────────
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information for 't' command using the "--help" option: stderr 1`] = `""`;
+
+exports[`help should show help information for 't' command using the "--help" option: stdout 1`] = `
+"
+⬡ webpack configtest
+────────────────────────────────────────────────────────────────────────
+Validate a webpack configuration.
+
+Usage: webpack configtest|t [config-path]
+
+Global options
+────────────────────────────────────────────────────────────────────────
+  --color               Enable colors on console.
+  --no-color            Disable colors on console.
+  -v, --version         Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
+  -h, --help [verbose]  Display help for commands and options.
+
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information for 'w' command using command syntax: stderr 1`] = `""`;
+
+exports[`help should show help information for 'w' command using command syntax: stdout 1`] = `
+"
+⬡ webpack watch
+────────────────────────────────────────────────────────────────────────
+Run webpack and watch for files changes.
+
+Usage: webpack watch|w [entries...] [options]
+
+Options
+────────────────────────────────────────────────────────────────────────
+  -c, --config <pathToConfigFile...>  Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
+  --config-name <name...>             Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
+  -m, --merge                         Merge two or more configurations using 'webpack-merge'.
+  --env <value...>                    Environment variables passed to the configuration when it is a function, e.g. "myvar" or "myvar=myval".
+  --config-node-env <value>           Sets process.env.NODE_ENV to the specified value for access within the configuration.
+  --analyze                           It invokes webpack-bundle-analyzer plugin to get bundle information.
+  --progress [value]                  Print compilation progress during build.
+  -j, --json [pathToJsonFile]         Prints result as JSON or store it in a file.
+  --fail-on-warnings                  Stop webpack-cli process with non-zero exit code on warnings from webpack.
+  --disable-interpret                 Disable interpret for loading the config file.
+  -d, --devtool <value>               A developer tool to enhance debugging (false | eval | [inline-|hidden-|eval-][nosources-][cheap-[module-]]source-map).
+  --no-devtool                        Negative 'devtool' option.
+  --entry <value...>                  A module that is loaded upon startup. Only the last one is exported.
+  -e, --extends <value...>            Path to the configuration to be extended (only works when using webpack-cli).
+  --mode <value>                      Enable production optimizations or development hints.
+  --name <value>                      Name of the configuration. Used when loading multiple configurations.
+  -o, --output-path <value>           The output directory as **absolute path** (required).
+  --stats [value]                     Stats options object or preset name.
+  -t, --target <value...>             Specific environment, runtime, or syntax. Environment to build for. An array of environments to build for all of them when possible.
+  --watch-options-stdin               Stop watching when stdin stream has ended.
+
+Global options
+────────────────────────────────────────────────────────────────────────
+  --color                             Enable colors on console.
+  --no-color                          Disable colors on console.
+  -v, --version                       Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
+  -h, --help [verbose]                Display help for commands and options.
+
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information for 'w' command using the "--help verbose" option: stderr 1`] = `""`;
+
+exports[`help should show help information for 'w' command using the "--help verbose" option: stdout 1`] = `
+"
+⬡ webpack watch
+────────────────────────────────────────────────────────────────────────
+Run webpack and watch for files changes.
+
+Usage: webpack watch|w [entries...] [options]
+
+Options
+────────────────────────────────────────────────────────────────────────
+  -c, --config <pathToConfigFile...>                                                 Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
+  --config-name <name...>                                                            Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
+  -m, --merge                                                                        Merge two or more configurations using 'webpack-merge'.
+  --env <value...>                                                                   Environment variables passed to the configuration when it is a function, e.g. "myvar" or "myvar=myval".
+  --config-node-env <value>                                                          Sets process.env.NODE_ENV to the specified value for access within the configuration.
+  --analyze                                                                          It invokes webpack-bundle-analyzer plugin to get bundle information.
+  --progress [value]                                                                 Print compilation progress during build.
+  -j, --json [pathToJsonFile]                                                        Prints result as JSON or store it in a file.
+  --fail-on-warnings                                                                 Stop webpack-cli process with non-zero exit code on warnings from webpack.
+  --disable-interpret                                                                Disable interpret for loading the config file.
+  --no-amd                                                                           Negative 'amd' option.
+  --bail                                                                             Report the first error as a hard error instead of tolerating it.
+  --no-bail                                                                          Negative 'bail' option.
+  --cache                                                                            Enable in memory caching. Disable caching.
+  --no-cache                                                                         Negative 'cache' option.
+  --cache-cache-unaffected                                                           Additionally cache computation of modules that are unchanged and reference only unchanged modules.
+  --no-cache-cache-unaffected                                                        Negative 'cache-cache-unaffected' option.
+  --cache-max-generations <value>                                                    Number of generations unused cache entries stay in memory cache
+    at stack.
+  --watch-options-poll [value]                                                       \`number\`: use polling with specified interval. \`true\`: use polling.
+  --no-watch-options-poll                                                            Negative 'watch-options-poll' option.
+  --watch-options-stdin                                                              Stop watching when stdin stream has ended.
+  --no-watch-options-stdin                                                           Negative 'watch-options-stdin' option.
+
+Global options
+────────────────────────────────────────────────────────────────────────
+  --color                                                                            Enable colors on console.
+  --no-color                                                                         Disable colors on console.
+  -v, --version                                                                      Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
+  -h, --help [verbose]                                                               Display help for commands and options.
+
+────────────────────────────────────────────────────────────────────────
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information for 'w' command using the "--help" option: stderr 1`] = `""`;
+
+exports[`help should show help information for 'w' command using the "--help" option: stdout 1`] = `
+"
+⬡ webpack watch
+────────────────────────────────────────────────────────────────────────
+Run webpack and watch for files changes.
+
+Usage: webpack watch|w [entries...] [options]
+
+Options
+────────────────────────────────────────────────────────────────────────
+  -c, --config <pathToConfigFile...>  Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
+  --config-name <name...>             Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
+  -m, --merge                         Merge two or more configurations using 'webpack-merge'.
+  --env <value...>                    Environment variables passed to the configuration when it is a function, e.g. "myvar" or "myvar=myval".
+  --config-node-env <value>           Sets process.env.NODE_ENV to the specified value for access within the configuration.
+  --analyze                           It invokes webpack-bundle-analyzer plugin to get bundle information.
+  --progress [value]                  Print compilation progress during build.
+  -j, --json [pathToJsonFile]         Prints result as JSON or store it in a file.
+  --fail-on-warnings                  Stop webpack-cli process with non-zero exit code on warnings from webpack.
+  --disable-interpret                 Disable interpret for loading the config file.
+  -d, --devtool <value>               A developer tool to enhance debugging (false | eval | [inline-|hidden-|eval-][nosources-][cheap-[module-]]source-map).
+  --no-devtool                        Negative 'devtool' option.
+  --entry <value...>                  A module that is loaded upon startup. Only the last one is exported.
+  -e, --extends <value...>            Path to the configuration to be extended (only works when using webpack-cli).
+  --mode <value>                      Enable production optimizations or development hints.
+  --name <value>                      Name of the configuration. Used when loading multiple configurations.
+  -o, --output-path <value>           The output directory as **absolute path** (required).
+  --stats [value]                     Stats options object or preset name.
+  -t, --target <value...>             Specific environment, runtime, or syntax. Environment to build for. An array of environments to build for all of them when possible.
+  --watch-options-stdin               Stop watching when stdin stream has ended.
+
+Global options
+────────────────────────────────────────────────────────────────────────
+  --color                             Enable colors on console.
+  --no-color                          Disable colors on console.
+  -v, --version                       Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
+  -h, --help [verbose]                Display help for commands and options.
+
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information for 'watch' and respect the "--color" flag using the "--help" option: stderr 1`] = `""`;
+
+exports[`help should show help information for 'watch' and respect the "--color" flag using the "--help" option: stdout 1`] = `
+"
+⬡ webpack watch
+────────────────────────────────────────────────────────────────────────
+Run webpack and watch for files changes.
+
+Usage: webpack watch|w [entries...] [options]
+
+Options
+────────────────────────────────────────────────────────────────────────
+  -c, --config <pathToConfigFile...>  Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
+  --config-name <name...>             Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
+  -m, --merge                         Merge two or more configurations using 'webpack-merge'.
+  --env <value...>                    Environment variables passed to the configuration when it is a function, e.g. "myvar" or "myvar=myval".
+  --config-node-env <value>           Sets process.env.NODE_ENV to the specified value for access within the configuration.
+  --analyze                           It invokes webpack-bundle-analyzer plugin to get bundle information.
+  --progress [value]                  Print compilation progress during build.
+  -j, --json [pathToJsonFile]         Prints result as JSON or store it in a file.
+  --fail-on-warnings                  Stop webpack-cli process with non-zero exit code on warnings from webpack.
+  --disable-interpret                 Disable interpret for loading the config file.
+  -d, --devtool <value>               A developer tool to enhance debugging (false | eval | [inline-|hidden-|eval-][nosources-][cheap-[module-]]source-map).
+  --no-devtool                        Negative 'devtool' option.
+  --entry <value...>                  A module that is loaded upon startup. Only the last one is exported.
+  -e, --extends <value...>            Path to the configuration to be extended (only works when using webpack-cli).
+  --mode <value>                      Enable production optimizations or development hints.
+  --name <value>                      Name of the configuration. Used when loading multiple configurations.
+  -o, --output-path <value>           The output directory as **absolute path** (required).
+  --stats [value]                     Stats options object or preset name.
+  -t, --target <value...>             Specific environment, runtime, or syntax. Environment to build for. An array of environments to build for all of them when possible.
+  --watch-options-stdin               Stop watching when stdin stream has ended.
+
+Global options
+────────────────────────────────────────────────────────────────────────
+  --color                             Enable colors on console.
+  --no-color                          Disable colors on console.
+  -v, --version                       Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
+  -h, --help [verbose]                Display help for commands and options.
+
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information for 'watch' and respect the "--no-color" flag using the "--help" option: stderr 1`] = `""`;
+
+exports[`help should show help information for 'watch' and respect the "--no-color" flag using the "--help" option: stdout 1`] = `
+"
+⬡ webpack watch
+────────────────────────────────────────────────────────────────────────
+Run webpack and watch for files changes.
+
+Usage: webpack watch|w [entries...] [options]
+
+Options
+────────────────────────────────────────────────────────────────────────
+  -c, --config <pathToConfigFile...>  Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
+  --config-name <name...>             Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
+  -m, --merge                         Merge two or more configurations using 'webpack-merge'.
+  --env <value...>                    Environment variables passed to the configuration when it is a function, e.g. "myvar" or "myvar=myval".
+  --config-node-env <value>           Sets process.env.NODE_ENV to the specified value for access within the configuration.
+  --analyze                           It invokes webpack-bundle-analyzer plugin to get bundle information.
+  --progress [value]                  Print compilation progress during build.
+  -j, --json [pathToJsonFile]         Prints result as JSON or store it in a file.
+  --fail-on-warnings                  Stop webpack-cli process with non-zero exit code on warnings from webpack.
+  --disable-interpret                 Disable interpret for loading the config file.
+  -d, --devtool <value>               A developer tool to enhance debugging (false | eval | [inline-|hidden-|eval-][nosources-][cheap-[module-]]source-map).
+  --no-devtool                        Negative 'devtool' option.
+  --entry <value...>                  A module that is loaded upon startup. Only the last one is exported.
+  -e, --extends <value...>            Path to the configuration to be extended (only works when using webpack-cli).
+  --mode <value>                      Enable production optimizations or development hints.
+  --name <value>                      Name of the configuration. Used when loading multiple configurations.
+  -o, --output-path <value>           The output directory as **absolute path** (required).
+  --stats [value]                     Stats options object or preset name.
+  -t, --target <value...>             Specific environment, runtime, or syntax. Environment to build for. An array of environments to build for all of them when possible.
+  --watch-options-stdin               Stop watching when stdin stream has ended.
+
+Global options
+────────────────────────────────────────────────────────────────────────
+  --color                             Enable colors on console.
+  --no-color                          Disable colors on console.
+  -v, --version                       Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
+  -h, --help [verbose]                Display help for commands and options.
+
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information for 'watch' command using command syntax: stderr 1`] = `""`;
+
+exports[`help should show help information for 'watch' command using command syntax: stdout 1`] = `
+"
+⬡ webpack watch
+────────────────────────────────────────────────────────────────────────
+Run webpack and watch for files changes.
+
+Usage: webpack watch|w [entries...] [options]
+
+Options
+────────────────────────────────────────────────────────────────────────
+  -c, --config <pathToConfigFile...>  Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
+  --config-name <name...>             Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
+  -m, --merge                         Merge two or more configurations using 'webpack-merge'.
+  --env <value...>                    Environment variables passed to the configuration when it is a function, e.g. "myvar" or "myvar=myval".
+  --config-node-env <value>           Sets process.env.NODE_ENV to the specified value for access within the configuration.
+  --analyze                           It invokes webpack-bundle-analyzer plugin to get bundle information.
+  --progress [value]                  Print compilation progress during build.
+  -j, --json [pathToJsonFile]         Prints result as JSON or store it in a file.
+  --fail-on-warnings                  Stop webpack-cli process with non-zero exit code on warnings from webpack.
+  --disable-interpret                 Disable interpret for loading the config file.
+  -d, --devtool <value>               A developer tool to enhance debugging (false | eval | [inline-|hidden-|eval-][nosources-][cheap-[module-]]source-map).
+  --no-devtool                        Negative 'devtool' option.
+  --entry <value...>                  A module that is loaded upon startup. Only the last one is exported.
+  -e, --extends <value...>            Path to the configuration to be extended (only works when using webpack-cli).
+  --mode <value>                      Enable production optimizations or development hints.
+  --name <value>                      Name of the configuration. Used when loading multiple configurations.
+  -o, --output-path <value>           The output directory as **absolute path** (required).
+  --stats [value]                     Stats options object or preset name.
+  -t, --target <value...>             Specific environment, runtime, or syntax. Environment to build for. An array of environments to build for all of them when possible.
+  --watch-options-stdin               Stop watching when stdin stream has ended.
+
+Global options
+────────────────────────────────────────────────────────────────────────
+  --color                             Enable colors on console.
+  --no-color                          Disable colors on console.
+  -v, --version                       Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
+  -h, --help [verbose]                Display help for commands and options.
+
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information for 'watch' command using the "--help verbose" option: stderr 1`] = `""`;
+
+exports[`help should show help information for 'watch' command using the "--help verbose" option: stdout 1`] = `
+"
+⬡ webpack watch
+────────────────────────────────────────────────────────────────────────
+Run webpack and watch for files changes.
+
+Usage: webpack watch|w [entries...] [options]
+
+Options
+────────────────────────────────────────────────────────────────────────
+  -c, --config <pathToConfigFile...>                                                 Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
+  --config-name <name...>                                                            Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
+  -m, --merge                                                                        Merge two or more configurations using 'webpack-merge'.
+  --env <value...>                                                                   Environment variables passed to the configuration when it is a function, e.g. "myvar" or "myvar=myval".
+  --config-node-env <value>                                                          Sets process.env.NODE_ENV to the specified value for access within the configuration.
+  --analyze                                                                          It invokes webpack-bundle-analyzer plugin to get bundle information.
+  --progress [value]                                                                 Print compilation progress during build.
+  -j, --json [pathToJsonFile]                                                        Prints result as JSON or store it in a file.
+  --fail-on-warnings                                                                 Stop webpack-cli process with non-zero exit code on warnings from webpack.
+  --disable-interpret                                                                Disable interpret for loading the config file.
+  --no-amd                                                                           Negative 'amd' option.
+  --bail                                                                             Report the first error as a hard error instead of tolerating it.
+  --no-bail                                                                          Negative 'bail' option.
+  --cache                                                                            Enable in memory caching. Disable caching.
+  --no-cache                                                                         Negative 'cache' option.
+  --cache-cache-unaffected                                                           Additionally cache computation of modules that are unchanged and reference only unchanged modules.
+  --no-cache-cache-unaffected                                                        Negative 'cache-cache-unaffected' option.
+  --cache-max-generations <value>                                                    Number of generations unused cache entries stay in memory cache
+    at stack.
+  --watch-options-poll [value]                                                       \`number\`: use polling with specified interval. \`true\`: use polling.
+  --no-watch-options-poll                                                            Negative 'watch-options-poll' option.
+  --watch-options-stdin                                                              Stop watching when stdin stream has ended.
+  --no-watch-options-stdin                                                           Negative 'watch-options-stdin' option.
+
+Global options
+────────────────────────────────────────────────────────────────────────
+  --color                                                                            Enable colors on console.
+  --no-color                                                                         Disable colors on console.
+  -v, --version                                                                      Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
+  -h, --help [verbose]                                                               Display help for commands and options.
+
+────────────────────────────────────────────────────────────────────────
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information for 'watch' command using the "--help" option: stderr 1`] = `""`;
+
+exports[`help should show help information for 'watch' command using the "--help" option: stdout 1`] = `
+"
+⬡ webpack watch
+────────────────────────────────────────────────────────────────────────
+Run webpack and watch for files changes.
+
+Usage: webpack watch|w [entries...] [options]
+
+Options
+────────────────────────────────────────────────────────────────────────
+  -c, --config <pathToConfigFile...>  Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
+  --config-name <name...>             Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
+  -m, --merge                         Merge two or more configurations using 'webpack-merge'.
+  --env <value...>                    Environment variables passed to the configuration when it is a function, e.g. "myvar" or "myvar=myval".
+  --config-node-env <value>           Sets process.env.NODE_ENV to the specified value for access within the configuration.
+  --analyze                           It invokes webpack-bundle-analyzer plugin to get bundle information.
+  --progress [value]                  Print compilation progress during build.
+  -j, --json [pathToJsonFile]         Prints result as JSON or store it in a file.
+  --fail-on-warnings                  Stop webpack-cli process with non-zero exit code on warnings from webpack.
+  --disable-interpret                 Disable interpret for loading the config file.
+  -d, --devtool <value>               A developer tool to enhance debugging (false | eval | [inline-|hidden-|eval-][nosources-][cheap-[module-]]source-map).
+  --no-devtool                        Negative 'devtool' option.
+  --entry <value...>                  A module that is loaded upon startup. Only the last one is exported.
+  -e, --extends <value...>            Path to the configuration to be extended (only works when using webpack-cli).
+  --mode <value>                      Enable production optimizations or development hints.
+  --name <value>                      Name of the configuration. Used when loading multiple configurations.
+  -o, --output-path <value>           The output directory as **absolute path** (required).
+  --stats [value]                     Stats options object or preset name.
+  -t, --target <value...>             Specific environment, runtime, or syntax. Environment to build for. An array of environments to build for all of them when possible.
+  --watch-options-stdin               Stop watching when stdin stream has ended.
+
+Global options
+────────────────────────────────────────────────────────────────────────
+  --color                             Enable colors on console.
+  --no-color                          Disable colors on console.
+  -v, --version                       Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
+  -h, --help [verbose]                Display help for commands and options.
+
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information using command syntax: stderr 1`] = `""`;
+
+exports[`help should show help information using command syntax: stdout 1`] = `
+"
+⬡ webpack
+────────────────────────────────────────────────────────────────────────
+The build tool for modern web applications.
+
+Usage: webpack [entries...] [options] | webpack [command] [options]
+
+Options
+────────────────────────────────────────────────────────────────────────
+  -c, --config <pathToConfigFile...>     Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
+  --config-name <name...>                Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
+  -m, --merge                            Merge two or more configurations using 'webpack-merge'.
+  --env <value...>                       Environment variables passed to the configuration when it is a function, e.g. "myvar" or "myvar=myval".
+  --config-node-env <value>              Sets process.env.NODE_ENV to the specified value for access within the configuration.
+  --analyze                              It invokes webpack-bundle-analyzer plugin to get bundle information.
+  --progress [value]                     Print compilation progress during build.
+  -j, --json [pathToJsonFile]            Prints result as JSON or store it in a file.
+  --fail-on-warnings                     Stop webpack-cli process with non-zero exit code on warnings from webpack.
+  --disable-interpret                    Disable interpret for loading the config file.
+  -d, --devtool <value>                  A developer tool to enhance debugging (false | eval | [inline-|hidden-|eval-][nosources-][cheap-[module-]]source-map).
+  --no-devtool                           Negative 'devtool' option.
+  --entry <value...>                     A module that is loaded upon startup. Only the last one is exported.
+  -e, --extends <value...>               Path to the configuration to be extended (only works when using webpack-cli).
+  --mode <value>                         Enable production optimizations or development hints.
+  --name <value>                         Name of the configuration. Used when loading multiple configurations.
+  -o, --output-path <value>              The output directory as **absolute path** (required).
+  --stats [value]                        Stats options object or preset name.
+  -t, --target <value...>                Specific environment, runtime, or syntax. Environment to build for. An array of environments to build for all of them when possible.
+  -w, --watch                            Enter watch mode, which rebuilds on file change.
+  --watch-options-stdin                  Stop watching when stdin stream has ended.
+
+Global options
+────────────────────────────────────────────────────────────────────────
+  --color                                Enable colors on console.
+  --no-color                             Disable colors on console.
+  -v, --version                          Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
+  -h, --help [verbose]                   Display help for commands and options.
+
+Commands
+────────────────────────────────────────────────────────────────────────
+  build|bundle|b [entries...] [options]  Run webpack (default command, can be omitted).
+  configtest|t [config-path]             Validate a webpack configuration.
+  help|h [command] [option]              Display help for commands and options.
+  info|i [options]                       Outputs information about your system.
+  serve|server|s [entries...] [options]  Run the webpack dev server and watch for source file changes while serving.
+  version|v [options]                    Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
+  watch|w [entries...] [options]         Run webpack and watch for files changes.
+
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information using the "--help" option with the "verbose" value #2: stderr 1`] = `""`;
+
+exports[`help should show help information using the "--help" option with the "verbose" value #2: stdout 1`] = `
+"
+⬡ webpack
+────────────────────────────────────────────────────────────────────────
+The build tool for modern web applications.
+
+Usage: webpack [
+...
+pack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information using the "--help" option with the "verbose" value: stderr 1`] = `""`;
+
+exports[`help should show help information using the "--help" option with the "verbose" value: stdout 1`] = `
+"
+⬡ webpack
+────────────────────────────────────────────────────────────────────────
+The build tool for modern web applications.
+
+Usage: webpack [
+...
+pack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information using the "--help" option: stderr 1`] = `""`;
+
+exports[`help should show help information using the "--help" option: stdout 1`] = `
+"
+⬡ webpack
+────────────────────────────────────────────────────────────────────────
+The build tool for modern web applications.
+
+Usage: webpack [entries...] [options] | webpack [command] [options]
+
+Options
+────────────────────────────────────────────────────────────────────────
+  -c, --config <pathToConfigFile...>     Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
+  --config-name <name...>                Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
+  -m, --merge                            Merge two or more configurations using 'webpack-merge'.
+  --env <value...>                       Environment variables passed to the configuration when it is a function, e.g. "myvar" or "myvar=myval".
+  --config-node-env <value>              Sets process.env.NODE_ENV to the specified value for access within the configuration.
+  --analyze                              It invokes webpack-bundle-analyzer plugin to get bundle information.
+  --progress [value]                     Print compilation progress during build.
+  -j, --json [pathToJsonFile]            Prints result as JSON or store it in a file.
+  --fail-on-warnings                     Stop webpack-cli process with non-zero exit code on warnings from webpack.
+  --disable-interpret                    Disable interpret for loading the config file.
+  -d, --devtool <value>                  A developer tool to enhance debugging (false | eval | [inline-|hidden-|eval-][nosources-][cheap-[module-]]source-map).
+  --no-devtool                           Negative 'devtool' option.
+  --entry <value...>                     A module that is loaded upon startup. Only the last one is exported.
+  -e, --extends <value...>               Path to the configuration to be extended (only works when using webpack-cli).
+  --mode <value>                         Enable production optimizations or development hints.
+  --name <value>                         Name of the configuration. Used when loading multiple configurations.
+  -o, --output-path <value>              The output directory as **absolute path** (required).
+  --stats [value]                        Stats options object or preset name.
+  -t, --target <value...>                Specific environment, runtime, or syntax. Environment to build for. An array of environments to build for all of them when possible.
+  -w, --watch                            Enter watch mode, which rebuilds on file change.
+  --watch-options-stdin                  Stop watching when stdin stream has ended.
+
+Global options
+────────────────────────────────────────────────────────────────────────
+  --color                                Enable colors on console.
+  --no-color                             Disable colors on console.
+  -v, --version                          Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
+  -h, --help [verbose]                   Display help for commands and options.
+
+Commands
+────────────────────────────────────────────────────────────────────────
+  build|bundle|b [entries...] [options]  Run webpack (default command, can be omitted).
+  configtest|t [config-path]             Validate a webpack configuration.
+  help|h [command] [option]              Display help for commands and options.
+  info|i [options]                       Outputs information about your system.
+  serve|server|s [entries...] [options]  Run the webpack dev server and watch for source file changes while serving.
+  version|v [options]                    Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
+  watch|w [entries...] [options]         Run webpack and watch for files changes.
+
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information using the "help --cache-type" option when using serve: stderr 1`] = `""`;
+
+exports[`help should show help information using the "help --cache-type" option when using serve: stdout 1`] = `
+"
+⬡ --cache-type
+────────────────────────────────────────────────────────────────────────
+  Usage: webpack serve --cache-type <value>
+  Description: In memory caching. Filesystem caching.
+  Possible values: 'memory' | 'filesystem'
+────────────────────────────────────────────────────────────────────────
+
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information using the "help --cache-type" option: stderr 1`] = `""`;
+
+exports[`help should show help information using the "help --cache-type" option: stdout 1`] = `
+"
+⬡ --cache-type
+────────────────────────────────────────────────────────────────────────
+  Usage: webpack --cache-type <value>
+  Description: In memory caching. Filesystem caching.
+  Possible values: 'memory' | 'filesystem'
+────────────────────────────────────────────────────────────────────────
+
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information using the "help --color" option: stderr 1`] = `""`;
+
+exports[`help should show help information using the "help --color" option: stdout 1`] = `
+"
+⬡ --color
+────────────────────────────────────────────────────────────────────────
+  Usage: webpack --color
+  Description: Enable colors on console.
+────────────────────────────────────────────────────────────────────────
+
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information using the "help --mode" option: stderr 1`] = `""`;
+
+exports[`help should show help information using the "help --mode" option: stdout 1`] = `
+"
+⬡ --mode
+────────────────────────────────────────────────────────────────────────
+  Usage: webpack --mode <value>
+  Description: Enable production optimizations or development hints.
+  Possible values: 'development' | 'production' | 'none'
+────────────────────────────────────────────────────────────────────────
+
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information using the "help --no-color" option: stderr 1`] = `""`;
+
+exports[`help should show help information using the "help --no-color" option: stdout 1`] = `
+"
+⬡ --no-color
+────────────────────────────────────────────────────────────────────────
+  Usage: webpack --no-color
+  Description: Disable colors on console.
+────────────────────────────────────────────────────────────────────────
+
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information using the "help --no-stats" option: stderr 1`] = `""`;
+
+exports[`help should show help information using the "help --no-stats" option: stdout 1`] = `
+"
+⬡ --no-stats
+────────────────────────────────────────────────────────────────────────
+  Usage: webpack --no-stats
+  Description: Negative 'stats' option.
+────────────────────────────────────────────────────────────────────────
+
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information using the "help --output-chunk-format" option: stderr 1`] = `""`;
+
+exports[`help should show help information using the "help --output-chunk-format" option: stdout 1`] = `
+"
+⬡ --output-chunk-format
+────────────────────────────────────────────────────────────────────────
+  Usage: webpack --output-chunk-format <value>
+  Description: The format of chunks (formats included by default are 'array-push' (web/WebWorker), 'commonjs' (node.js), 'module' (ESM), but others might be added by plugins).
+  Possible values: 'array-push' | 'commonjs' | 'module' | false
+────────────────────────────────────────────────────────────────────────
+
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information using the "help --server-type" option when using serve: stderr 1`] = `""`;
+
+exports[`help should show help information using the "help --server-type" option when using serve: stdout 1`] = `
+"
+⬡ --server-type
+────────────────────────────────────────────────────────────────────────
+  Usage: webpack serve --server-type <value>
+  Description: Allows to set server and options (by default 'http').
+  Possible values: 'http' | 'https' | 'http2'
+────────────────────────────────────────────────────────────────────────
+
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information using the "help --stats" option: stderr 1`] = `""`;
+
+exports[`help should show help information using the "help --stats" option: stdout 1`] = `
+"
+⬡ --stats
+────────────────────────────────────────────────────────────────────────
+  Usage: webpack --stats [value]
+  Description: Stats options object or preset name.
+  Possible values: 'none' | 'summary' | 'errors-only' | 'errors-warnings' | 'minimal' | 'normal' | 'detailed' | 'verbose'
+────────────────────────────────────────────────────────────────────────
+
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information using the "help --target" option: stderr 1`] = `""`;
+
+exports[`help should show help information using the "help --target" option: stdout 1`] = `
+"
+⬡ --target
+────────────────────────────────────────────────────────────────────────
+  Usage: webpack --target <value...>
+  Short: webpack -t <value...>
+  Description: Specific environment, runtime, or syntax. Environment to build for. An array of environments to build for all of them when possible.
+  Possible values: false
+────────────────────────────────────────────────────────────────────────
+
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information using the "help --version" option: stderr 1`] = `""`;
+
+exports[`help should show help information using the "help --version" option: stdout 1`] = `
+"
+⬡ --version
+────────────────────────────────────────────────────────────────────────
+  Usage: webpack --version
+  Short: webpack -v
+  Description: Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
+────────────────────────────────────────────────────────────────────────
+
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information using the "help -v" option: stderr 1`] = `""`;
+
+exports[`help should show help information using the "help -v" option: stdout 1`] = `
+"
+⬡ --version
+────────────────────────────────────────────────────────────────────────
+  Usage: webpack --version
+  Short: webpack -v
+  Description: Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
+────────────────────────────────────────────────────────────────────────
+
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information using the "help serve --color" option: stderr 1`] = `""`;
+
+exports[`help should show help information using the "help serve --color" option: stdout 1`] = `
+"
+⬡ --color
+────────────────────────────────────────────────────────────────────────
+  Usage: webpack serve --color
+  Description: Enable colors on console.
+────────────────────────────────────────────────────────────────────────
+
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information using the "help serve --mode" option: stderr 1`] = `""`;
+
+exports[`help should show help information using the "help serve --mode" option: stdout 1`] = `
+"
+⬡ --mode
+────────────────────────────────────────────────────────────────────────
+  Usage: webpack serve --mode <value>
+  Description: Enable production optimizations or development hints.
+  Possible values: 'development' | 'production' | 'none'
+────────────────────────────────────────────────────────────────────────
+
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information using the "help serve --no-color" option: stderr 1`] = `""`;
+
+exports[`help should show help information using the "help serve --no-color" option: stdout 1`] = `
+"
+⬡ --no-color
+────────────────────────────────────────────────────────────────────────
+  Usage: webpack serve --no-color
+  Description: Disable colors on console.
+────────────────────────────────────────────────────────────────────────
+
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show help information with options for sub commands: stderr 1`] = `""`;
+
+exports[`help should show help information with options for sub commands: stdout 1`] = `
+"
+⬡ webpack info
+────────────────────────────────────────────────────────────────────────
+Outputs information about your system.
+
+Usage: webpack info|i [options]
+
+Options
+────────────────────────────────────────────────────────────────────────
+  -o, --output <value>                 To get the output in a specified format (accept json or markdown)
+  -a, --additional-package <value...>  Adds additional packages to the output
+
+Global options
+────────────────────────────────────────────────────────────────────────
+  --color                              Enable colors on console.
+  --no-color                           Disable colors on console.
+  -v, --version                        Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
+  -h, --help [verbose]                 Display help for commands and options.
+
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show the same information using the "--help" option and command syntax: stderr from command syntax 1`] = `""`;
+
+exports[`help should show the same information using the "--help" option and command syntax: stderr from option 1`] = `""`;
+
+exports[`help should show the same information using the "--help" option and command syntax: stdout from command syntax 1`] = `
+"
+⬡ webpack
+────────────────────────────────────────────────────────────────────────
+The build tool for modern web applications.
+
+Usage: webpack [entries...] [options] | webpack [command] [options]
+
+Options
+────────────────────────────────────────────────────────────────────────
+  -c, --config <pathToConfigFile...>     Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
+  --config-name <name...>                Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
+  -m, --merge                            Merge two or more configurations using 'webpack-merge'.
+  --env <value...>                       Environment variables passed to the configuration when it is a function, e.g. "myvar" or "myvar=myval".
+  --config-node-env <value>              Sets process.env.NODE_ENV to the specified value for access within the configuration.
+  --analyze                              It invokes webpack-bundle-analyzer plugin to get bundle information.
+  --progress [value]                     Print compilation progress during build.
+  -j, --json [pathToJsonFile]            Prints result as JSON or store it in a file.
+  --fail-on-warnings                     Stop webpack-cli process with non-zero exit code on warnings from webpack.
+  --disable-interpret                    Disable interpret for loading the config file.
+  -d, --devtool <value>                  A developer tool to enhance debugging (false | eval | [inline-|hidden-|eval-][nosources-][cheap-[module-]]source-map).
+  --no-devtool                           Negative 'devtool' option.
+  --entry <value...>                     A module that is loaded upon startup. Only the last one is exported.
+  -e, --extends <value...>               Path to the configuration to be extended (only works when using webpack-cli).
+  --mode <value>                         Enable production optimizations or development hints.
+  --name <value>                         Name of the configuration. Used when loading multiple configurations.
+  -o, --output-path <value>              The output directory as **absolute path** (required).
+  --stats [value]                        Stats options object or preset name.
+  -t, --target <value...>                Specific environment, runtime, or syntax. Environment to build for. An array of environments to build for all of them when possible.
+  -w, --watch                            Enter watch mode, which rebuilds on file change.
+  --watch-options-stdin                  Stop watching when stdin stream has ended.
+
+Global options
+────────────────────────────────────────────────────────────────────────
+  --color                                Enable colors on console.
+  --no-color                             Disable colors on console.
+  -v, --version                          Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
+  -h, --help [verbose]                   Display help for commands and options.
+
+Commands
+────────────────────────────────────────────────────────────────────────
+  build|bundle|b [entries...] [options]  Run webpack (default command, can be omitted).
+  configtest|t [config-path]             Validate a webpack configuration.
+  help|h [command] [option]              Display help for commands and options.
+  info|i [options]                       Outputs information about your system.
+  serve|server|s [entries...] [options]  Run the webpack dev server and watch for source file changes while serving.
+  version|v [options]                    Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
+  watch|w [entries...] [options]         Run webpack and watch for files changes.
+
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;
+
+exports[`help should show the same information using the "--help" option and command syntax: stdout from option 1`] = `
+"
+⬡ webpack
+────────────────────────────────────────────────────────────────────────
+The build tool for modern web applications.
+
+Usage: webpack [entries...] [options] | webpack [command] [options]
+
+Options
+────────────────────────────────────────────────────────────────────────
+  -c, --config <pathToConfigFile...>     Provide path to one or more webpack configuration files to process, e.g. "./webpack.config.js".
+  --config-name <name...>                Name(s) of particular configuration(s) to use if configuration file exports an array of multiple configurations.
+  -m, --merge                            Merge two or more configurations using 'webpack-merge'.
+  --env <value...>                       Environment variables passed to the configuration when it is a function, e.g. "myvar" or "myvar=myval".
+  --config-node-env <value>              Sets process.env.NODE_ENV to the specified value for access within the configuration.
+  --analyze                              It invokes webpack-bundle-analyzer plugin to get bundle information.
+  --progress [value]                     Print compilation progress during build.
+  -j, --json [pathToJsonFile]            Prints result as JSON or store it in a file.
+  --fail-on-warnings                     Stop webpack-cli process with non-zero exit code on warnings from webpack.
+  --disable-interpret                    Disable interpret for loading the config file.
+  -d, --devtool <value>                  A developer tool to enhance debugging (false | eval | [inline-|hidden-|eval-][nosources-][cheap-[module-]]source-map).
+  --no-devtool                           Negative 'devtool' option.
+  --entry <value...>                     A module that is loaded upon startup. Only the last one is exported.
+  -e, --extends <value...>               Path to the configuration to be extended (only works when using webpack-cli).
+  --mode <value>                         Enable production optimizations or development hints.
+  --name <value>                         Name of the configuration. Used when loading multiple configurations.
+  -o, --output-path <value>              The output directory as **absolute path** (required).
+  --stats [value]                        Stats options object or preset name.
+  -t, --target <value...>                Specific environment, runtime, or syntax. Environment to build for. An array of environments to build for all of them when possible.
+  -w, --watch                            Enter watch mode, which rebuilds on file change.
+  --watch-options-stdin                  Stop watching when stdin stream has ended.
+
+Global options
+────────────────────────────────────────────────────────────────────────
+  --color                                Enable colors on console.
+  --no-color                             Disable colors on console.
+  -v, --version                          Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
+  -h, --help [verbose]                   Display help for commands and options.
+
+Commands
+────────────────────────────────────────────────────────────────────────
+  build|bundle|b [entries...] [options]  Run webpack (default command, can be omitted).
+  configtest|t [config-path]             Validate a webpack configuration.
+  help|h [command] [option]              Display help for commands and options.
+  info|i [options]                       Outputs information about your system.
+  serve|server|s [entries...] [options]  Run the webpack dev server and watch for source file changes while serving.
+  version|v [options]                    Output the version number of 'webpack', 'webpack-cli' and 'webpack-dev-server' and other packages.
+  watch|w [entries...] [options]         Run webpack and watch for files changes.
+
+────────────────────────────────────────────────────────────────────────
+ℹ Run 'webpack --help=verbose' to see all available commands and options.
+
+Webpack documentation:  https://webpack.js.org/
+CLI documentation:      https://webpack.js.org/api/cli/
+Made with ♥ by the webpack team"
+`;

--- a/test/serve/basic/__snapshots__/serve-basic.test.js.snap.devServer6.webpack5
+++ b/test/serve/basic/__snapshots__/serve-basic.test.js.snap.devServer6.webpack5
@@ -1,0 +1,253 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`basic serve usage should log an error on unknown flag: stderr 1`] = `
+"[webpack-cli] ✖ Error: Unknown option '--unknown-flag'
+[webpack-cli] ✖ Run 'webpack --help' to see available commands and options"
+`;
+
+exports[`basic serve usage should log an error on unknown flag: stdout 1`] = `""`;
+
+exports[`basic serve usage should log error on using '--watch' flag with serve: stderr 1`] = `
+"[webpack-cli] ⚠ No need to use the 'serve' command together with '{ watch: true | false }' or '--watch'/'--no-watch' configuration, it does not make sense.
+<i> [webpack-dev-server] Project is running at:
+<i> [webpack-dev-server] Loopback: http://localhost:<port>/, http://[::1]:<port>/
+<i> [webpack-dev-server] On Your Network (IPv4): http://x.x.x.x:<port>/
+<i> [webpack-dev-server] On Your Network (IPv6): http://[x:x:x:x:x:x:x:x]:<port>/
+<i> [webpack-dev-server] Content not from webpack is served from '<cwd>/test/serve/basic/public' directory"
+`;
+
+exports[`basic serve usage should log warning on using '-w' alias with serve: stderr 1`] = `
+"[webpack-cli] ⚠ No need to use the 'serve' command together with '{ watch: true | false }' or '--watch'/'--no-watch' configuration, it does not make sense.
+<i> [webpack-dev-server] Project is running at:
+<i> [webpack-dev-server] Loopback: http://localhost:<port>/, http://[::1]:<port>/
+<i> [webpack-dev-server] On Your Network (IPv4): http://x.x.x.x:<port>/
+<i> [webpack-dev-server] On Your Network (IPv6): http://[x:x:x:x:x:x:x:x]:<port>/
+<i> [webpack-dev-server] Content not from webpack is served from '<cwd>/test/serve/basic/public' directory"
+`;
+
+exports[`basic serve usage should not start dev server when supplied false #1: stderr 1`] = `
+"<i> [webpack-dev-server] Project is running at:
+<i> [webpack-dev-server] Loopback: http://localhost:<port>/, http://[::1]:<port>/
+<i> [webpack-dev-server] On Your Network (IPv4): http://x.x.x.x:<port>/
+<i> [webpack-dev-server] On Your Network (IPv6): http://[x:x:x:x:x:x:x:x]:<port>/
+<i> [webpack-dev-server] Content not from webpack is served from '<cwd>/test/serve/basic/public' directory"
+`;
+
+exports[`basic serve usage should respect the "publicPath" option from configuration (from the "devServer" options): stderr 1`] = `
+"<i> [webpack-dev-server] Project is running at:
+<i> [webpack-dev-server] Loopback: http://localhost:<port>/, http://[::1]:<port>/
+<i> [webpack-dev-server] On Your Network (IPv4): http://x.x.x.x:<port>/
+<i> [webpack-dev-server] On Your Network (IPv6): http://[x:x:x:x:x:x:x:x]:<port>/
+<i> [webpack-dev-server] Content not from webpack is served from '<cwd>/test/serve/basic/public' directory"
+`;
+
+exports[`basic serve usage should respect the "publicPath" option from configuration using multi compiler mode (from the "devServer" options): stderr 1`] = `
+"<i> [webpack-dev-server] Project is running at:
+<i> [webpack-dev-server] Loopback: http://localhost:<port>/, http://[::1]:<port>/
+<i> [webpack-dev-server] On Your Network (IPv4): http://x.x.x.x:<port>/
+<i> [webpack-dev-server] On Your Network (IPv6): http://[x:x:x:x:x:x:x:x]:<port>/
+<i> [webpack-dev-server] Content not from webpack is served from '<cwd>/test/serve/basic/public' directory"
+`;
+
+exports[`basic serve usage should respect the "publicPath" option from configuration using multi compiler mode: stderr 1`] = `
+"<i> [webpack-dev-server] Project is running at:
+<i> [webpack-dev-server] Loopback: http://localhost:<port>/, http://[::1]:<port>/
+<i> [webpack-dev-server] On Your Network (IPv4): http://x.x.x.x:<port>/
+<i> [webpack-dev-server] On Your Network (IPv6): http://[x:x:x:x:x:x:x:x]:<port>/
+<i> [webpack-dev-server] Content not from webpack is served from '<cwd>/test/serve/basic/public' directory"
+`;
+
+exports[`basic serve usage should respect the "publicPath" option from configuration: stderr 1`] = `
+"<i> [webpack-dev-server] Project is running at:
+<i> [webpack-dev-server] Loopback: http://localhost:<port>/, http://[::1]:<port>/
+<i> [webpack-dev-server] On Your Network (IPv4): http://x.x.x.x:<port>/
+<i> [webpack-dev-server] On Your Network (IPv6): http://[x:x:x:x:x:x:x:x]:<port>/
+<i> [webpack-dev-server] Content not from webpack is served from '<cwd>/test/serve/basic/public' directory"
+`;
+
+exports[`basic serve usage should throw error when same ports in multicompiler: stderr 1`] = `
+"<i> [webpack-dev-server] Project is running at:
+<i> [webpack-dev-server] Loopback: http://localhost:<port>/, http://[::1]:<port>/
+<i> [webpack-dev-server] On Your Network (IPv4): http://x.x.x.x:<port>/
+<i> [webpack-dev-server] On Your Network (IPv6): http://[x:x:x:x:x:x:x:x]:<port>/
+<i> [webpack-dev-server] Content not from webpack is served from '<cwd>/test/serve/basic/public' directory
+[webpack-cli] ✖ Error: Unique ports must be specified for each devServer option in your webpack configuration. Alternatively, run only 1 devServer config using the --config-name flag to specify your desired config.
+    at stack"
+`;
+
+exports[`basic serve usage should work and log warning on the 'watch' option in a configuration: stderr 1`] = `
+"[webpack-cli] ⚠ No need to use the 'serve' command together with '{ watch: true | false }' or '--watch'/'--no-watch' configuration, it does not make sense.
+<i> [webpack-dev-server] Project is running at:
+<i> [webpack-dev-server] Loopback: http://localhost:<port>/, http://[::1]:<port>/
+<i> [webpack-dev-server] On Your Network (IPv4): http://x.x.x.x:<port>/
+<i> [webpack-dev-server] On Your Network (IPv6): http://[x:x:x:x:x:x:x:x]:<port>/
+<i> [webpack-dev-server] Content not from webpack is served from '<cwd>/test/serve/basic/public' directory"
+`;
+
+exports[`basic serve usage should work in multi compiler mode: stderr 1`] = `
+"<i> [webpack-dev-server] Project is running at:
+<i> [webpack-dev-server] Loopback: http://localhost:<port>/, http://[::1]:<port>/
+<i> [webpack-dev-server] On Your Network (IPv4): http://x.x.x.x:<port>/
+<i> [webpack-dev-server] On Your Network (IPv6): http://[x:x:x:x:x:x:x:x]:<port>/
+<i> [webpack-dev-server] Content not from webpack is served from '<cwd>/test/serve/basic/public' directory"
+`;
+
+exports[`basic serve usage should work with "--hot" and "--port" options: stderr 1`] = `
+"<i> [webpack-dev-server] Project is running at:
+<i> [webpack-dev-server] Loopback: http://localhost:<port>/, http://[::1]:<port>/
+<i> [webpack-dev-server] On Your Network (IPv4): http://x.x.x.x:<port>/
+<i> [webpack-dev-server] On Your Network (IPv6): http://[x:x:x:x:x:x:x:x]:<port>/
+<i> [webpack-dev-server] Content not from webpack is served from '<cwd>/test/serve/basic/public' directory"
+`;
+
+exports[`basic serve usage should work with entries syntax: stderr 1`] = `
+"<i> [webpack-dev-server] Project is running at:
+<i> [webpack-dev-server] Loopback: http://localhost:<port>/, http://[::1]:<port>/
+<i> [webpack-dev-server] On Your Network (IPv4): http://x.x.x.x:<port>/
+<i> [webpack-dev-server] On Your Network (IPv6): http://[x:x:x:x:x:x:x:x]:<port>/
+<i> [webpack-dev-server] Content not from webpack is served from '<cwd>/test/serve/basic/public' directory"
+`;
+
+exports[`basic serve usage should work with the "--client-log-level" option: stderr 1`] = `
+"<i> [webpack-dev-server] Project is running at:
+<i> [webpack-dev-server] Loopback: http://localhost:<port>/, http://[::1]:<port>/
+<i> [webpack-dev-server] On Your Network (IPv4): http://x.x.x.x:<port>/
+<i> [webpack-dev-server] On Your Network (IPv6): http://[x:x:x:x:x:x:x:x]:<port>/
+<i> [webpack-dev-server] Content not from webpack is served from '<cwd>/test/serve/basic/public' directory"
+`;
+
+exports[`basic serve usage should work with the "--config" and "--env" options and expose dev server options: stderr 1`] = `
+"<i> [webpack-dev-server] Project is running at:
+<i> [webpack-dev-server] Loopback: http://localhost:<port>/, http://[::1]:<port>/
+<i> [webpack-dev-server] On Your Network (IPv4): http://x.x.x.x:<port>/
+<i> [webpack-dev-server] On Your Network (IPv6): http://[x:x:x:x:x:x:x:x]:<port>/
+<i> [webpack-dev-server] Content not from webpack is served from '<cwd>/test/serve/basic/public' directory"
+`;
+
+exports[`basic serve usage should work with the "--config" and "--env" options: stderr 1`] = `
+"<i> [webpack-dev-server] Project is running at:
+<i> [webpack-dev-server] Loopback: http://localhost:<port>/, http://[::1]:<port>/
+<i> [webpack-dev-server] On Your Network (IPv4): http://x.x.x.x:<port>/
+<i> [webpack-dev-server] On Your Network (IPv6): http://[x:x:x:x:x:x:x:x]:<port>/
+<i> [webpack-dev-server] Content not from webpack is served from '<cwd>/test/serve/basic/public' directory"
+`;
+
+exports[`basic serve usage should work with the "--config" option: stderr 1`] = `
+"<i> [webpack-dev-server] Project is running at:
+<i> [webpack-dev-server] Loopback: http://localhost:<port>/, http://[::1]:<port>/
+<i> [webpack-dev-server] On Your Network (IPv4): http://x.x.x.x:<port>/
+<i> [webpack-dev-server] On Your Network (IPv6): http://[x:x:x:x:x:x:x:x]:<port>/
+<i> [webpack-dev-server] Content not from webpack is served from '<cwd>/test/serve/basic/public' directory"
+`;
+
+exports[`basic serve usage should work with the "--hot" option using the "only" value: stderr 1`] = `
+"<i> [webpack-dev-server] Project is running at:
+<i> [webpack-dev-server] Loopback: http://localhost:<port>/, http://[::1]:<port>/
+<i> [webpack-dev-server] On Your Network (IPv4): http://x.x.x.x:<port>/
+<i> [webpack-dev-server] On Your Network (IPv6): http://[x:x:x:x:x:x:x:x]:<port>/
+<i> [webpack-dev-server] Content not from webpack is served from '<cwd>/test/serve/basic/public' directory"
+`;
+
+exports[`basic serve usage should work with the "--hot" option: stderr 1`] = `
+"<i> [webpack-dev-server] Project is running at:
+<i> [webpack-dev-server] Loopback: http://localhost:<port>/, http://[::1]:<port>/
+<i> [webpack-dev-server] On Your Network (IPv4): http://x.x.x.x:<port>/
+<i> [webpack-dev-server] On Your Network (IPv6): http://[x:x:x:x:x:x:x:x]:<port>/
+<i> [webpack-dev-server] Content not from webpack is served from '<cwd>/test/serve/basic/public' directory"
+`;
+
+exports[`basic serve usage should work with the "--mode" option #2: stderr 1`] = `
+"<i> [webpack-dev-server] Project is running at:
+<i> [webpack-dev-server] Loopback: http://localhost:<port>/, http://[::1]:<port>/
+<i> [webpack-dev-server] On Your Network (IPv4): http://x.x.x.x:<port>/
+<i> [webpack-dev-server] On Your Network (IPv6): http://[x:x:x:x:x:x:x:x]:<port>/
+<i> [webpack-dev-server] Content not from webpack is served from '<cwd>/test/serve/basic/public' directory"
+`;
+
+exports[`basic serve usage should work with the "--mode" option #3: stderr 1`] = `
+"<i> [webpack-dev-server] Project is running at:
+<i> [webpack-dev-server] Loopback: http://localhost:<port>/, http://[::1]:<port>/
+<i> [webpack-dev-server] On Your Network (IPv4): http://x.x.x.x:<port>/
+<i> [webpack-dev-server] On Your Network (IPv6): http://[x:x:x:x:x:x:x:x]:<port>/
+<i> [webpack-dev-server] Content not from webpack is served from '<cwd>/test/serve/basic/public' directory"
+`;
+
+exports[`basic serve usage should work with the "--mode" option: stderr 1`] = `
+"<i> [webpack-dev-server] Project is running at:
+<i> [webpack-dev-server] Loopback: http://localhost:<port>/, http://[::1]:<port>/
+<i> [webpack-dev-server] On Your Network (IPv4): http://x.x.x.x:<port>/
+<i> [webpack-dev-server] On Your Network (IPv6): http://[x:x:x:x:x:x:x:x]:<port>/
+<i> [webpack-dev-server] Content not from webpack is served from '<cwd>/test/serve/basic/public' directory"
+`;
+
+exports[`basic serve usage should work with the "--no-hot" option: stderr 1`] = `
+"<i> [webpack-dev-server] Project is running at:
+<i> [webpack-dev-server] Loopback: http://localhost:<port>/, http://[::1]:<port>/
+<i> [webpack-dev-server] On Your Network (IPv4): http://x.x.x.x:<port>/
+<i> [webpack-dev-server] On Your Network (IPv6): http://[x:x:x:x:x:x:x:x]:<port>/
+<i> [webpack-dev-server] Content not from webpack is served from '<cwd>/test/serve/basic/public' directory"
+`;
+
+exports[`basic serve usage should work with the "--open" option: stderr 1`] = `
+"<i> [webpack-dev-server] Project is running at:
+<i> [webpack-dev-server] Loopback: http://localhost:<port>/, http://[::1]:<port>/
+<i> [webpack-dev-server] On Your Network (IPv4): http://x.x.x.x:<port>/
+<i> [webpack-dev-server] On Your Network (IPv6): http://[x:x:x:x:x:x:x:x]:<port>/
+<i> [webpack-dev-server] Content not from webpack is served from '<cwd>/test/serve/basic/public' directory"
+`;
+
+exports[`basic serve usage should work with the "--output-public-path" option: stderr 1`] = `
+"<i> [webpack-dev-server] Project is running at:
+<i> [webpack-dev-server] Loopback: http://localhost:<port>/, http://[::1]:<port>/
+<i> [webpack-dev-server] On Your Network (IPv4): http://x.x.x.x:<port>/
+<i> [webpack-dev-server] On Your Network (IPv6): http://[x:x:x:x:x:x:x:x]:<port>/
+<i> [webpack-dev-server] Content not from webpack is served from '<cwd>/test/serve/basic/public' directory"
+`;
+
+exports[`basic serve usage should work with the "--port" option: stderr 1`] = `
+"<i> [webpack-dev-server] Project is running at:
+<i> [webpack-dev-server] Loopback: http://localhost:<port>/, http://[::1]:<port>/
+<i> [webpack-dev-server] On Your Network (IPv4): http://x.x.x.x:<port>/
+<i> [webpack-dev-server] On Your Network (IPv6): http://[x:x:x:x:x:x:x:x]:<port>/
+<i> [webpack-dev-server] Content not from webpack is served from '<cwd>/test/serve/basic/public' directory"
+`;
+
+exports[`basic serve usage should work with the "--stats verbose" option: stderr 1`] = `
+"<i> [webpack-dev-server] Project is running at:
+<i> [webpack-dev-server] Loopback: http://localhost:<port>/, http://[::1]:<port>/
+<i> [webpack-dev-server] On Your Network (IPv4): http://x.x.x.x:<port>/
+<i> [webpack-dev-server] On Your Network (IPv6): http://[x:x:x:x:x:x:x:x]:<port>/
+<i> [webpack-dev-server] Content not from webpack is served from '<cwd>/test/serve/basic/public' directory"
+`;
+
+exports[`basic serve usage should work with the "--stats" option: stderr 1`] = `
+"<i> [webpack-dev-server] Project is running at:
+<i> [webpack-dev-server] Loopback: http://localhost:<port>/, http://[::1]:<port>/
+<i> [webpack-dev-server] On Your Network (IPv4): http://x.x.x.x:<port>/
+<i> [webpack-dev-server] On Your Network (IPv6): http://[x:x:x:x:x:x:x:x]:<port>/
+<i> [webpack-dev-server] Content not from webpack is served from '<cwd>/test/serve/basic/public' directory"
+`;
+
+exports[`basic serve usage should work with the "stats" option in config: stderr 1`] = `
+"<i> [webpack-dev-server] Project is running at:
+<i> [webpack-dev-server] Loopback: http://localhost:<port>/, http://[::1]:<port>/
+<i> [webpack-dev-server] On Your Network (IPv4): http://x.x.x.x:<port>/
+<i> [webpack-dev-server] On Your Network (IPv6): http://[x:x:x:x:x:x:x:x]:<port>/
+<i> [webpack-dev-server] Content not from webpack is served from '<cwd>/test/serve/basic/public' directory"
+`;
+
+exports[`basic serve usage should work with the default "publicPath" option: stderr 1`] = `
+"<i> [webpack-dev-server] Project is running at:
+<i> [webpack-dev-server] Loopback: http://localhost:<port>/, http://[::1]:<port>/
+<i> [webpack-dev-server] On Your Network (IPv4): http://x.x.x.x:<port>/
+<i> [webpack-dev-server] On Your Network (IPv6): http://[x:x:x:x:x:x:x:x]:<port>/
+<i> [webpack-dev-server] Content not from webpack is served from '<cwd>/test/serve/basic/public' directory"
+`;
+
+exports[`basic serve usage should work: stderr 1`] = `
+"<i> [webpack-dev-server] Project is running at:
+<i> [webpack-dev-server] Loopback: http://localhost:<port>/, http://[::1]:<port>/
+<i> [webpack-dev-server] On Your Network (IPv4): http://x.x.x.x:<port>/
+<i> [webpack-dev-server] On Your Network (IPv6): http://[x:x:x:x:x:x:x:x]:<port>/
+<i> [webpack-dev-server] Content not from webpack is served from '<cwd>/test/serve/basic/public' directory"
+`;

--- a/test/serve/invalid-schema/__snapshots__/invalid-schema.test.js.snap.devServer6.webpack5
+++ b/test/serve/invalid-schema/__snapshots__/invalid-schema.test.js.snap.devServer6.webpack5
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`invalid schema should log webpack error and exit process on invalid config: stderr 1`] = `
+"[webpack-cli] ✖ Invalid configuration object. Webpack has been initialized using a configuration object that does not match the API schema.
+ - configuration.mode should be one of these:
+   "development" | "production" | "none"
+   -> Enable production optimizations or development hints."
+`;
+
+exports[`invalid schema should log webpack error and exit process on invalid config: stdout 1`] = `""`;
+
+exports[`invalid schema should log webpack error and exit process on invalid flag: stderr 1`] = `
+"[webpack-cli] ✖ Invalid value 'Yukihira' for the '--mode' option
+[webpack-cli] ✖ Expected: 'development | production | none'"
+`;
+
+exports[`invalid schema should log webpack error and exit process on invalid flag: stdout 1`] = `""`;
+
+exports[`invalid schema should log webpack-dev-server error and exit process on invalid config: stderr 1`] = `
+"[webpack-cli] ✖ Invalid options object. Dev Server has been initialized using an options object that does not match the API schema.
+ - options.bonjour should be one of these:
+   boolean | object { … }
+   -> Allows to broadcasts dev server via ZeroConf networking on start.
+   -> Read more
+    at stack
+      -> Options for bonjour.
+      -> Read more at https://github.com/watson/bonjour#initializing"
+`;
+
+exports[`invalid schema should log webpack-dev-server error and exit process on invalid config: stdout 1`] = `""`;
+
+exports[`invalid schema should log webpack-dev-server error and exit process on invalid flag: stderr 1`] = `
+"[webpack-cli] ✖ Invalid options object. Dev Server has been initialized using an options object that does not match the API schema.
+ - options.port should be >= 0 and <= 65535."
+`;
+
+exports[`invalid schema should log webpack-dev-server error and exit process on invalid flag: stdout 1`] = `""`;

--- a/test/serve/serve-variable/__snapshots__/serve-variable.test.js.snap.devServer6.webpack5
+++ b/test/serve/serve-variable/__snapshots__/serve-variable.test.js.snap.devServer6.webpack5
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`serve variable compiles without flags and export variable 1`] = `
+"<i> [webpack-dev-server] Project is running at:
+<i> [webpack-dev-server] Loopback: http://localhost:<port>/, http://[::1]:<port>/
+<i> [webpack-dev-server] On Your Network (IPv4): http://x.x.x.x:<port>/
+<i> [webpack-dev-server] On Your Network (IPv6): http://[x:x:x:x:x:x:x:x]:<port>/
+<i> [webpack-dev-server] Content not from webpack is served from '<cwd>/test/serve/serve-variable/public' directory"
+`;

--- a/test/serve/with-custom-port/__snapshots__/serve-custom-config.test.js.snap.devServer6.webpack5
+++ b/test/serve/with-custom-port/__snapshots__/serve-custom-config.test.js.snap.devServer6.webpack5
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`serve with devServer in config passing hot flag works alongside other server config: stderr 1`] = `
+"<i> [webpack-dev-server] Project is running at:
+<i> [webpack-dev-server] Loopback: http://localhost:<port>/, http://[::1]:<port>/
+<i> [webpack-dev-server] On Your Network (IPv4): http://x.x.x.x:<port>/
+<i> [webpack-dev-server] On Your Network (IPv6): http://[x:x:x:x:x:x:x:x]:<port>/
+<i> [webpack-dev-server] Content not from webpack is served from '<cwd>/test/serve/with-custom-port/public' directory"
+`;
+
+exports[`serve with devServer in config port flag should override the config port: stderr 1`] = `
+"<i> [webpack-dev-server] Project is running at:
+<i> [webpack-dev-server] Loopback: http://localhost:<port>/, http://[::1]:<port>/
+<i> [webpack-dev-server] On Your Network (IPv4): http://x.x.x.x:<port>/
+<i> [webpack-dev-server] On Your Network (IPv6): http://[x:x:x:x:x:x:x:x]:<port>/
+<i> [webpack-dev-server] Content not from webpack is served from '<cwd>/test/serve/with-custom-port/public' directory"
+`;
+
+exports[`serve with devServer in config should pick up the host and port from config: stderr 1`] = `
+"<i> [webpack-dev-server] Project is running at:
+<i> [webpack-dev-server] Loopback: http://localhost:<port>/, http://[::1]:<port>/
+<i> [webpack-dev-server] On Your Network (IPv4): http://x.x.x.x:<port>/
+<i> [webpack-dev-server] On Your Network (IPv6): http://[x:x:x:x:x:x:x:x]:<port>/
+<i> [webpack-dev-server] Content not from webpack is served from '<cwd>/test/serve/with-custom-port/public' directory"
+`;
+
+exports[`serve with devServer in config works fine when no-hot flag is passed alongside other server config: stderr 1`] = `
+"<i> [webpack-dev-server] Project is running at:
+<i> [webpack-dev-server] Loopback: http://localhost:<port>/, http://[::1]:<port>/
+<i> [webpack-dev-server] On Your Network (IPv4): http://x.x.x.x:<port>/
+<i> [webpack-dev-server] On Your Network (IPv6): http://[x:x:x:x:x:x:x:x]:<port>/
+<i> [webpack-dev-server] Content not from webpack is served from '<cwd>/test/serve/with-custom-port/public' directory"
+`;


### PR DESCRIPTION
**Summary**

Updates the `webpack-dev-server` dev dependency to v6 and makes the test suite cover both v5 and v6, which are the versions the `webpack-cli` peer range allows (`^5.0.0 || ^6.0.0`).

- Snapshots for dev-server 6 are added next to the existing v5 ones. The snapshot resolver already supports this through the `.snap.devServer<major>.webpack<major>` extension, so no tooling change was needed. The only difference in the output is the help text for `--server-type`, since v6 drops `spdy` from the possible values.
- CI runs the matrix against `dev-server-version: [5, latest]`, installing v5 with `npm install ... --no-save --ignore-scripts` for that job, following the same approach as #4791.
- `webpack-dev-server` v6 is ESM and exposes the server as its `default` export, while v5 exports it directly, so `tsc` failed with "This expression is not constructable". The CLI now resolves the constructor type from the default export when there is one, which type-checks against both versions. Runtime behavior is unchanged: the package was already loaded through `(await import(pkg)).default`.

**What kind of change does this PR introduce?**

chore, plus a types fix in `webpack-cli`.

**Did you add tests for your changes?**

No new tests, the existing `test/help` and `test/serve` suites now run against both dev-server versions with their own snapshots.

**Does this PR introduce a breaking change?**

No. The peer range already allowed v6, and the type change only affects how the constructor type is resolved.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

`SERVE-OPTIONS-v6.md` will be generated by the scheduled "Update documentation" workflow, which derives the filename from the installed dev-server major.

**Use of AI**

Yes. I used Claude Code (Opus) to carry out the upgrade under my direction: the dependency bump, the type fix, the CI matrix and the snapshots. I verified the build and ran `test/help` against the new snapshots locally, and reviewed the final diff.
