### PR TITLE
feat(create-webpack-app): stop asking about HTML and CSS

### DIFF
--- a/.changeset/init-no-html-css-questions.md
+++ b/.changeset/init-no-html-css-questions.md
@@ -2,4 +2,4 @@
 "create-webpack-app": minor
 ---
 
-feat: stop asking about HTML and CSS in `init`, keeping one question for the CSS preprocessors webpack does not cover
+feat: stop asking about HTML and CSS in `init`, keeping one question for the CSS tools webpack does not cover (PostCSS, Sass, Less, Stylus)

--- a/.changeset/init-no-html-css-questions.md
+++ b/.changeset/init-no-html-css-questions.md
@@ -1,0 +1,5 @@
+---
+"create-webpack-app": minor
+---
+
+feat: stop asking about HTML and CSS in `init`, keeping one question for the CSS preprocessors webpack does not cover

--- a/.changeset/init-no-html-css-questions.md
+++ b/.changeset/init-no-html-css-questions.md
@@ -2,4 +2,4 @@
 "create-webpack-app": minor
 ---
 
-feat: stop asking about HTML and CSS in `init`, keeping one question for the CSS tools webpack does not cover (PostCSS, Sass, Less, Stylus)
+feat: stop asking about HTML and CSS in `init`, scaffold TypeScript on webpack's own support, and keep one question for the CSS tools webpack does not cover (PostCSS, Sass, Less, Stylus, and each preprocessor with PostCSS)

--- a/.cspell.json
+++ b/.cspell.json
@@ -87,6 +87,7 @@
     "splitted",
     "Statsv",
     "styl",
+    "stylesheet",
     "Tanjiro",
     "tapable",
     "taskkill",

--- a/packages/create-webpack-app/README.md
+++ b/packages/create-webpack-app/README.md
@@ -68,7 +68,7 @@ Available templates:
 Every template scaffolds `index.html` as the entry point of the project and relies on
 webpack's built-in HTML and CSS support (webpack >= 5.109), so the generated projects
 carry no `html-webpack-plugin`, `css-loader`, `style-loader` or `mini-css-extract-plugin`.
-A Sass/Less/Stylus project adds only its preprocessor loader.
+Picking Sass, Less, Stylus or PostCSS adds only that tool's loader on top.
 
 Available templates for `loader` and `plugin` generators:
 

--- a/packages/create-webpack-app/README.md
+++ b/packages/create-webpack-app/README.md
@@ -65,6 +65,11 @@ Available templates:
 - [`vue`](https://vuejs.org/)
 - [`svelte`](https://svelte.dev/)
 
+Every template scaffolds `index.html` as the entry point of the project and relies on
+webpack's built-in HTML and CSS support (webpack >= 5.109), so the generated projects
+carry no `html-webpack-plugin`, `css-loader`, `style-loader` or `mini-css-extract-plugin`.
+A Sass/Less/Stylus project adds only its preprocessor loader.
+
 Available templates for `loader` and `plugin` generators:
 
 - `default` (used by default when nothing specified) - generate bootstrap code

--- a/packages/create-webpack-app/src/generators/init/default.ts
+++ b/packages/create-webpack-app/src/generators/init/default.ts
@@ -3,6 +3,12 @@ import { fileURLToPath } from "node:url";
 import { type DynamicActionsFunction, type NodePlopAPI } from "node-plop";
 import { type ActionType, type Answers, type FileRecord } from "../../types.js";
 
+const STYLE_EXTENSIONS: Record<string, string> = {
+  SASS: "scss",
+  LESS: "less",
+  Stylus: "styl",
+};
+
 export default async function defaultInitGenerator(plop: NodePlopAPI) {
   const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -41,9 +47,18 @@ export default async function defaultInitGenerator(plop: NodePlopAPI) {
       },
       {
         type: "list",
-        name: "cssPreprocessor",
-        message: "Which CSS preprocessor do you want to use?",
-        choices: ["none", "SASS", "LESS", "Stylus"],
+        name: "cssTool",
+        message: "Which CSS tool do you want to use?",
+        choices: [
+          "none",
+          "PostCSS",
+          "SASS",
+          "SASS with PostCSS",
+          "LESS",
+          "LESS with PostCSS",
+          "Stylus",
+          "Stylus with PostCSS",
+        ],
         default: "none",
       },
       {
@@ -80,22 +95,31 @@ export default async function defaultInitGenerator(plop: NodePlopAPI) {
         devDependencies.push("workbox-webpack-plugin");
       }
 
-      switch (answers.cssPreprocessor) {
-        case "SASS":
-          answers.styleExtension = "scss";
-          devDependencies.push("sass-loader", "sass");
-          break;
-        case "LESS":
-          answers.styleExtension = "less";
-          devDependencies.push("less-loader", "less");
-          break;
-        case "Stylus":
-          answers.styleExtension = "styl";
-          devDependencies.push("stylus-loader", "stylus");
-          break;
-        default:
-          answers.styleExtension = "css";
-          break;
+      const cssTool = (answers.cssTool as string | undefined) ?? "none";
+      // PostCSS runs on its own or over a preprocessor, so both are read off the answer
+      const preprocessor = Object.keys(STYLE_EXTENSIONS).find((name) => cssTool.startsWith(name));
+
+      answers.usePostCSS = cssTool.includes("PostCSS");
+      answers.useSASS = preprocessor === "SASS";
+      answers.useLESS = preprocessor === "LESS";
+      answers.useStylus = preprocessor === "Stylus";
+      // The starter stylesheet is written in the language that was picked
+      answers.styleExtension = preprocessor ? STYLE_EXTENSIONS[preprocessor] : "css";
+
+      if (answers.usePostCSS) {
+        devDependencies.push("postcss-loader", "postcss", "autoprefixer");
+      }
+
+      if (answers.useSASS) {
+        devDependencies.push("sass-loader", "sass");
+      }
+
+      if (answers.useLESS) {
+        devDependencies.push("less-loader", "less");
+      }
+
+      if (answers.useStylus) {
+        devDependencies.push("stylus-loader", "stylus");
       }
 
       const files: FileRecord[] = [
@@ -127,6 +151,10 @@ export default async function defaultInitGenerator(plop: NodePlopAPI) {
           answers.entryPoint = "./src/index.js";
           files.push({ filePath: answers.entryPoint as string, fileType: "text" });
           break;
+      }
+
+      if (answers.usePostCSS) {
+        files.push({ filePath: "postcss.config.js", fileType: "text" });
       }
 
       files.push({

--- a/packages/create-webpack-app/src/generators/init/default.ts
+++ b/packages/create-webpack-app/src/generators/init/default.ts
@@ -83,7 +83,9 @@ export default async function defaultInitGenerator(plop: NodePlopAPI) {
           devDependencies.push("babel-loader", "@babel/core", "@babel/preset-env");
           break;
         case "Typescript":
-          devDependencies.push("typescript", "ts-loader");
+          // webpack strips the types itself; `typescript` is here for the editor
+          // and for the `check:types` script, not for the build
+          devDependencies.push("typescript");
           break;
       }
 

--- a/packages/create-webpack-app/src/generators/init/default.ts
+++ b/packages/create-webpack-app/src/generators/init/default.ts
@@ -110,8 +110,9 @@ export default async function defaultInitGenerator(plop: NodePlopAPI) {
           answers.useTsLoader = answers.tsCompiler === "ts-loader";
 
           if (answers.useTsLoader) {
-            // ts-loader 9 (its latest) throws on TypeScript 7, so pin what it supports
-            devDependencies.push("typescript@5", "ts-loader");
+            // ts-loader 9 (its latest) throws on TypeScript 7, the native port,
+            // so pin the last JavaScript-line release it still works with
+            devDependencies.push("typescript@6", "ts-loader");
           } else {
             devDependencies.push("typescript");
           }

--- a/packages/create-webpack-app/src/generators/init/default.ts
+++ b/packages/create-webpack-app/src/generators/init/default.ts
@@ -37,7 +37,18 @@ export default async function defaultInitGenerator(plop: NodePlopAPI) {
         type: "list",
         name: "tsCompiler",
         message: "How should TypeScript be compiled?",
-        choices: ["built-in", "ts-loader"],
+        // The labels spell out the trade-off; a label must not end with `)`,
+        // which is what the prompt tests watch for to send the next answer
+        choices: [
+          {
+            name: "webpack itself: strips types, no type checking, needs Node.js >= 22.6",
+            value: "built-in",
+          },
+          {
+            name: "ts-loader: type checks while it builds, and handles .tsx, enums and decorators",
+            value: "ts-loader",
+          },
+        ],
         default: "built-in",
         when: (answers: Answers) => answers.langType === "Typescript",
       },

--- a/packages/create-webpack-app/src/generators/init/default.ts
+++ b/packages/create-webpack-app/src/generators/init/default.ts
@@ -35,45 +35,16 @@ export default async function defaultInitGenerator(plop: NodePlopAPI) {
       },
       {
         type: "confirm",
-        name: "html",
-        message: "Do you want to simplify the creation of HTML files for your bundle?",
-        default: true,
-      },
-      {
-        type: "confirm",
         name: "workboxWebpackPlugin",
         message: "Do you want to add PWA support?",
         default: true,
       },
       {
         type: "list",
-        name: "cssType",
-        message: "Which of the following CSS solution do you want to use?",
-        choices: ["none", "CSS only", "SASS", "LESS", "Stylus"],
-        default: "CSS only",
-        filter: (input: string, answers: Answers) => {
-          if (input === "none") {
-            answers.isCSS = false;
-            answers.isPostCSS = false;
-          } else if (input === "CSS only") {
-            answers.isCSS = true;
-          }
-          return input;
-        },
-      },
-      {
-        type: "confirm",
-        name: "isCSS",
-        message: (answers: Answers) =>
-          `Will you be using CSS styles along with ${answers.cssType} in your project?`,
-        when: (answers: Answers) => answers.cssType !== "CSS only",
-        default: true,
-      },
-      {
-        type: "confirm",
-        name: "isPostCSS",
-        message: "Do you want to use PostCSS in your project?",
-        default: (answers: Answers) => answers.cssType === "CSS only",
+        name: "cssPreprocessor",
+        message: "Which CSS preprocessor do you want to use?",
+        choices: ["none", "SASS", "LESS", "Stylus"],
+        default: "none",
       },
       {
         type: "list",
@@ -109,22 +80,22 @@ export default async function defaultInitGenerator(plop: NodePlopAPI) {
         devDependencies.push("workbox-webpack-plugin");
       }
 
-      if (answers.isPostCSS) {
-        devDependencies.push("postcss-loader", "postcss", "autoprefixer");
-      }
-
-      if (answers.cssType !== "none") {
-        switch (answers.cssType) {
-          case "SASS":
-            devDependencies.push("sass-loader", "sass");
-            break;
-          case "LESS":
-            devDependencies.push("less-loader", "less");
-            break;
-          case "Stylus":
-            devDependencies.push("stylus-loader", "stylus");
-            break;
-        }
+      switch (answers.cssPreprocessor) {
+        case "SASS":
+          answers.styleExtension = "scss";
+          devDependencies.push("sass-loader", "sass");
+          break;
+        case "LESS":
+          answers.styleExtension = "less";
+          devDependencies.push("less-loader", "less");
+          break;
+        case "Stylus":
+          answers.styleExtension = "styl";
+          devDependencies.push("stylus-loader", "stylus");
+          break;
+        default:
+          answers.styleExtension = "css";
+          break;
       }
 
       const files: FileRecord[] = [
@@ -158,9 +129,10 @@ export default async function defaultInitGenerator(plop: NodePlopAPI) {
           break;
       }
 
-      if (answers.isPostCSS) {
-        files.push({ filePath: "postcss.config.js", fileType: "text" });
-      }
+      files.push({
+        filePath: `./src/styles.${answers.styleExtension}`,
+        fileType: "text",
+      });
 
       for (const file of files) {
         actions.push({

--- a/packages/create-webpack-app/src/generators/init/default.ts
+++ b/packages/create-webpack-app/src/generators/init/default.ts
@@ -34,6 +34,14 @@ export default async function defaultInitGenerator(plop: NodePlopAPI) {
         default: "none",
       },
       {
+        type: "list",
+        name: "tsCompiler",
+        message: "How should TypeScript be compiled?",
+        choices: ["built-in", "ts-loader"],
+        default: "built-in",
+        when: (answers: Answers) => answers.langType === "Typescript",
+      },
+      {
         type: "confirm",
         name: "devServer",
         message: "Would you like to use Webpack Dev server?",
@@ -78,14 +86,24 @@ export default async function defaultInitGenerator(plop: NodePlopAPI) {
     actions: function actions(answers: Answers) {
       const actions: ActionType[] = [];
 
+      // the config template reads this, so it has to be set whatever the language is
+      answers.useTsLoader = false;
+
       switch (answers.langType) {
         case "ES6":
           devDependencies.push("babel-loader", "@babel/core", "@babel/preset-env");
           break;
         case "Typescript":
-          // webpack strips the types itself; `typescript` is here for the editor
-          // and for the `check:types` script, not for the build
-          devDependencies.push("typescript");
+          // Type stripping covers erasable syntax only, so ts-loader stays on
+          // offer; either way `typescript` backs the editor and `check:types`
+          answers.useTsLoader = answers.tsCompiler === "ts-loader";
+
+          if (answers.useTsLoader) {
+            // ts-loader 9 (its latest) throws on TypeScript 7, so pin what it supports
+            devDependencies.push("typescript@5", "ts-loader");
+          } else {
+            devDependencies.push("typescript");
+          }
           break;
       }
 

--- a/packages/create-webpack-app/src/generators/init/react.ts
+++ b/packages/create-webpack-app/src/generators/init/react.ts
@@ -3,6 +3,12 @@ import { fileURLToPath } from "node:url";
 import { type DynamicActionsFunction, type NodePlopAPI } from "node-plop";
 import { type ActionType, type Answers, type FileRecord } from "../../types.js";
 
+const STYLE_EXTENSIONS: Record<string, string> = {
+  SASS: "scss",
+  LESS: "less",
+  Stylus: "styl",
+};
+
 export default async function reactInitGenerator(plop: NodePlopAPI) {
   const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -49,9 +55,18 @@ export default async function reactInitGenerator(plop: NodePlopAPI) {
       },
       {
         type: "list",
-        name: "cssPreprocessor",
-        message: "Which CSS preprocessor do you want to use?",
-        choices: ["none", "SASS", "LESS", "Stylus"],
+        name: "cssTool",
+        message: "Which CSS tool do you want to use?",
+        choices: [
+          "none",
+          "PostCSS",
+          "SASS",
+          "SASS with PostCSS",
+          "LESS",
+          "LESS with PostCSS",
+          "Stylus",
+          "Stylus with PostCSS",
+        ],
         default: "none",
       },
       {
@@ -89,22 +104,31 @@ export default async function reactInitGenerator(plop: NodePlopAPI) {
         devDependencies.push("workbox-webpack-plugin");
       }
 
-      switch (answers.cssPreprocessor) {
-        case "SASS":
-          answers.styleExtension = "scss";
-          devDependencies.push("sass-loader", "sass");
-          break;
-        case "LESS":
-          answers.styleExtension = "less";
-          devDependencies.push("less-loader", "less");
-          break;
-        case "Stylus":
-          answers.styleExtension = "styl";
-          devDependencies.push("stylus-loader", "stylus");
-          break;
-        default:
-          answers.styleExtension = "css";
-          break;
+      const cssTool = (answers.cssTool as string | undefined) ?? "none";
+      // PostCSS runs on its own or over a preprocessor, so both are read off the answer
+      const preprocessor = Object.keys(STYLE_EXTENSIONS).find((name) => cssTool.startsWith(name));
+
+      answers.usePostCSS = cssTool.includes("PostCSS");
+      answers.useSASS = preprocessor === "SASS";
+      answers.useLESS = preprocessor === "LESS";
+      answers.useStylus = preprocessor === "Stylus";
+      // The starter stylesheet is written in the language that was picked
+      answers.styleExtension = preprocessor ? STYLE_EXTENSIONS[preprocessor] : "css";
+
+      if (answers.usePostCSS) {
+        devDependencies.push("postcss-loader", "postcss", "autoprefixer");
+      }
+
+      if (answers.useSASS) {
+        devDependencies.push("sass-loader", "sass");
+      }
+
+      if (answers.useLESS) {
+        devDependencies.push("less-loader", "less");
+      }
+
+      if (answers.useStylus) {
+        devDependencies.push("stylus-loader", "stylus");
       }
 
       const files: FileRecord[] = [
@@ -143,6 +167,10 @@ export default async function reactInitGenerator(plop: NodePlopAPI) {
             { filePath: answers.entry as string, fileType: "text" },
           );
           break;
+      }
+
+      if (answers.usePostCSS) {
+        files.push({ filePath: "postcss.config.js", fileType: "text" });
       }
 
       files.push({

--- a/packages/create-webpack-app/src/generators/init/react.ts
+++ b/packages/create-webpack-app/src/generators/init/react.ts
@@ -49,33 +49,10 @@ export default async function reactInitGenerator(plop: NodePlopAPI) {
       },
       {
         type: "list",
-        name: "cssType",
-        message: "Which of the following CSS solution do you want to use?",
-        choices: ["none", "CSS only", "SASS", "LESS", "Stylus"],
-        default: "CSS only",
-        filter: (input: string, answers: Answers) => {
-          if (input === "none") {
-            answers.isCSS = false;
-            answers.isPostCSS = false;
-          } else if (input === "CSS only") {
-            answers.isCSS = true;
-          }
-          return input;
-        },
-      },
-      {
-        type: "confirm",
-        name: "isCSS",
-        message: (answers: Answers) =>
-          `Will you be using CSS styles along with ${answers.cssType} in your project?`,
-        when: (answers: Answers) => answers.cssType !== "CSS only",
-        default: true,
-      },
-      {
-        type: "confirm",
-        name: "isPostCSS",
-        message: "Do you want to use PostCSS in your project?",
-        default: (answers: Answers) => answers.cssType === "CSS only",
+        name: "cssPreprocessor",
+        message: "Which CSS preprocessor do you want to use?",
+        choices: ["none", "SASS", "LESS", "Stylus"],
+        default: "none",
       },
       {
         type: "list",
@@ -94,7 +71,6 @@ export default async function reactInitGenerator(plop: NodePlopAPI) {
     actions: function actions(answers: Answers) {
       // setting some default values based on the answers
       const actions: ActionType[] = [];
-      answers.html = true;
       answers.devServer = true;
       switch (answers.langType) {
         case "ES6":
@@ -109,30 +85,26 @@ export default async function reactInitGenerator(plop: NodePlopAPI) {
           devDependencies.push("typescript", "ts-loader", "@types/react", "@types/react-dom");
           break;
       }
-      if (answers.isPostCSS) {
-        devDependencies.push("postcss-loader", "postcss", "autoprefixer");
-      }
-      if (answers.cssType === "none") {
-        answers.isCSS = false;
-        answers.isPostCSS = false;
-      } else {
-        switch (answers.cssType) {
-          case "CSS only":
-            answers.isCSS = true;
-            break;
-          case "SASS":
-            devDependencies.push("sass-loader", "sass");
-            break;
-          case "LESS":
-            devDependencies.push("less-loader", "less");
-            break;
-          case "Stylus":
-            devDependencies.push("stylus-loader", "stylus");
-            break;
-        }
-      }
       if (answers.workboxWebpackPlugin) {
         devDependencies.push("workbox-webpack-plugin");
+      }
+
+      switch (answers.cssPreprocessor) {
+        case "SASS":
+          answers.styleExtension = "scss";
+          devDependencies.push("sass-loader", "sass");
+          break;
+        case "LESS":
+          answers.styleExtension = "less";
+          devDependencies.push("less-loader", "less");
+          break;
+        case "Stylus":
+          answers.styleExtension = "styl";
+          devDependencies.push("stylus-loader", "stylus");
+          break;
+        default:
+          answers.styleExtension = "css";
+          break;
       }
 
       const files: FileRecord[] = [
@@ -173,20 +145,10 @@ export default async function reactInitGenerator(plop: NodePlopAPI) {
           break;
       }
 
-      switch (answers.cssType) {
-        case "CSS only":
-          files.push({ filePath: "./src/styles/global.css", fileType: "text" });
-          break;
-        case "SASS":
-          files.push({ filePath: "./src/styles/global.scss", fileType: "text" });
-          break;
-        case "LESS":
-          files.push({ filePath: "./src/styles/global.less", fileType: "text" });
-          break;
-        case "Stylus":
-          files.push({ filePath: "./src/styles/global.styl", fileType: "text" });
-          break;
-      }
+      files.push({
+        filePath: `./src/styles/global.${answers.styleExtension}`,
+        fileType: "text",
+      });
 
       for (const file of files) {
         actions.push({

--- a/packages/create-webpack-app/src/generators/init/react.ts
+++ b/packages/create-webpack-app/src/generators/init/react.ts
@@ -97,8 +97,9 @@ export default async function reactInitGenerator(plop: NodePlopAPI) {
           );
           break;
         case "Typescript":
-          // ts-loader 9 (its latest) throws on TypeScript 7, so pin what it supports
-          devDependencies.push("typescript@5", "ts-loader", "@types/react", "@types/react-dom");
+          // ts-loader 9 (its latest) throws on TypeScript 7, the native port, so pin
+          // the last release of the JavaScript line it still works with
+          devDependencies.push("typescript@6", "ts-loader", "@types/react", "@types/react-dom");
           break;
       }
       if (answers.workboxWebpackPlugin) {

--- a/packages/create-webpack-app/src/generators/init/react.ts
+++ b/packages/create-webpack-app/src/generators/init/react.ts
@@ -97,7 +97,8 @@ export default async function reactInitGenerator(plop: NodePlopAPI) {
           );
           break;
         case "Typescript":
-          devDependencies.push("typescript", "ts-loader", "@types/react", "@types/react-dom");
+          // ts-loader 9 (its latest) throws on TypeScript 7, so pin what it supports
+          devDependencies.push("typescript@5", "ts-loader", "@types/react", "@types/react-dom");
           break;
       }
       if (answers.workboxWebpackPlugin) {

--- a/packages/create-webpack-app/src/generators/init/svelte.ts
+++ b/packages/create-webpack-app/src/generators/init/svelte.ts
@@ -84,8 +84,9 @@ export default async function svelteInitGenerator(plop: NodePlopAPI) {
           devDependencies.push("babel-loader", "@babel/core", "@babel/preset-env");
           break;
         case "Typescript":
-          // ts-loader 9 (its latest) throws on TypeScript 7, so pin what it supports
-          devDependencies.push("typescript@5", "ts-loader", "@tsconfig/svelte");
+          // ts-loader 9 (its latest) throws on TypeScript 7, the native port, so pin
+          // the last release of the JavaScript line it still works with
+          devDependencies.push("typescript@6", "ts-loader", "@tsconfig/svelte");
           break;
       }
 

--- a/packages/create-webpack-app/src/generators/init/svelte.ts
+++ b/packages/create-webpack-app/src/generators/init/svelte.ts
@@ -3,6 +3,12 @@ import { fileURLToPath } from "node:url";
 import { type DynamicActionsFunction, type NodePlopAPI } from "node-plop";
 import { type ActionType, type Answers, type FileRecord } from "../../types.js";
 
+const STYLE_EXTENSIONS: Record<string, string> = {
+  SASS: "scss",
+  LESS: "less",
+  Stylus: "styl",
+};
+
 export default async function svelteInitGenerator(plop: NodePlopAPI) {
   const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -40,9 +46,18 @@ export default async function svelteInitGenerator(plop: NodePlopAPI) {
       },
       {
         type: "list",
-        name: "cssPreprocessor",
-        message: "Which CSS preprocessor do you want to use?",
-        choices: ["none", "SASS", "LESS", "Stylus"],
+        name: "cssTool",
+        message: "Which CSS tool do you want to use?",
+        choices: [
+          "none",
+          "PostCSS",
+          "SASS",
+          "SASS with PostCSS",
+          "LESS",
+          "LESS with PostCSS",
+          "Stylus",
+          "Stylus with PostCSS",
+        ],
         default: "none",
       },
       {
@@ -77,22 +92,31 @@ export default async function svelteInitGenerator(plop: NodePlopAPI) {
         devDependencies.push("workbox-webpack-plugin");
       }
 
-      switch (answers.cssPreprocessor) {
-        case "SASS":
-          answers.styleExtension = "scss";
-          devDependencies.push("sass-loader", "sass");
-          break;
-        case "LESS":
-          answers.styleExtension = "less";
-          devDependencies.push("less-loader", "less");
-          break;
-        case "Stylus":
-          answers.styleExtension = "styl";
-          devDependencies.push("stylus-loader", "stylus");
-          break;
-        default:
-          answers.styleExtension = "css";
-          break;
+      const cssTool = (answers.cssTool as string | undefined) ?? "none";
+      // PostCSS runs on its own or over a preprocessor, so both are read off the answer
+      const preprocessor = Object.keys(STYLE_EXTENSIONS).find((name) => cssTool.startsWith(name));
+
+      answers.usePostCSS = cssTool.includes("PostCSS");
+      answers.useSASS = preprocessor === "SASS";
+      answers.useLESS = preprocessor === "LESS";
+      answers.useStylus = preprocessor === "Stylus";
+      // The starter stylesheet is written in the language that was picked
+      answers.styleExtension = preprocessor ? STYLE_EXTENSIONS[preprocessor] : "css";
+
+      if (answers.usePostCSS) {
+        devDependencies.push("postcss-loader", "postcss", "autoprefixer");
+      }
+
+      if (answers.useSASS) {
+        devDependencies.push("sass-loader", "sass");
+      }
+
+      if (answers.useLESS) {
+        devDependencies.push("less-loader", "less");
+      }
+
+      if (answers.useStylus) {
+        devDependencies.push("stylus-loader", "stylus");
       }
 
       const files: FileRecord[] = [
@@ -127,6 +151,10 @@ export default async function svelteInitGenerator(plop: NodePlopAPI) {
         files.push({ filePath: "./src/store/index.ts", fileType: "text" });
       } else {
         files.push({ filePath: "./src/store/index.js", fileType: "text" });
+      }
+
+      if (answers.usePostCSS) {
+        files.push({ filePath: "postcss.config.js", fileType: "text" });
       }
 
       files.push({

--- a/packages/create-webpack-app/src/generators/init/svelte.ts
+++ b/packages/create-webpack-app/src/generators/init/svelte.ts
@@ -84,7 +84,8 @@ export default async function svelteInitGenerator(plop: NodePlopAPI) {
           devDependencies.push("babel-loader", "@babel/core", "@babel/preset-env");
           break;
         case "Typescript":
-          devDependencies.push("typescript", "ts-loader", "@tsconfig/svelte");
+          // ts-loader 9 (its latest) throws on TypeScript 7, so pin what it supports
+          devDependencies.push("typescript@5", "ts-loader", "@tsconfig/svelte");
           break;
       }
 

--- a/packages/create-webpack-app/src/generators/init/svelte.ts
+++ b/packages/create-webpack-app/src/generators/init/svelte.ts
@@ -40,33 +40,10 @@ export default async function svelteInitGenerator(plop: NodePlopAPI) {
       },
       {
         type: "list",
-        name: "cssType",
-        message: "Which of the following CSS solution do you want to use?",
-        choices: ["none", "CSS only", "SASS", "LESS", "Stylus"],
-        default: "CSS only",
-        filter: (input: string, answers: Answers) => {
-          if (input === "none") {
-            answers.isCSS = false;
-            answers.isPostCSS = false;
-          } else if (input === "CSS only") {
-            answers.isCSS = true;
-          }
-          return input;
-        },
-      },
-      {
-        type: "confirm",
-        name: "isCSS",
-        message: (answers: Answers) =>
-          `Will you be using CSS styles along with ${answers.cssType} in your project?`,
-        when: (answers: Answers) => answers.cssType !== "CSS only",
-        default: true,
-      },
-      {
-        type: "confirm",
-        name: "isPostCSS",
-        message: "Do you want to use PostCSS in your project?",
-        default: (answers: Answers) => answers.cssType === "CSS only",
+        name: "cssPreprocessor",
+        message: "Which CSS preprocessor do you want to use?",
+        choices: ["none", "SASS", "LESS", "Stylus"],
+        default: "none",
       },
       {
         type: "list",
@@ -85,7 +62,6 @@ export default async function svelteInitGenerator(plop: NodePlopAPI) {
     actions: function actions(answers: Answers) {
       // setting some default values based on the answers
       const actions: ActionType[] = [];
-      answers.html = true;
       answers.devServer = true;
 
       switch (answers.langType) {
@@ -97,32 +73,26 @@ export default async function svelteInitGenerator(plop: NodePlopAPI) {
           break;
       }
 
-      if (answers.isPostCSS) {
-        devDependencies.push("postcss-loader", "postcss", "autoprefixer");
-      }
-
       if (answers.workboxWebpackPlugin) {
         devDependencies.push("workbox-webpack-plugin");
       }
 
-      if (answers.cssType === "none") {
-        answers.isCSS = false;
-        answers.isPostCSS = false;
-      } else {
-        switch (answers.cssType) {
-          case "CSS only":
-            answers.isCSS = true;
-            break;
-          case "SASS":
-            devDependencies.push("sass-loader", "sass");
-            break;
-          case "LESS":
-            devDependencies.push("less-loader", "less");
-            break;
-          case "Stylus":
-            devDependencies.push("stylus-loader", "stylus");
-            break;
-        }
+      switch (answers.cssPreprocessor) {
+        case "SASS":
+          answers.styleExtension = "scss";
+          devDependencies.push("sass-loader", "sass");
+          break;
+        case "LESS":
+          answers.styleExtension = "less";
+          devDependencies.push("less-loader", "less");
+          break;
+        case "Stylus":
+          answers.styleExtension = "styl";
+          devDependencies.push("stylus-loader", "stylus");
+          break;
+        default:
+          answers.styleExtension = "css";
+          break;
       }
 
       const files: FileRecord[] = [
@@ -159,20 +129,10 @@ export default async function svelteInitGenerator(plop: NodePlopAPI) {
         files.push({ filePath: "./src/store/index.js", fileType: "text" });
       }
 
-      switch (answers.cssType) {
-        case "CSS only":
-          files.push({ filePath: "./src/styles/global.css", fileType: "text" });
-          break;
-        case "SASS":
-          files.push({ filePath: "./src/styles/global.scss", fileType: "text" });
-          break;
-        case "LESS":
-          files.push({ filePath: "./src/styles/global.less", fileType: "text" });
-          break;
-        case "Stylus":
-          files.push({ filePath: "./src/styles/global.styl", fileType: "text" });
-          break;
-      }
+      files.push({
+        filePath: `./src/styles/global.${answers.styleExtension}`,
+        fileType: "text",
+      });
 
       for (const file of files) {
         actions.push({

--- a/packages/create-webpack-app/src/generators/init/vue.ts
+++ b/packages/create-webpack-app/src/generators/init/vue.ts
@@ -92,8 +92,9 @@ export default async function vueInitGenerator(plop: NodePlopAPI) {
           devDependencies.push("babel-loader", "@babel/core", "@babel/preset-env");
           break;
         case "Typescript":
-          // ts-loader 9 (its latest) throws on TypeScript 7, so pin what it supports
-          devDependencies.push("typescript@5", "ts-loader");
+          // ts-loader 9 (its latest) throws on TypeScript 7, the native port, so pin
+          // the last release of the JavaScript line it still works with
+          devDependencies.push("typescript@6", "ts-loader");
           break;
       }
 

--- a/packages/create-webpack-app/src/generators/init/vue.ts
+++ b/packages/create-webpack-app/src/generators/init/vue.ts
@@ -48,33 +48,10 @@ export default async function vueInitGenerator(plop: NodePlopAPI) {
       },
       {
         type: "list",
-        name: "cssType",
-        message: "Which of the following CSS solution do you want to use?",
-        choices: ["none", "CSS only", "SASS", "LESS", "Stylus"],
-        default: "CSS only",
-        filter: (input: string, answers: Answers) => {
-          if (input === "none") {
-            answers.isCSS = false;
-            answers.isPostCSS = false;
-          } else if (input === "CSS only") {
-            answers.isCSS = true;
-          }
-          return input;
-        },
-      },
-      {
-        type: "confirm",
-        name: "isCSS",
-        message: (answers: Answers) =>
-          `Will you be using CSS styles along with ${answers.cssType} in your project?`,
-        when: (answers: Answers) => answers.cssType !== "CSS only",
-        default: true,
-      },
-      {
-        type: "confirm",
-        name: "isPostCSS",
-        message: "Do you want to use PostCSS in your project?",
-        default: (answers: Answers) => answers.cssType === "CSS only",
+        name: "cssPreprocessor",
+        message: "Which CSS preprocessor do you want to use?",
+        choices: ["none", "SASS", "LESS", "Stylus"],
+        default: "none",
       },
       {
         type: "list",
@@ -93,7 +70,6 @@ export default async function vueInitGenerator(plop: NodePlopAPI) {
     actions: function actions(answers: Answers) {
       // setting some default values based on the answers
       const actions: ActionType[] = [];
-      answers.html = true;
       answers.devServer = true;
 
       switch (answers.langType) {
@@ -109,32 +85,26 @@ export default async function vueInitGenerator(plop: NodePlopAPI) {
         devDependencies.push("pinia");
       }
 
-      if (answers.isPostCSS) {
-        devDependencies.push("postcss-loader", "postcss", "autoprefixer");
-      }
-
       if (answers.workboxWebpackPlugin) {
         devDependencies.push("workbox-webpack-plugin");
       }
 
-      if (answers.cssType === "none") {
-        answers.isCSS = false;
-        answers.isPostCSS = false;
-      } else {
-        switch (answers.cssType) {
-          case "CSS only":
-            answers.isCSS = true;
-            break;
-          case "SASS":
-            devDependencies.push("sass-loader", "sass");
-            break;
-          case "LESS":
-            devDependencies.push("less-loader", "less");
-            break;
-          case "Stylus":
-            devDependencies.push("stylus-loader", "stylus");
-            break;
-        }
+      switch (answers.cssPreprocessor) {
+        case "SASS":
+          answers.styleExtension = "scss";
+          devDependencies.push("sass-loader", "sass");
+          break;
+        case "LESS":
+          answers.styleExtension = "less";
+          devDependencies.push("less-loader", "less");
+          break;
+        case "Stylus":
+          answers.styleExtension = "styl";
+          devDependencies.push("stylus-loader", "stylus");
+          break;
+        default:
+          answers.styleExtension = "css";
+          break;
       }
 
       const files: FileRecord[] = [
@@ -181,20 +151,10 @@ export default async function vueInitGenerator(plop: NodePlopAPI) {
         }
       }
 
-      switch (answers.cssType) {
-        case "CSS only":
-          files.push({ filePath: "./src/styles/global.css", fileType: "text" });
-          break;
-        case "SASS":
-          files.push({ filePath: "./src/styles/global.scss", fileType: "text" });
-          break;
-        case "LESS":
-          files.push({ filePath: "./src/styles/global.less", fileType: "text" });
-          break;
-        case "Stylus":
-          files.push({ filePath: "./src/styles/global.styl", fileType: "text" });
-          break;
-      }
+      files.push({
+        filePath: `./src/styles/global.${answers.styleExtension}`,
+        fileType: "text",
+      });
 
       for (const file of files) {
         actions.push({

--- a/packages/create-webpack-app/src/generators/init/vue.ts
+++ b/packages/create-webpack-app/src/generators/init/vue.ts
@@ -92,7 +92,8 @@ export default async function vueInitGenerator(plop: NodePlopAPI) {
           devDependencies.push("babel-loader", "@babel/core", "@babel/preset-env");
           break;
         case "Typescript":
-          devDependencies.push("typescript", "ts-loader");
+          // ts-loader 9 (its latest) throws on TypeScript 7, so pin what it supports
+          devDependencies.push("typescript@5", "ts-loader");
           break;
       }
 

--- a/packages/create-webpack-app/src/generators/init/vue.ts
+++ b/packages/create-webpack-app/src/generators/init/vue.ts
@@ -3,6 +3,12 @@ import { fileURLToPath } from "node:url";
 import { type DynamicActionsFunction, type NodePlopAPI } from "node-plop";
 import { type ActionType, type Answers, type FileRecord } from "../../types.js";
 
+const STYLE_EXTENSIONS: Record<string, string> = {
+  SASS: "scss",
+  LESS: "less",
+  Stylus: "styl",
+};
+
 export default async function vueInitGenerator(plop: NodePlopAPI) {
   const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -48,9 +54,18 @@ export default async function vueInitGenerator(plop: NodePlopAPI) {
       },
       {
         type: "list",
-        name: "cssPreprocessor",
-        message: "Which CSS preprocessor do you want to use?",
-        choices: ["none", "SASS", "LESS", "Stylus"],
+        name: "cssTool",
+        message: "Which CSS tool do you want to use?",
+        choices: [
+          "none",
+          "PostCSS",
+          "SASS",
+          "SASS with PostCSS",
+          "LESS",
+          "LESS with PostCSS",
+          "Stylus",
+          "Stylus with PostCSS",
+        ],
         default: "none",
       },
       {
@@ -89,22 +104,31 @@ export default async function vueInitGenerator(plop: NodePlopAPI) {
         devDependencies.push("workbox-webpack-plugin");
       }
 
-      switch (answers.cssPreprocessor) {
-        case "SASS":
-          answers.styleExtension = "scss";
-          devDependencies.push("sass-loader", "sass");
-          break;
-        case "LESS":
-          answers.styleExtension = "less";
-          devDependencies.push("less-loader", "less");
-          break;
-        case "Stylus":
-          answers.styleExtension = "styl";
-          devDependencies.push("stylus-loader", "stylus");
-          break;
-        default:
-          answers.styleExtension = "css";
-          break;
+      const cssTool = (answers.cssTool as string | undefined) ?? "none";
+      // PostCSS runs on its own or over a preprocessor, so both are read off the answer
+      const preprocessor = Object.keys(STYLE_EXTENSIONS).find((name) => cssTool.startsWith(name));
+
+      answers.usePostCSS = cssTool.includes("PostCSS");
+      answers.useSASS = preprocessor === "SASS";
+      answers.useLESS = preprocessor === "LESS";
+      answers.useStylus = preprocessor === "Stylus";
+      // The starter stylesheet is written in the language that was picked
+      answers.styleExtension = preprocessor ? STYLE_EXTENSIONS[preprocessor] : "css";
+
+      if (answers.usePostCSS) {
+        devDependencies.push("postcss-loader", "postcss", "autoprefixer");
+      }
+
+      if (answers.useSASS) {
+        devDependencies.push("sass-loader", "sass");
+      }
+
+      if (answers.useLESS) {
+        devDependencies.push("less-loader", "less");
+      }
+
+      if (answers.useStylus) {
+        devDependencies.push("stylus-loader", "stylus");
       }
 
       const files: FileRecord[] = [
@@ -149,6 +173,10 @@ export default async function vueInitGenerator(plop: NodePlopAPI) {
         } else {
           files.push({ filePath: "./src/store/index.js", fileType: "text" });
         }
+      }
+
+      if (answers.usePostCSS) {
+        files.push({ filePath: "postcss.config.js", fileType: "text" });
       }
 
       files.push({

--- a/packages/create-webpack-app/src/index.ts
+++ b/packages/create-webpack-app/src/index.ts
@@ -18,7 +18,7 @@ const baseAnswers: Answers = {
   langType: "none",
   devServer: true,
   workboxWebpackPlugin: true,
-  cssPreprocessor: "none",
+  cssTool: "none",
   packageManager: "npm",
 };
 const initValues: Record<string, Answers> = {

--- a/packages/create-webpack-app/src/index.ts
+++ b/packages/create-webpack-app/src/index.ts
@@ -19,6 +19,7 @@ const baseAnswers: Answers = {
   devServer: true,
   workboxWebpackPlugin: true,
   cssTool: "none",
+  tsCompiler: "built-in",
   packageManager: "npm",
 };
 const initValues: Record<string, Answers> = {

--- a/packages/create-webpack-app/src/index.ts
+++ b/packages/create-webpack-app/src/index.ts
@@ -17,11 +17,8 @@ const baseAnswers: Answers = {
   projectPath: process.cwd(),
   langType: "none",
   devServer: true,
-  html: true,
   workboxWebpackPlugin: true,
-  cssType: "none",
-  isCSS: false,
-  isPostCSS: false,
+  cssPreprocessor: "none",
   packageManager: "npm",
 };
 const initValues: Record<string, Answers> = {
@@ -32,18 +29,15 @@ const initValues: Record<string, Answers> = {
     ...baseAnswers,
     langType: "ES6",
     useReactState: true,
-    cssType: "CSS only",
   },
   vue: {
     ...baseAnswers,
     langType: "ES6",
     useVueStore: true,
-    cssType: "CSS only",
   },
   svelte: {
     ...baseAnswers,
     langType: "ES6",
-    cssType: "CSS only",
   },
 };
 

--- a/packages/create-webpack-app/templates/init/default/README.md.tpl
+++ b/packages/create-webpack-app/templates/init/default/README.md.tpl
@@ -21,7 +21,8 @@ stylesheet the page references and emits the page as `dist/index.html`, with the
 references rewritten to the generated assets. Both are supported out of the box, so
 no loader or plugin is needed for `.html` and `.css` files.
 
-A preprocessor keeps that support and only adds its own loader, e.g. for Sass:
+Sass, Less, Stylus and PostCSS keep that support and only add their own loader on
+top of it, as a `css/auto` rule:
 
 ```js
 {
@@ -30,3 +31,6 @@ A preprocessor keeps that support and only adds its own loader, e.g. for Sass:
     use: ["sass-loader"],
 }
 ```
+
+They combine, too: webpack applies `use` right to left, so `["postcss-loader",
+"sass-loader"]` compiles the Sass first and runs PostCSS over the result.

--- a/packages/create-webpack-app/templates/init/default/README.md.tpl
+++ b/packages/create-webpack-app/templates/init/default/README.md.tpl
@@ -37,13 +37,19 @@ They combine, too: webpack applies `use` right to left, so `["postcss-loader",
 <% if (langType === "Typescript") { %>
 ## TypeScript
 
-webpack strips the types itself (it needs Node.js >= 22.6), so this project has no
-TypeScript loader. Stripping is erasable syntax only — types, generics, `import type`
-and casts — so `enum`, `namespace`, parameter properties and `.tsx` need a loader such
-as `ts-loader` or `swc-loader` instead.
+<% if (useTsLoader) { %>This project compiles TypeScript with `ts-loader`, which type
+checks as it builds and handles every TypeScript feature, `.tsx` included.
 
-Nothing is type checked during the build. `tsconfig.json` is what your editor reads,
-and:
+webpack can also strip the types itself, with no loader at all — it is faster, but it
+covers erasable syntax only (types, generics, `import type`, casts) and checks nothing.
+Re-run `create-webpack-app` and answer `built-in` to that question to try it.<% } else { %>webpack strips the types itself (it needs Node.js >= 22.6), so this project has no
+TypeScript loader. Stripping is erasable syntax only — types, generics, `import type`
+and casts — so `enum`, `namespace`, parameter properties, decorator metadata and `.tsx`
+need a loader instead: re-run `create-webpack-app` and answer `ts-loader` to that
+question, which also type checks as it builds.<% } %>
+
+<% if (useTsLoader) { %>Either way, `tsconfig.json` is what your editor reads, and:<% } else { %>Nothing is type checked during the build. `tsconfig.json` is what your editor reads,
+and:<% } %>
 
 ```bash
 npm run check:types

--- a/packages/create-webpack-app/templates/init/default/README.md.tpl
+++ b/packages/create-webpack-app/templates/init/default/README.md.tpl
@@ -34,3 +34,20 @@ top of it, as a `css/auto` rule:
 
 They combine, too: webpack applies `use` right to left, so `["postcss-loader",
 "sass-loader"]` compiles the Sass first and runs PostCSS over the result.
+<% if (langType === "Typescript") { %>
+## TypeScript
+
+webpack strips the types itself (it needs Node.js >= 22.6), so this project has no
+TypeScript loader. Stripping is erasable syntax only — types, generics, `import type`
+and casts — so `enum`, `namespace`, parameter properties and `.tsx` need a loader such
+as `ts-loader` or `swc-loader` instead.
+
+Nothing is type checked during the build. `tsconfig.json` is what your editor reads,
+and:
+
+```bash
+npm run check:types
+```
+
+runs `tsc --noEmit` over the project.
+<% } %>

--- a/packages/create-webpack-app/templates/init/default/README.md.tpl
+++ b/packages/create-webpack-app/templates/init/default/README.md.tpl
@@ -13,3 +13,20 @@ yarn build
 ```
 
 to bundle your application
+
+## HTML and CSS
+
+`index.html` is the entry point of this project — webpack bundles every script and
+stylesheet the page references and emits the page as `dist/index.html`, with the
+references rewritten to the generated assets. Both are supported out of the box, so
+no loader or plugin is needed for `.html` and `.css` files.
+
+A preprocessor keeps that support and only adds its own loader, e.g. for Sass:
+
+```js
+{
+    test: /\.s[ac]ss$/i,
+    type: "css/auto",
+    use: ["sass-loader"],
+}
+```

--- a/packages/create-webpack-app/templates/init/default/index.html.tpl
+++ b/packages/create-webpack-app/templates/init/default/index.html.tpl
@@ -3,11 +3,12 @@
     <head>
         <meta charset="utf-8" />
         <title>Webpack App</title>
+        <link rel="stylesheet" href="./src/styles.<%= styleExtension %>" />
+        <script defer src="<%= entryPoint %>"></script>
     </head>
     <body>
         <h1>Hello world!</h1>
-        <h2>Tip: Check your console</h2><% if (html) { %>
-        <script src="<%= entryPoint %>"></script><% } %>
+        <h2>Tip: Check your console</h2>
     </body>
     <% if (workboxWebpackPlugin) { %>
     <script>

--- a/packages/create-webpack-app/templates/init/default/package.json.tpl
+++ b/packages/create-webpack-app/templates/init/default/package.json.tpl
@@ -2,13 +2,17 @@
   "version": "1.0.0",
   "description": "My webpack project",
   "name": "webpack-project",
-  "type": "module",
+  "type": "module",<% if (langType === "Typescript") { %>
+  "engines": {
+    "node": ">=22.6.0"
+  },<% } %>
   "scripts": {
     "build": "webpack --mode=production --config-node-env=production",
     "build:dev": "webpack --mode=development",
     <% if (devServer) { %>
       "serve": "webpack serve",
     <% } %>
-    "watch": "webpack --watch"
+    "watch": "webpack --watch"<% if (langType === "Typescript") { %>,
+    "check:types": "tsc --noEmit"<% } %>
   }
 }

--- a/packages/create-webpack-app/templates/init/default/postcss.config.js.tpl
+++ b/packages/create-webpack-app/templates/init/default/postcss.config.js.tpl
@@ -1,0 +1,5 @@
+export default {
+  // Add your PostCSS configuration here
+  // Learn more about it at https://github.com/webpack-contrib/postcss-loader#config-files
+  plugins: [["autoprefixer"]],
+};

--- a/packages/create-webpack-app/templates/init/default/postcss.config.js.tpl
+++ b/packages/create-webpack-app/templates/init/default/postcss.config.js.tpl
@@ -1,7 +1,0 @@
-import autoprefixer from "autoprefixer";
-
-export default {
-  // Add you postcss configuration here
-  // Learn more about it at https://github.com/webpack-contrib/postcss-loader#config-files
-  plugins: [["autoprefixer"]],
-};

--- a/packages/create-webpack-app/templates/init/default/src/styles.css.tpl
+++ b/packages/create-webpack-app/templates/init/default/src/styles.css.tpl
@@ -1,0 +1,7 @@
+body {
+    margin: 0;
+    padding: 2rem;
+    font-family: system-ui, sans-serif;
+    color: #1c78c0;
+    background-color: #f5f7fa;
+}

--- a/packages/create-webpack-app/templates/init/default/src/styles.less.tpl
+++ b/packages/create-webpack-app/templates/init/default/src/styles.less.tpl
@@ -1,0 +1,10 @@
+@color-primary: #1c78c0;
+@color-background: #f5f7fa;
+
+body {
+    margin: 0;
+    padding: 2rem;
+    font-family: system-ui, sans-serif;
+    color: @color-primary;
+    background-color: @color-background;
+}

--- a/packages/create-webpack-app/templates/init/default/src/styles.scss.tpl
+++ b/packages/create-webpack-app/templates/init/default/src/styles.scss.tpl
@@ -1,0 +1,10 @@
+$color-primary: #1c78c0;
+$color-background: #f5f7fa;
+
+body {
+    margin: 0;
+    padding: 2rem;
+    font-family: system-ui, sans-serif;
+    color: $color-primary;
+    background-color: $color-background;
+}

--- a/packages/create-webpack-app/templates/init/default/src/styles.styl.tpl
+++ b/packages/create-webpack-app/templates/init/default/src/styles.styl.tpl
@@ -1,0 +1,9 @@
+color-primary = #1c78c0
+color-background = #f5f7fa
+
+body
+    margin 0
+    padding 2rem
+    font-family system-ui, sans-serif
+    color color-primary
+    background-color color-background

--- a/packages/create-webpack-app/templates/init/default/tsconfig.json.tpl
+++ b/packages/create-webpack-app/templates/init/default/tsconfig.json.tpl
@@ -11,7 +11,6 @@
     "verbatimModuleSyntax": true,
     "erasableSyntaxOnly": true,
     "isolatedModules": true,
-    "noEmit": true,
     "rewriteRelativeImportExtensions": true
   },
   "include": ["./src/**/*"],

--- a/packages/create-webpack-app/templates/init/default/tsconfig.json.tpl
+++ b/packages/create-webpack-app/templates/init/default/tsconfig.json.tpl
@@ -11,6 +11,7 @@
     "verbatimModuleSyntax": true,
     "erasableSyntaxOnly": true,
     "isolatedModules": true,
+    "noEmit": true,
     "rewriteRelativeImportExtensions": true
   },
   "include": ["./src/**/*"],

--- a/packages/create-webpack-app/templates/init/default/webpack.config.tpl
+++ b/packages/create-webpack-app/templates/init/default/webpack.config.tpl
@@ -12,15 +12,14 @@ const isProduction = process.env.NODE_ENV === "production";
 
 /** @type {import("webpack").Configuration} */
 const config <% if (langType === "Typescript") { %>: Configuration <% } %>= {
-    entry: <% if (html) { %>"./index.html"<% } else { %>"<%= entryPoint %>"<% } %>,
+    // The page itself is the entry: webpack bundles the scripts and stylesheets
+    // it references and emits it as `dist/index.html`.
+    entry: { index: "./index.html" },
     output: {
         path: path.resolve(__dirname, "dist"),
     },<% if (devServer) { %>
     devServer: {
         open: true,
-    },<% } %><% if (isCSS && isPostCSS) { %>
-    experiments: {
-        css: true,
     },<% } %>
     plugins: [
         // Add your plugins here
@@ -36,26 +35,21 @@ const config <% if (langType === "Typescript") { %>: Configuration <% } %>= {
                 test: /\.(ts|tsx)$/i,
                 loader: "ts-loader",
                 exclude: ["/node_modules/"],
-            },<% } %><%  if (isCSS && isPostCSS) { %>
-            {
-                test: /\.css$/i,
-                type: "css/auto",
-                use: ["postcss-loader"],
-            },<% } %><%  if (cssType == "SASS") { %>
+            },<% } %><%  if (cssPreprocessor == "SASS") { %>
             {
                 test: /\.s[ac]ss$/i,
                 type: "css/auto",
-                use: [<% if (isPostCSS) { %>"postcss-loader", <% } %>"sass-loader"],
-            },<% } %><%  if (cssType == "LESS") { %>
+                use: ["sass-loader"],
+            },<% } %><%  if (cssPreprocessor == "LESS") { %>
             {
                 test: /\.less$/i,
                 type: "css/auto",
-                use: [<% if (isPostCSS) { %>"postcss-loader", <% } %>"less-loader"],
-            },<% } %><%  if (cssType == "Stylus") { %>
+                use: ["less-loader"],
+            },<% } %><%  if (cssPreprocessor == "Stylus") { %>
             {
                 test: /\.styl$/i,
                 type: "css/auto",
-                use: [<% if (isPostCSS) { %>"postcss-loader", <% } %>"stylus-loader"],
+                use: ["stylus-loader"],
             },<% } %>
             {
                 test: /\.(eot|svg|ttf|woff|woff2|png|jpg|gif)$/i,

--- a/packages/create-webpack-app/templates/init/default/webpack.config.tpl
+++ b/packages/create-webpack-app/templates/init/default/webpack.config.tpl
@@ -31,7 +31,12 @@ const config <% if (langType === "Typescript") { %>: Configuration <% } %>= {
         // Learn more about plugins from https://webpack.js.org/configuration/plugins/
     ],
     module: {
-        rules: [<% if (langType == "ES6") { %>
+        rules: [<% if (useTsLoader) { %>
+            {
+                test: /\.(ts|tsx)$/i,
+                loader: "ts-loader",
+                exclude: ["/node_modules/"],
+            },<% } %><% if (langType == "ES6") { %>
             {
                 test: /\.(js|jsx)$/i,
                 loader: "babel-loader",
@@ -61,7 +66,7 @@ const config <% if (langType === "Typescript") { %>: Configuration <% } %>= {
                 type: "asset",
             },
 
-            // HTML, CSS<% if (langType == "Typescript") { %> and TypeScript<% } %> need no loader — webpack supports them out of the box
+            // HTML, CSS<% if (langType == "Typescript" && !useTsLoader) { %> and TypeScript<% } %> need no loader — webpack supports them out of the box
             // Add your rules for custom modules here
             // Learn more about loaders from https://webpack.js.org/loaders/
         ],

--- a/packages/create-webpack-app/templates/init/default/webpack.config.tpl
+++ b/packages/create-webpack-app/templates/init/default/webpack.config.tpl
@@ -20,6 +20,11 @@ const config <% if (langType === "Typescript") { %>: Configuration <% } %>= {
     },<% if (devServer) { %>
     devServer: {
         open: true,
+    },<% } %><% if (usePostCSS) { %>
+    // The PostCSS rule registers a loader for `.css`, which turns off the
+    // automatic detection of webpack's built-in CSS support — ask for it
+    experiments: {
+        css: true,
     },<% } %>
     plugins: [
         // Add your plugins here
@@ -35,21 +40,26 @@ const config <% if (langType === "Typescript") { %>: Configuration <% } %>= {
                 test: /\.(ts|tsx)$/i,
                 loader: "ts-loader",
                 exclude: ["/node_modules/"],
-            },<% } %><%  if (cssPreprocessor == "SASS") { %>
+            },<% } %><%  if (usePostCSS) { %>
+            {
+                test: /\.css$/i,
+                type: "css/auto",
+                use: ["postcss-loader"],
+            },<% } %><%  if (useSASS) { %>
             {
                 test: /\.s[ac]ss$/i,
                 type: "css/auto",
-                use: ["sass-loader"],
-            },<% } %><%  if (cssPreprocessor == "LESS") { %>
+                use: [<% if (usePostCSS) { %>"postcss-loader", <% } %>"sass-loader"],
+            },<% } %><%  if (useLESS) { %>
             {
                 test: /\.less$/i,
                 type: "css/auto",
-                use: ["less-loader"],
-            },<% } %><%  if (cssPreprocessor == "Stylus") { %>
+                use: [<% if (usePostCSS) { %>"postcss-loader", <% } %>"less-loader"],
+            },<% } %><%  if (useStylus) { %>
             {
                 test: /\.styl$/i,
                 type: "css/auto",
-                use: ["stylus-loader"],
+                use: [<% if (usePostCSS) { %>"postcss-loader", <% } %>"stylus-loader"],
             },<% } %>
             {
                 test: /\.(eot|svg|ttf|woff|woff2|png|jpg|gif)$/i,

--- a/packages/create-webpack-app/templates/init/default/webpack.config.tpl
+++ b/packages/create-webpack-app/templates/init/default/webpack.config.tpl
@@ -35,11 +35,6 @@ const config <% if (langType === "Typescript") { %>: Configuration <% } %>= {
             {
                 test: /\.(js|jsx)$/i,
                 loader: "babel-loader",
-            },<% } %><% if (langType == "Typescript") { %>
-            {
-                test: /\.(ts|tsx)$/i,
-                loader: "ts-loader",
-                exclude: ["/node_modules/"],
             },<% } %><%  if (usePostCSS) { %>
             {
                 test: /\.css$/i,
@@ -66,6 +61,7 @@ const config <% if (langType === "Typescript") { %>: Configuration <% } %>= {
                 type: "asset",
             },
 
+            // HTML, CSS<% if (langType == "Typescript") { %> and TypeScript<% } %> need no loader — webpack supports them out of the box
             // Add your rules for custom modules here
             // Learn more about loaders from https://webpack.js.org/loaders/
         ],

--- a/packages/create-webpack-app/templates/init/react/README.md.tpl
+++ b/packages/create-webpack-app/templates/init/react/README.md.tpl
@@ -13,3 +13,10 @@ yarn build
 ```
 
 to bundle your application
+
+## HTML and CSS
+
+`index.html` is the entry point of this project — webpack bundles every script and
+stylesheet the page references and emits the page as `dist/index.html`, with the
+references rewritten to the generated assets. Both are supported out of the box, so
+no loader or plugin is needed for `.html` and `.css` files.

--- a/packages/create-webpack-app/templates/init/react/index.d.ts.tpl
+++ b/packages/create-webpack-app/templates/init/react/index.d.ts.tpl
@@ -1,3 +1,7 @@
+declare module "*.css";
+declare module "*.scss";
+declare module "*.less";
+declare module "*.styl";
 declare module "*.png";
 declare module "*.jpg";
 declare module "*.gif";

--- a/packages/create-webpack-app/templates/init/react/postcss.config.js.tpl
+++ b/packages/create-webpack-app/templates/init/react/postcss.config.js.tpl
@@ -1,0 +1,5 @@
+export default {
+  // Add your PostCSS configuration here
+  // Learn more about it at https://github.com/webpack-contrib/postcss-loader#config-files
+  plugins: [["autoprefixer"]],
+};

--- a/packages/create-webpack-app/templates/init/react/src/index.jsx.tpl
+++ b/packages/create-webpack-app/templates/init/react/src/index.jsx.tpl
@@ -1,11 +1,7 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
-<%  if (cssType == 'CSS only') { %>
-import "./styles/global.css";<% } if (cssType == 'SASS') { %>
-import "./styles/global.scss";<% } if (cssType == 'LESS') { %>
-import "./styles/global.less";<% } if (cssType == 'Stylus') { %>
-import "./styles/global.styl";<% } %>
+import "./styles/global.<%= styleExtension %>";
 
 const container = document.getElementById('root');
 const root = createRoot(container);

--- a/packages/create-webpack-app/templates/init/react/src/index.tsx.tpl
+++ b/packages/create-webpack-app/templates/init/react/src/index.tsx.tpl
@@ -1,11 +1,7 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
-<%  if (cssType == 'CSS only') { %>
-import "./styles/global.css";<% } if (cssType == 'SASS') { %>
-import "./styles/global.scss";<% } if (cssType == 'LESS') { %>
-import "./styles/global.less";<% } if (cssType == 'Stylus') { %>
-import "./styles/global.styl";<% } %>
+import "./styles/global.<%= styleExtension %>";
 
 const container = document.getElementById('root') as HTMLElement;
 const root = createRoot(container);

--- a/packages/create-webpack-app/templates/init/react/webpack.config.tpl
+++ b/packages/create-webpack-app/templates/init/react/webpack.config.tpl
@@ -20,6 +20,11 @@ const config <% if (langType === "Typescript") { %>: Configuration <% } %>= {
     },<% if (devServer) { %>
     devServer: {
         open: true,
+    },<% } %><% if (usePostCSS) { %>
+    // The PostCSS rule registers a loader for `.css`, which turns off the
+    // automatic detection of webpack's built-in CSS support — ask for it
+    experiments: {
+        css: true,
     },<% } %>
     plugins: [
         // Add your plugins here
@@ -41,21 +46,26 @@ const config <% if (langType === "Typescript") { %>: Configuration <% } %>= {
                 test: /\.(ts|tsx)$/i,
                 loader: "ts-loader",
                 exclude: ["/node_modules/"],
-            },<% } %><%  if (cssPreprocessor == "SASS") { %>
+            },<% } %><%  if (usePostCSS) { %>
+            {
+                test: /\.css$/i,
+                type: "css/auto",
+                use: ["postcss-loader"],
+            },<% } %><%  if (useSASS) { %>
             {
                 test: /\.s[ac]ss$/i,
                 type: "css/auto",
-                use: ["sass-loader"],
-            },<% } %><%  if (cssPreprocessor == "LESS") { %>
+                use: [<% if (usePostCSS) { %>"postcss-loader", <% } %>"sass-loader"],
+            },<% } %><%  if (useLESS) { %>
             {
                 test: /\.less$/i,
                 type: "css/auto",
-                use: ["less-loader"],
-            },<% } %><%  if (cssPreprocessor == "Stylus") { %>
+                use: [<% if (usePostCSS) { %>"postcss-loader", <% } %>"less-loader"],
+            },<% } %><%  if (useStylus) { %>
             {
                 test: /\.styl$/i,
                 type: "css/auto",
-                use: ["stylus-loader"],
+                use: [<% if (usePostCSS) { %>"postcss-loader", <% } %>"stylus-loader"],
             },<% } %>
             {
                 test: /\.(eot|svg|ttf|woff|woff2|png|jpg|gif)$/i,

--- a/packages/create-webpack-app/templates/init/react/webpack.config.tpl
+++ b/packages/create-webpack-app/templates/init/react/webpack.config.tpl
@@ -72,6 +72,7 @@ const config <% if (langType === "Typescript") { %>: Configuration <% } %>= {
                 type: "asset",
             },
 
+            // HTML and CSS need no loader — webpack supports them out of the box
             // Add your rules for custom modules here
             // Learn more about loaders from https://webpack.js.org/loaders/
         ],

--- a/packages/create-webpack-app/templates/init/react/webpack.config.tpl
+++ b/packages/create-webpack-app/templates/init/react/webpack.config.tpl
@@ -12,15 +12,14 @@ const isProduction = process.env.NODE_ENV === "production";
 
 /** @type {import("webpack").Configuration} */
 const config <% if (langType === "Typescript") { %>: Configuration <% } %>= {
-    entry: <% if (html) { %>"./index.html"<% } else { %>"<%= entry %>"<% } %>,
+    // The page itself is the entry: webpack bundles the scripts and stylesheets
+    // it references and emits it as `dist/index.html`.
+    entry: { index: "./index.html" },
     output: {
         path: path.resolve(__dirname, "dist"),
     },<% if (devServer) { %>
     devServer: {
         open: true,
-    },<% } %><% if (isCSS && isPostCSS) { %>
-    experiments: {
-        css: true,
     },<% } %>
     plugins: [
         // Add your plugins here
@@ -42,26 +41,21 @@ const config <% if (langType === "Typescript") { %>: Configuration <% } %>= {
                 test: /\.(ts|tsx)$/i,
                 loader: "ts-loader",
                 exclude: ["/node_modules/"],
-            },<% } %><%  if (isCSS && isPostCSS) { %>
-            {
-                test: /\.css$/i,
-                type: "css/auto",
-                use: ["postcss-loader"],
-            },<% } %><%  if (cssType == "SASS") { %>
+            },<% } %><%  if (cssPreprocessor == "SASS") { %>
             {
                 test: /\.s[ac]ss$/i,
                 type: "css/auto",
-                use: [<% if (isPostCSS) { %>"postcss-loader", <% } %>"sass-loader"],
-            },<% } %><%  if (cssType == "LESS") { %>
+                use: ["sass-loader"],
+            },<% } %><%  if (cssPreprocessor == "LESS") { %>
             {
                 test: /\.less$/i,
                 type: "css/auto",
-                use: [<% if (isPostCSS) { %>"postcss-loader", <% } %>"less-loader"],
-            },<% } %><%  if (cssType == "Stylus") { %>
+                use: ["less-loader"],
+            },<% } %><%  if (cssPreprocessor == "Stylus") { %>
             {
                 test: /\.styl$/i,
                 type: "css/auto",
-                use: [<% if (isPostCSS) { %>"postcss-loader", <% } %>"stylus-loader"],
+                use: ["stylus-loader"],
             },<% } %>
             {
                 test: /\.(eot|svg|ttf|woff|woff2|png|jpg|gif)$/i,

--- a/packages/create-webpack-app/templates/init/svelte/README.md.tpl
+++ b/packages/create-webpack-app/templates/init/svelte/README.md.tpl
@@ -13,3 +13,10 @@ yarn build
 ```
 
 to bundle your application
+
+## HTML and CSS
+
+`index.html` is the entry point of this project — webpack bundles every script and
+stylesheet the page references and emits the page as `dist/index.html`, with the
+references rewritten to the generated assets. Both are supported out of the box, so
+no loader or plugin is needed for `.html` and `.css` files.

--- a/packages/create-webpack-app/templates/init/svelte/postcss.config.js.tpl
+++ b/packages/create-webpack-app/templates/init/svelte/postcss.config.js.tpl
@@ -1,0 +1,5 @@
+export default {
+  // Add your PostCSS configuration here
+  // Learn more about it at https://github.com/webpack-contrib/postcss-loader#config-files
+  plugins: [["autoprefixer"]],
+};

--- a/packages/create-webpack-app/templates/init/svelte/src/App.svelte.tpl
+++ b/packages/create-webpack-app/templates/init/svelte/src/App.svelte.tpl
@@ -15,7 +15,6 @@
   </div>
 </main>
 
-<% if (isCSS) { %>
 <style>
   :root {
     --color-primary: #1C78C0;
@@ -46,4 +45,3 @@
     background-color: #6EB8E0;
   }
 </style>
-<% } %>

--- a/packages/create-webpack-app/templates/init/svelte/src/index.d.ts.tpl
+++ b/packages/create-webpack-app/templates/init/svelte/src/index.d.ts.tpl
@@ -1,3 +1,8 @@
 declare module '*.svelte' {
     export { SvelteComponentDev as default } from 'svelte/internal';
 }
+
+declare module '*.css';
+declare module '*.scss';
+declare module '*.less';
+declare module '*.styl';

--- a/packages/create-webpack-app/templates/init/svelte/src/main.js.tpl
+++ b/packages/create-webpack-app/templates/init/svelte/src/main.js.tpl
@@ -1,13 +1,10 @@
+import { mount } from 'svelte';
 import App from './App.svelte';
 
-<%  if (cssType == 'CSS only') { %>
-import "./styles/global.css";<% } if (cssType == 'SASS') { %>
-import "./styles/global.scss";<% } if (cssType == 'LESS') { %>
-import "./styles/global.less";<% } if (cssType == 'Stylus') { %>
-import "./styles/global.styl";<% } %>
+import "./styles/global.<%= styleExtension %>";
 
 
-const app = new App({
+const app = mount(App, {
   target: document.getElementById('app'),
 });
 

--- a/packages/create-webpack-app/templates/init/svelte/src/main.ts.tpl
+++ b/packages/create-webpack-app/templates/init/svelte/src/main.ts.tpl
@@ -1,14 +1,11 @@
+import { mount } from 'svelte';
 import App from './App.svelte';
 
-<%  if (cssType == 'CSS only') { %>
-import "./styles/global.css";<% } if (cssType == 'SASS') { %>
-import "./styles/global.scss";<% } if (cssType == 'LESS') { %>
-import "./styles/global.less";<% } if (cssType == 'Stylus') { %>
-import "./styles/global.styl";<% } %>
+import "./styles/global.<%= styleExtension %>";
 
 
-const app = new App({
-  target: document.getElementById('app'),
+const app = mount(App, {
+  target: document.getElementById('app') as HTMLElement,
 });
 
 export default app;

--- a/packages/create-webpack-app/templates/init/svelte/webpack.config.tpl
+++ b/packages/create-webpack-app/templates/init/svelte/webpack.config.tpl
@@ -12,15 +12,14 @@ const isProduction = process.env.NODE_ENV === "production";
 
 /** @type {import("webpack").Configuration} */
 const config <% if (langType === "Typescript") { %>: Configuration <% } %>= {
-    entry: <% if (html) { %>"./index.html"<% } else { %>"<%= entry %>"<% } %>,
+    // The page itself is the entry: webpack bundles the scripts and stylesheets
+    // it references and emits it as `dist/index.html`.
+    entry: { index: "./index.html" },
     output: {
         path: path.resolve(__dirname, "dist"),
     },<% if (devServer) { %>
     devServer: {
         open: true,
-    },<% } %><% if (isCSS && isPostCSS) { %>
-    experiments: {
-        css: true,
     },<% } %>
     plugins: [
         // Add your plugins here
@@ -55,26 +54,21 @@ const config <% if (langType === "Typescript") { %>: Configuration <% } %>= {
                 options: {
                     appendTsSuffixTo: [/\.svelte$/],
                 },
-            },<% } %><%  if (isCSS && isPostCSS) { %>
-            {
-                test: /\.css$/i,
-                type: "css/auto",
-                use: ["postcss-loader"],
-            },<% } %><%  if (cssType == "SASS") { %>
+            },<% } %><%  if (cssPreprocessor == "SASS") { %>
             {
                 test: /\.s[ac]ss$/i,
                 type: "css/auto",
-                use: [<% if (isPostCSS) { %>"postcss-loader", <% } %>"sass-loader"],
-            },<% } %><%  if (cssType == "LESS") { %>
+                use: ["sass-loader"],
+            },<% } %><%  if (cssPreprocessor == "LESS") { %>
             {
                 test: /\.less$/i,
                 type: "css/auto",
-                use: [<% if (isPostCSS) { %>"postcss-loader", <% } %>"less-loader"],
-            },<% } %><%  if (cssType == "Stylus") { %>
+                use: ["less-loader"],
+            },<% } %><%  if (cssPreprocessor == "Stylus") { %>
             {
                 test: /\.styl$/i,
                 type: "css/auto",
-                use: [<% if (isPostCSS) { %>"postcss-loader", <% } %>"stylus-loader"],
+                use: ["stylus-loader"],
             },<% } %>
             {
                 test: /\.(eot|svg|ttf|woff|woff2|png|jpg|gif)$/i,

--- a/packages/create-webpack-app/templates/init/svelte/webpack.config.tpl
+++ b/packages/create-webpack-app/templates/init/svelte/webpack.config.tpl
@@ -20,6 +20,11 @@ const config <% if (langType === "Typescript") { %>: Configuration <% } %>= {
     },<% if (devServer) { %>
     devServer: {
         open: true,
+    },<% } %><% if (usePostCSS) { %>
+    // The PostCSS rule registers a loader for `.css`, which turns off the
+    // automatic detection of webpack's built-in CSS support — ask for it
+    experiments: {
+        css: true,
     },<% } %>
     plugins: [
         // Add your plugins here
@@ -54,21 +59,26 @@ const config <% if (langType === "Typescript") { %>: Configuration <% } %>= {
                 options: {
                     appendTsSuffixTo: [/\.svelte$/],
                 },
-            },<% } %><%  if (cssPreprocessor == "SASS") { %>
+            },<% } %><%  if (usePostCSS) { %>
+            {
+                test: /\.css$/i,
+                type: "css/auto",
+                use: ["postcss-loader"],
+            },<% } %><%  if (useSASS) { %>
             {
                 test: /\.s[ac]ss$/i,
                 type: "css/auto",
-                use: ["sass-loader"],
-            },<% } %><%  if (cssPreprocessor == "LESS") { %>
+                use: [<% if (usePostCSS) { %>"postcss-loader", <% } %>"sass-loader"],
+            },<% } %><%  if (useLESS) { %>
             {
                 test: /\.less$/i,
                 type: "css/auto",
-                use: ["less-loader"],
-            },<% } %><%  if (cssPreprocessor == "Stylus") { %>
+                use: [<% if (usePostCSS) { %>"postcss-loader", <% } %>"less-loader"],
+            },<% } %><%  if (useStylus) { %>
             {
                 test: /\.styl$/i,
                 type: "css/auto",
-                use: ["stylus-loader"],
+                use: [<% if (usePostCSS) { %>"postcss-loader", <% } %>"stylus-loader"],
             },<% } %>
             {
                 test: /\.(eot|svg|ttf|woff|woff2|png|jpg|gif)$/i,

--- a/packages/create-webpack-app/templates/init/svelte/webpack.config.tpl
+++ b/packages/create-webpack-app/templates/init/svelte/webpack.config.tpl
@@ -84,6 +84,7 @@ const config <% if (langType === "Typescript") { %>: Configuration <% } %>= {
                 test: /\.(eot|svg|ttf|woff|woff2|png|jpg|gif)$/i,
                 type: "asset",
             },
+            // HTML and CSS need no loader — webpack supports them out of the box
             // Add your rules for custom modules here
             // Learn more about loaders from https://webpack.js.org/loaders/
         ],

--- a/packages/create-webpack-app/templates/init/vue/README.md.tpl
+++ b/packages/create-webpack-app/templates/init/vue/README.md.tpl
@@ -13,3 +13,10 @@ yarn build
 ```
 
 to bundle your application
+
+## HTML and CSS
+
+`index.html` is the entry point of this project — webpack bundles every script and
+stylesheet the page references and emits the page as `dist/index.html`, with the
+references rewritten to the generated assets. Both are supported out of the box, so
+no loader or plugin is needed for `.html` and `.css` files.

--- a/packages/create-webpack-app/templates/init/vue/postcss.config.js.tpl
+++ b/packages/create-webpack-app/templates/init/vue/postcss.config.js.tpl
@@ -1,0 +1,5 @@
+export default {
+  // Add your PostCSS configuration here
+  // Learn more about it at https://github.com/webpack-contrib/postcss-loader#config-files
+  plugins: [["autoprefixer"]],
+};

--- a/packages/create-webpack-app/templates/init/vue/src/main.js.tpl
+++ b/packages/create-webpack-app/templates/init/vue/src/main.js.tpl
@@ -1,15 +1,11 @@
 import { createApp } from 'vue'
 import App from './App.vue'
-import router from './router'
+import router from './router/index.js'
 <% if (useVueStore) { %>
   import { createPinia } from 'pinia'
   const store = createPinia()
 <% } %>
-<%  if (cssType == 'CSS only') { %>
-import "./styles/global.css";<% } if (cssType == 'SASS') { %>
-import "./styles/global.scss";<% } if (cssType == 'LESS') { %>
-import "./styles/global.less";<% } if (cssType == 'Stylus') { %>
-import "./styles/global.styl";<% } %>
+import "./styles/global.<%= styleExtension %>";
 
 
 const app = createApp(App)

--- a/packages/create-webpack-app/templates/init/vue/src/main.ts.tpl
+++ b/packages/create-webpack-app/templates/init/vue/src/main.ts.tpl
@@ -5,11 +5,7 @@ import router from './router'
   import { createPinia } from 'pinia'
   const store = createPinia()
 <% } %>
-<%  if (cssType == 'CSS only') { %>
-import "./styles/global.css";<% } if (cssType == 'SASS') { %>
-import "./styles/global.scss";<% } if (cssType == 'LESS') { %>
-import "./styles/global.less";<% } if (cssType == 'Stylus') { %>
-import "./styles/global.styl";<% } %>
+import "./styles/global.<%= styleExtension %>";
 
 
 const app = createApp(App)

--- a/packages/create-webpack-app/templates/init/vue/tsconfig.json.tpl
+++ b/packages/create-webpack-app/templates/init/vue/tsconfig.json.tpl
@@ -14,6 +14,7 @@
     "erasableSyntaxOnly": true,
     "isolatedModules": true,
     "rewriteRelativeImportExtensions": true,
+    "baseUrl": ".",
     "types": [
       "webpack-env",
       "vue-router"

--- a/packages/create-webpack-app/templates/init/vue/tsconfig.json.tpl
+++ b/packages/create-webpack-app/templates/init/vue/tsconfig.json.tpl
@@ -14,14 +14,13 @@
     "erasableSyntaxOnly": true,
     "isolatedModules": true,
     "rewriteRelativeImportExtensions": true,
-    "baseUrl": ".",
     "types": [
       "webpack-env",
       "vue-router"
     ],
     "paths": {
       "@/*": [
-        "src/*"
+        "./src/*"
       ]
     },
     "lib": [

--- a/packages/create-webpack-app/templates/init/vue/webpack.config.tpl
+++ b/packages/create-webpack-app/templates/init/vue/webpack.config.tpl
@@ -60,21 +60,26 @@ const config <% if (langType === "Typescript") { %>: Configuration <% } %>= {
                     transpileOnly: true,
                 },
                 exclude: ["/node_modules/"],
-            },<% } %><%  if (cssPreprocessor == "SASS") { %>
+            },<% } %><%  if (usePostCSS) { %>
+            {
+                test: /\.css$/i,
+                type: "css/auto",
+                use: ["postcss-loader"],
+            },<% } %><%  if (useSASS) { %>
             {
                 test: /\.s[ac]ss$/i,
                 type: "css/auto",
-                use: ["sass-loader"],
-            },<% } %><%  if (cssPreprocessor == "LESS") { %>
+                use: [<% if (usePostCSS) { %>"postcss-loader", <% } %>"sass-loader"],
+            },<% } %><%  if (useLESS) { %>
             {
                 test: /\.less$/i,
                 type: "css/auto",
-                use: ["less-loader"],
-            },<% } %><%  if (cssPreprocessor == "Stylus") { %>
+                use: [<% if (usePostCSS) { %>"postcss-loader", <% } %>"less-loader"],
+            },<% } %><%  if (useStylus) { %>
             {
                 test: /\.styl$/i,
                 type: "css/auto",
-                use: ["stylus-loader"],
+                use: [<% if (usePostCSS) { %>"postcss-loader", <% } %>"stylus-loader"],
             },<% } %>
             {
                 test: /\.(eot|svg|ttf|woff|woff2|png|jpg|gif)$/i,

--- a/packages/create-webpack-app/templates/init/vue/webpack.config.tpl
+++ b/packages/create-webpack-app/templates/init/vue/webpack.config.tpl
@@ -13,16 +13,20 @@ const isProduction = process.env.NODE_ENV === "production";
 
 /** @type {import("webpack").Configuration} */
 const config <% if (langType === "Typescript") { %>: Configuration <% } %>= {
-    entry: <% if (html) { %>"./index.html"<% } else { %>"<%= entry %>"<% } %>,
+    // The page itself is the entry: webpack bundles the scripts and stylesheets
+    // it references and emits it as `dist/index.html`.
+    entry: { index: "./index.html" },
     output: {
         path: path.resolve(__dirname, "dist"),
     },<% if (devServer) { %>
     devServer: {
         open: true,
     },<% } %>
+    // vue-loader rewrites `module.rules`, which hides from webpack that no rule
+    // handles `.html`/`.css` — so ask for the built-in support explicitly
     experiments: {
-        css: true,<% if (html) { %>
-        html: true,<% } %>
+        css: true,
+        html: true,
     },
     plugins: [
         new VueLoaderPlugin(),
@@ -56,26 +60,21 @@ const config <% if (langType === "Typescript") { %>: Configuration <% } %>= {
                     transpileOnly: true,
                 },
                 exclude: ["/node_modules/"],
-            },<% } %><%  if (isCSS && isPostCSS) { %>
-            {
-                test: /\.css$/i,
-                type: "css/auto",
-                use: ["postcss-loader"],
-            },<% } %><%  if (cssType == "SASS") { %>
+            },<% } %><%  if (cssPreprocessor == "SASS") { %>
             {
                 test: /\.s[ac]ss$/i,
                 type: "css/auto",
-                use: [<% if (isPostCSS) { %>"postcss-loader", <% } %>"sass-loader"],
-            },<% } %><%  if (cssType == "LESS") { %>
+                use: ["sass-loader"],
+            },<% } %><%  if (cssPreprocessor == "LESS") { %>
             {
                 test: /\.less$/i,
                 type: "css/auto",
-                use: [<% if (isPostCSS) { %>"postcss-loader", <% } %>"less-loader"],
-            },<% } %><%  if (cssType == "Stylus") { %>
+                use: ["less-loader"],
+            },<% } %><%  if (cssPreprocessor == "Stylus") { %>
             {
                 test: /\.styl$/i,
                 type: "css/auto",
-                use: [<% if (isPostCSS) { %>"postcss-loader", <% } %>"stylus-loader"],
+                use: ["stylus-loader"],
             },<% } %>
             {
                 test: /\.(eot|svg|ttf|woff|woff2|png|jpg|gif)$/i,

--- a/packages/create-webpack-app/templates/init/vue/webpack.config.tpl
+++ b/packages/create-webpack-app/templates/init/vue/webpack.config.tpl
@@ -85,6 +85,7 @@ const config <% if (langType === "Typescript") { %>: Configuration <% } %>= {
                 test: /\.(eot|svg|ttf|woff|woff2|png|jpg|gif)$/i,
                 type: "asset",
             },
+            // HTML and CSS need no loader — webpack supports them out of the box
             // Add your rules for custom modules here
             // Learn more about loaders from https://webpack.js.org/loaders/
         ],

--- a/test/create-webpack-app/init/__snapshots__/init.test.js.snap.webpack5
+++ b/test/create-webpack-app/init/__snapshots__/init.test.js.snap.webpack5
@@ -109,6 +109,7 @@ const config = {
                 type: "asset",
             },
 
+            // HTML, CSS need no loader — webpack supports them out of the box
             // Add your rules for custom modules here
             // Learn more about loaders from https://webpack.js.org/loaders/
         ],
@@ -178,6 +179,7 @@ const config = {
                 type: "asset",
             },
 
+            // HTML, CSS need no loader — webpack supports them out of the box
             // Add your rules for custom modules here
             // Learn more about loaders from https://webpack.js.org/loaders/
         ],
@@ -244,6 +246,7 @@ const config = {
                 type: "asset",
             },
 
+            // HTML, CSS need no loader — webpack supports them out of the box
             // Add your rules for custom modules here
             // Learn more about loaders from https://webpack.js.org/loaders/
         ],
@@ -316,6 +319,7 @@ const config = {
                 type: "asset",
             },
 
+            // HTML, CSS need no loader — webpack supports them out of the box
             // Add your rules for custom modules here
             // Learn more about loaders from https://webpack.js.org/loaders/
         ],
@@ -387,6 +391,7 @@ const config = {
                 type: "asset",
             },
 
+            // HTML, CSS need no loader — webpack supports them out of the box
             // Add your rules for custom modules here
             // Learn more about loaders from https://webpack.js.org/loaders/
         ],
@@ -459,6 +464,7 @@ const config = {
                 type: "asset",
             },
 
+            // HTML, CSS need no loader — webpack supports them out of the box
             // Add your rules for custom modules here
             // Learn more about loaders from https://webpack.js.org/loaders/
         ],
@@ -531,6 +537,7 @@ const config = {
                 type: "asset",
             },
 
+            // HTML, CSS need no loader — webpack supports them out of the box
             // Add your rules for custom modules here
             // Learn more about loaders from https://webpack.js.org/loaders/
         ],
@@ -603,6 +610,7 @@ const config = {
                 type: "asset",
             },
 
+            // HTML, CSS need no loader — webpack supports them out of the box
             // Add your rules for custom modules here
             // Learn more about loaders from https://webpack.js.org/loaders/
         ],
@@ -675,6 +683,7 @@ const config = {
                 type: "asset",
             },
 
+            // HTML, CSS need no loader — webpack supports them out of the box
             // Add your rules for custom modules here
             // Learn more about loaders from https://webpack.js.org/loaders/
         ],
@@ -807,6 +816,7 @@ const config = {
                 type: "asset",
             },
 
+            // HTML and CSS need no loader — webpack supports them out of the box
             // Add your rules for custom modules here
             // Learn more about loaders from https://webpack.js.org/loaders/
         ],
@@ -900,6 +910,7 @@ const config : Configuration = {
                 type: "asset",
             },
 
+            // HTML and CSS need no loader — webpack supports them out of the box
             // Add your rules for custom modules here
             // Learn more about loaders from https://webpack.js.org/loaders/
         ],
@@ -1002,6 +1013,7 @@ const config = {
                 test: /\\.(eot|svg|ttf|woff|woff2|png|jpg|gif)$/i,
                 type: "asset",
             },
+            // HTML and CSS need no loader — webpack supports them out of the box
             // Add your rules for custom modules here
             // Learn more about loaders from https://webpack.js.org/loaders/
         ],
@@ -1106,6 +1118,7 @@ const config : Configuration = {
                 test: /\\.(eot|svg|ttf|woff|woff2|png|jpg|gif)$/i,
                 type: "asset",
             },
+            // HTML and CSS need no loader — webpack supports them out of the box
             // Add your rules for custom modules here
             // Learn more about loaders from https://webpack.js.org/loaders/
         ],
@@ -1136,15 +1149,18 @@ exports[`create-webpack-app cli should generate typescript project correctly 1`]
 {
   "description": "My webpack project",
   "devDependencies": {
-    "ts-loader": "x.x.x",
     "typescript": "x.x.x",
     "webpack": "x.x.x",
     "webpack-cli": "x.x.x",
+  },
+  "engines": {
+    "node": ">=22.6.0",
   },
   "name": "webpack-project",
   "scripts": {
     "build": "webpack --mode=production --config-node-env=production",
     "build:dev": "webpack --mode=development",
+    "check:types": "tsc --noEmit",
     "watch": "webpack --watch",
   },
   "type": "module",
@@ -1178,15 +1194,11 @@ const config : Configuration = {
     module: {
         rules: [
             {
-                test: /\\.(ts|tsx)$/i,
-                loader: "ts-loader",
-                exclude: ["/node_modules/"],
-            },
-            {
                 test: /\\.(eot|svg|ttf|woff|woff2|png|jpg|gif)$/i,
                 type: "asset",
             },
 
+            // HTML, CSS and TypeScript need no loader — webpack supports them out of the box
             // Add your rules for custom modules here
             // Learn more about loaders from https://webpack.js.org/loaders/
         ],
@@ -1293,6 +1305,7 @@ const config = {
                 test: /\\.(eot|svg|ttf|woff|woff2|png|jpg|gif)$/i,
                 type: "asset",
             },
+            // HTML and CSS need no loader — webpack supports them out of the box
             // Add your rules for custom modules here
             // Learn more about loaders from https://webpack.js.org/loaders/
         ],
@@ -1402,6 +1415,7 @@ const config : Configuration = {
                 test: /\\.(eot|svg|ttf|woff|woff2|png|jpg|gif)$/i,
                 type: "asset",
             },
+            // HTML and CSS need no loader — webpack supports them out of the box
             // Add your rules for custom modules here
             // Learn more about loaders from https://webpack.js.org/loaders/
         ],
@@ -1486,6 +1500,7 @@ const config = {
                 type: "asset",
             },
 
+            // HTML, CSS need no loader — webpack supports them out of the box
             // Add your rules for custom modules here
             // Learn more about loaders from https://webpack.js.org/loaders/
         ],
@@ -1557,6 +1572,7 @@ const config = {
                 type: "asset",
             },
 
+            // HTML, CSS need no loader — webpack supports them out of the box
             // Add your rules for custom modules here
             // Learn more about loaders from https://webpack.js.org/loaders/
         ],

--- a/test/create-webpack-app/init/__snapshots__/init.test.js.snap.webpack5
+++ b/test/create-webpack-app/init/__snapshots__/init.test.js.snap.webpack5
@@ -74,74 +74,14 @@ const isProduction = process.env.NODE_ENV === "production";
 
 /** @type {import("webpack").Configuration} */
 const config = {
-    entry: "./src/index.js",
+    // The page itself is the entry: webpack bundles the scripts and stylesheets
+    // it references and emits it as \`dist/index.html\`.
+    entry: { index: "./index.html" },
     output: {
         path: path.resolve(__dirname, "dist"),
     },
     devServer: {
         open: true,
-    },
-    plugins: [
-        // Add your plugins here
-        // Learn more about plugins from https://webpack.js.org/configuration/plugins/
-    ],
-    module: {
-        rules: [
-            {
-                test: /\\.(eot|svg|ttf|woff|woff2|png|jpg|gif)$/i,
-                type: "asset",
-            },
-
-            // Add your rules for custom modules here
-            // Learn more about loaders from https://webpack.js.org/loaders/
-        ],
-    },
-};
-
-export default () => {
-    if (isProduction) {
-        config.mode = "production";
-    } else {
-        config.mode = "development";
-    }
-    return config;
-};
-"
-`;
-
-exports[`create-webpack-app cli should configure native HTML support as opted 1`] = `
-{
-  "description": "My webpack project",
-  "devDependencies": {
-    "webpack": "x.x.x",
-    "webpack-cli": "x.x.x",
-  },
-  "name": "webpack-project",
-  "scripts": {
-    "build": "webpack --mode=production --config-node-env=production",
-    "build:dev": "webpack --mode=development",
-    "watch": "webpack --watch",
-  },
-  "type": "module",
-  "version": "1.0.0",
-}
-`;
-
-exports[`create-webpack-app cli should configure native HTML support as opted 2`] = `
-"// Generated using webpack-cli https://github.com/webpack/webpack-cli
-
-import path from "node:path";
-import { fileURLToPath } from "node:url";
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const isProduction = process.env.NODE_ENV === "production";
-
-/** @type {import("webpack").Configuration} */
-const config = {
-    entry: "./index.html",
-    output: {
-        path: path.resolve(__dirname, "dist"),
     },
     plugins: [
         // Add your plugins here
@@ -203,7 +143,9 @@ const isProduction = process.env.NODE_ENV === "production";
 
 /** @type {import("webpack").Configuration} */
 const config = {
-    entry: "./index.html",
+    // The page itself is the entry: webpack bundles the scripts and stylesheets
+    // it references and emits it as \`dist/index.html\`.
+    entry: { index: "./index.html" },
     output: {
         path: path.resolve(__dirname, "dist"),
     },
@@ -269,7 +211,9 @@ const isProduction = process.env.NODE_ENV === "production";
 
 /** @type {import("webpack").Configuration} */
 const config = {
-    entry: "./src/index.js",
+    // The page itself is the entry: webpack bundles the scripts and stylesheets
+    // it references and emits it as \`dist/index.html\`.
+    entry: { index: "./index.html" },
     output: {
         path: path.resolve(__dirname, "dist"),
     },
@@ -339,7 +283,9 @@ const isProduction = process.env.NODE_ENV === "production";
 
 /** @type {import("webpack").Configuration} */
 const config = {
-    entry: "./index.html",
+    // The page itself is the entry: webpack bundles the scripts and stylesheets
+    // it references and emits it as \`dist/index.html\`.
+    entry: { index: "./index.html" },
     output: {
         path: path.resolve(__dirname, "dist"),
     },
@@ -409,7 +355,9 @@ const isProduction = process.env.NODE_ENV === "production";
 
 /** @type {import("webpack").Configuration} */
 const config = {
-    entry: "./index.html",
+    // The page itself is the entry: webpack bundles the scripts and stylesheets
+    // it references and emits it as \`dist/index.html\`.
+    entry: { index: "./index.html" },
     output: {
         path: path.resolve(__dirname, "dist"),
     },
@@ -479,7 +427,9 @@ const isProduction = process.env.NODE_ENV === "production";
 
 /** @type {import("webpack").Configuration} */
 const config = {
-    entry: "./index.html",
+    // The page itself is the entry: webpack bundles the scripts and stylesheets
+    // it references and emits it as \`dist/index.html\`.
+    entry: { index: "./index.html" },
     output: {
         path: path.resolve(__dirname, "dist"),
     },
@@ -549,7 +499,9 @@ const isProduction = process.env.NODE_ENV === "production";
 
 /** @type {import("webpack").Configuration} */
 const config = {
-    entry: "./index.html",
+    // The page itself is the entry: webpack bundles the scripts and stylesheets
+    // it references and emits it as \`dist/index.html\`.
+    entry: { index: "./index.html" },
     output: {
         path: path.resolve(__dirname, "dist"),
     },
@@ -619,7 +571,9 @@ const isProduction = process.env.NODE_ENV === "production";
 
 /** @type {import("webpack").Configuration} */
 const config = {
-    entry: "./index.html",
+    // The page itself is the entry: webpack bundles the scripts and stylesheets
+    // it references and emits it as \`dist/index.html\`.
+    entry: { index: "./index.html" },
     output: {
         path: path.resolve(__dirname, "dist"),
     },
@@ -705,10 +659,7 @@ exports[`create-webpack-app cli should generate react template with state and ro
     "@babel/preset-env": "x.x.x",
     "@babel/preset-react": "x.x.x",
     "@types/react-router-dom": "x.x.x",
-    "autoprefixer": "x.x.x",
     "babel-loader": "x.x.x",
-    "postcss": "x.x.x",
-    "postcss-loader": "x.x.x",
     "react": "x.x.x",
     "react-dom": "x.x.x",
     "react-router-dom": "x.x.x",
@@ -742,15 +693,14 @@ const isProduction = process.env.NODE_ENV === "production";
 
 /** @type {import("webpack").Configuration} */
 const config = {
-    entry: "./index.html",
+    // The page itself is the entry: webpack bundles the scripts and stylesheets
+    // it references and emits it as \`dist/index.html\`.
+    entry: { index: "./index.html" },
     output: {
         path: path.resolve(__dirname, "dist"),
     },
     devServer: {
         open: true,
-    },
-    experiments: {
-        css: true,
     },
     plugins: [
         // Add your plugins here
@@ -767,11 +717,6 @@ const config = {
                         presets: ["@babel/preset-env", "@babel/preset-react"],
                     },
                 },
-            },
-            {
-                test: /\\.css$/i,
-                type: "css/auto",
-                use: ["postcss-loader"],
             },
             {
                 test: /\\.(eot|svg|ttf|woff|woff2|png|jpg|gif)$/i,
@@ -809,9 +754,6 @@ exports[`create-webpack-app cli should generate react template with typescript 1
     "@types/react": "x.x.x",
     "@types/react-dom": "x.x.x",
     "@types/react-router-dom": "x.x.x",
-    "autoprefixer": "x.x.x",
-    "postcss": "x.x.x",
-    "postcss-loader": "x.x.x",
     "react": "x.x.x",
     "react-dom": "x.x.x",
     "react-router-dom": "x.x.x",
@@ -849,15 +791,14 @@ const isProduction = process.env.NODE_ENV === "production";
 
 /** @type {import("webpack").Configuration} */
 const config : Configuration = {
-    entry: "./index.html",
+    // The page itself is the entry: webpack bundles the scripts and stylesheets
+    // it references and emits it as \`dist/index.html\`.
+    entry: { index: "./index.html" },
     output: {
         path: path.resolve(__dirname, "dist"),
     },
     devServer: {
         open: true,
-    },
-    experiments: {
-        css: true,
     },
     plugins: [
         // Add your plugins here
@@ -869,11 +810,6 @@ const config : Configuration = {
                 test: /\\.(ts|tsx)$/i,
                 loader: "ts-loader",
                 exclude: ["/node_modules/"],
-            },
-            {
-                test: /\\.css$/i,
-                type: "css/auto",
-                use: ["postcss-loader"],
             },
             {
                 test: /\\.(eot|svg|ttf|woff|woff2|png|jpg|gif)$/i,
@@ -910,10 +846,7 @@ exports[`create-webpack-app cli should generate svelte template with prompt answ
   "devDependencies": {
     "@babel/core": "x.x.x",
     "@babel/preset-env": "x.x.x",
-    "autoprefixer": "x.x.x",
     "babel-loader": "x.x.x",
-    "postcss": "x.x.x",
-    "postcss-loader": "x.x.x",
     "svelte": "x.x.x",
     "svelte-loader": "x.x.x",
     "webpack": "x.x.x",
@@ -946,15 +879,14 @@ const isProduction = process.env.NODE_ENV === "production";
 
 /** @type {import("webpack").Configuration} */
 const config = {
-    entry: "./index.html",
+    // The page itself is the entry: webpack bundles the scripts and stylesheets
+    // it references and emits it as \`dist/index.html\`.
+    entry: { index: "./index.html" },
     output: {
         path: path.resolve(__dirname, "dist"),
     },
     devServer: {
         open: true,
-    },
-    experiments: {
-        css: true,
     },
     plugins: [
         // Add your plugins here
@@ -981,11 +913,6 @@ const config = {
                         presets: ["@babel/preset-env"],
                     },
                 },
-            },
-            {
-                test: /\\.css$/i,
-                type: "css/auto",
-                use: ["postcss-loader"],
             },
             {
                 test: /\\.(eot|svg|ttf|woff|woff2|png|jpg|gif)$/i,
@@ -1022,9 +949,6 @@ exports[`create-webpack-app cli should generate svelte template with typescript 
   "description": "My webpack project",
   "devDependencies": {
     "@tsconfig/svelte": "x.x.x",
-    "autoprefixer": "x.x.x",
-    "postcss": "x.x.x",
-    "postcss-loader": "x.x.x",
     "svelte": "x.x.x",
     "svelte-loader": "x.x.x",
     "ts-loader": "x.x.x",
@@ -1061,15 +985,14 @@ const isProduction = process.env.NODE_ENV === "production";
 
 /** @type {import("webpack").Configuration} */
 const config : Configuration = {
-    entry: "./index.html",
+    // The page itself is the entry: webpack bundles the scripts and stylesheets
+    // it references and emits it as \`dist/index.html\`.
+    entry: { index: "./index.html" },
     output: {
         path: path.resolve(__dirname, "dist"),
     },
     devServer: {
         open: true,
-    },
-    experiments: {
-        css: true,
     },
     plugins: [
         // Add your plugins here
@@ -1094,11 +1017,6 @@ const config : Configuration = {
                 options: {
                     appendTsSuffixTo: [/\\.svelte$/],
                 },
-            },
-            {
-                test: /\\.css$/i,
-                type: "css/auto",
-                use: ["postcss-loader"],
             },
             {
                 test: /\\.(eot|svg|ttf|woff|woff2|png|jpg|gif)$/i,
@@ -1163,7 +1081,9 @@ const isProduction = process.env.NODE_ENV === "production";
 
 /** @type {import("webpack").Configuration} */
 const config : Configuration = {
-    entry: "./src/index.ts",
+    // The page itself is the entry: webpack bundles the scripts and stylesheets
+    // it references and emits it as \`dist/index.html\`.
+    entry: { index: "./index.html" },
     output: {
         path: path.resolve(__dirname, "dist"),
     },
@@ -1210,11 +1130,8 @@ exports[`create-webpack-app cli should generate vue template with store and rout
     "@babel/core": "x.x.x",
     "@babel/preset-env": "x.x.x",
     "@vue/compiler-sfc": "x.x.x",
-    "autoprefixer": "x.x.x",
     "babel-loader": "x.x.x",
     "pinia": "x.x.x",
-    "postcss": "x.x.x",
-    "postcss-loader": "x.x.x",
     "vue": "x.x.x",
     "vue-loader": "x.x.x",
     "vue-router": "x.x.x",
@@ -1249,13 +1166,17 @@ const isProduction = process.env.NODE_ENV === "production";
 
 /** @type {import("webpack").Configuration} */
 const config = {
-    entry: "./index.html",
+    // The page itself is the entry: webpack bundles the scripts and stylesheets
+    // it references and emits it as \`dist/index.html\`.
+    entry: { index: "./index.html" },
     output: {
         path: path.resolve(__dirname, "dist"),
     },
     devServer: {
         open: true,
     },
+    // vue-loader rewrites \`module.rules\`, which hides from webpack that no rule
+    // handles \`.html\`/\`.css\` — so ask for the built-in support explicitly
     experiments: {
         css: true,
         html: true,
@@ -1283,11 +1204,6 @@ const config = {
                         presets: ["@babel/preset-env"],
                     },
                 },
-            },
-            {
-                test: /\\.css$/i,
-                type: "css/auto",
-                use: ["postcss-loader"],
             },
             {
                 test: /\\.(eot|svg|ttf|woff|woff2|png|jpg|gif)$/i,
@@ -1321,10 +1237,7 @@ exports[`create-webpack-app cli should generate vue template with typescript 1`]
   "description": "My webpack project",
   "devDependencies": {
     "@vue/compiler-sfc": "x.x.x",
-    "autoprefixer": "x.x.x",
     "pinia": "x.x.x",
-    "postcss": "x.x.x",
-    "postcss-loader": "x.x.x",
     "ts-loader": "x.x.x",
     "typescript": "x.x.x",
     "vue": "x.x.x",
@@ -1363,13 +1276,17 @@ const isProduction = process.env.NODE_ENV === "production";
 
 /** @type {import("webpack").Configuration} */
 const config : Configuration = {
-    entry: "./index.html",
+    // The page itself is the entry: webpack bundles the scripts and stylesheets
+    // it references and emits it as \`dist/index.html\`.
+    entry: { index: "./index.html" },
     output: {
         path: path.resolve(__dirname, "dist"),
     },
     devServer: {
         open: true,
     },
+    // vue-loader rewrites \`module.rules\`, which hides from webpack that no rule
+    // handles \`.html\`/\`.css\` — so ask for the built-in support explicitly
     experiments: {
         css: true,
         html: true,
@@ -1396,11 +1313,6 @@ const config : Configuration = {
                     transpileOnly: true,
                 },
                 exclude: ["/node_modules/"],
-            },
-            {
-                test: /\\.css$/i,
-                type: "css/auto",
-                use: ["postcss-loader"],
             },
             {
                 test: /\\.(eot|svg|ttf|woff|woff2|png|jpg|gif)$/i,
@@ -1430,13 +1342,10 @@ export default () => {
 "
 `;
 
-exports[`create-webpack-app cli should use css preprocessor and css with postcss in project when selected 1`] = `
+exports[`create-webpack-app cli should scaffold a preprocessor through the built-in CSS support when selected 1`] = `
 {
   "description": "My webpack project",
   "devDependencies": {
-    "autoprefixer": "x.x.x",
-    "postcss": "x.x.x",
-    "postcss-loader": "x.x.x",
     "sass": "x.x.x",
     "sass-loader": "x.x.x",
     "webpack": "x.x.x",
@@ -1453,7 +1362,7 @@ exports[`create-webpack-app cli should use css preprocessor and css with postcss
 }
 `;
 
-exports[`create-webpack-app cli should use css preprocessor and css with postcss in project when selected 2`] = `
+exports[`create-webpack-app cli should scaffold a preprocessor through the built-in CSS support when selected 2`] = `
 "// Generated using webpack-cli https://github.com/webpack/webpack-cli
 
 import path from "node:path";
@@ -1465,87 +1374,9 @@ const isProduction = process.env.NODE_ENV === "production";
 
 /** @type {import("webpack").Configuration} */
 const config = {
-    entry: "./src/index.js",
-    output: {
-        path: path.resolve(__dirname, "dist"),
-    },
-    experiments: {
-        css: true,
-    },
-    plugins: [
-        // Add your plugins here
-        // Learn more about plugins from https://webpack.js.org/configuration/plugins/
-    ],
-    module: {
-        rules: [
-            {
-                test: /\\.css$/i,
-                type: "css/auto",
-                use: ["postcss-loader"],
-            },
-            {
-                test: /\\.s[ac]ss$/i,
-                type: "css/auto",
-                use: ["postcss-loader", "sass-loader"],
-            },
-            {
-                test: /\\.(eot|svg|ttf|woff|woff2|png|jpg|gif)$/i,
-                type: "asset",
-            },
-
-            // Add your rules for custom modules here
-            // Learn more about loaders from https://webpack.js.org/loaders/
-        ],
-    },
-};
-
-export default () => {
-    if (isProduction) {
-        config.mode = "production";
-    } else {
-        config.mode = "development";
-    }
-    return config;
-};
-"
-`;
-
-exports[`create-webpack-app cli should use css preprocessor with postcss in project when selected 1`] = `
-{
-  "description": "My webpack project",
-  "devDependencies": {
-    "autoprefixer": "x.x.x",
-    "postcss": "x.x.x",
-    "postcss-loader": "x.x.x",
-    "sass": "x.x.x",
-    "sass-loader": "x.x.x",
-    "webpack": "x.x.x",
-    "webpack-cli": "x.x.x",
-  },
-  "name": "webpack-project",
-  "scripts": {
-    "build": "webpack --mode=production --config-node-env=production",
-    "build:dev": "webpack --mode=development",
-    "watch": "webpack --watch",
-  },
-  "type": "module",
-  "version": "1.0.0",
-}
-`;
-
-exports[`create-webpack-app cli should use css preprocessor with postcss in project when selected 2`] = `
-"// Generated using webpack-cli https://github.com/webpack/webpack-cli
-
-import path from "node:path";
-import { fileURLToPath } from "node:url";
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const isProduction = process.env.NODE_ENV === "production";
-
-/** @type {import("webpack").Configuration} */
-const config = {
-    entry: "./src/index.js",
+    // The page itself is the entry: webpack bundles the scripts and stylesheets
+    // it references and emits it as \`dist/index.html\`.
+    entry: { index: "./index.html" },
     output: {
         path: path.resolve(__dirname, "dist"),
     },
@@ -1558,7 +1389,7 @@ const config = {
             {
                 test: /\\.s[ac]ss$/i,
                 type: "css/auto",
-                use: ["postcss-loader", "sass-loader"],
+                use: ["sass-loader"],
             },
             {
                 test: /\\.(eot|svg|ttf|woff|woff2|png|jpg|gif)$/i,

--- a/test/create-webpack-app/init/__snapshots__/init.test.js.snap.webpack5
+++ b/test/create-webpack-app/init/__snapshots__/init.test.js.snap.webpack5
@@ -42,6 +42,90 @@ exports[`create-webpack-app cli should ask question when wrong template is suppl
 }
 `;
 
+exports[`create-webpack-app cli should chain PostCSS after a preprocessor when both are selected 1`] = `
+{
+  "description": "My webpack project",
+  "devDependencies": {
+    "autoprefixer": "x.x.x",
+    "postcss": "x.x.x",
+    "postcss-loader": "x.x.x",
+    "sass": "x.x.x",
+    "sass-loader": "x.x.x",
+    "webpack": "x.x.x",
+    "webpack-cli": "x.x.x",
+  },
+  "name": "webpack-project",
+  "scripts": {
+    "build": "webpack --mode=production --config-node-env=production",
+    "build:dev": "webpack --mode=development",
+    "watch": "webpack --watch",
+  },
+  "type": "module",
+  "version": "1.0.0",
+}
+`;
+
+exports[`create-webpack-app cli should chain PostCSS after a preprocessor when both are selected 2`] = `
+"// Generated using webpack-cli https://github.com/webpack/webpack-cli
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const isProduction = process.env.NODE_ENV === "production";
+
+/** @type {import("webpack").Configuration} */
+const config = {
+    // The page itself is the entry: webpack bundles the scripts and stylesheets
+    // it references and emits it as \`dist/index.html\`.
+    entry: { index: "./index.html" },
+    output: {
+        path: path.resolve(__dirname, "dist"),
+    },
+    // The PostCSS rule registers a loader for \`.css\`, which turns off the
+    // automatic detection of webpack's built-in CSS support — ask for it
+    experiments: {
+        css: true,
+    },
+    plugins: [
+        // Add your plugins here
+        // Learn more about plugins from https://webpack.js.org/configuration/plugins/
+    ],
+    module: {
+        rules: [
+            {
+                test: /\\.css$/i,
+                type: "css/auto",
+                use: ["postcss-loader"],
+            },
+            {
+                test: /\\.s[ac]ss$/i,
+                type: "css/auto",
+                use: ["postcss-loader", "sass-loader"],
+            },
+            {
+                test: /\\.(eot|svg|ttf|woff|woff2|png|jpg|gif)$/i,
+                type: "asset",
+            },
+
+            // Add your rules for custom modules here
+            // Learn more about loaders from https://webpack.js.org/loaders/
+        ],
+    },
+};
+
+export default () => {
+    if (isProduction) {
+        config.mode = "production";
+    } else {
+        config.mode = "development";
+    }
+    return config;
+};
+"
+`;
+
 exports[`create-webpack-app cli should configure WDS as opted 1`] = `
 {
   "description": "My webpack project",
@@ -1334,6 +1418,83 @@ export default () => {
     if (isProduction) {
         config.mode = "production";
         config.plugins?.push(new WorkboxWebpackPlugin.GenerateSW());
+    } else {
+        config.mode = "development";
+    }
+    return config;
+};
+"
+`;
+
+exports[`create-webpack-app cli should scaffold PostCSS on top of the built-in CSS support when selected 1`] = `
+{
+  "description": "My webpack project",
+  "devDependencies": {
+    "autoprefixer": "x.x.x",
+    "postcss": "x.x.x",
+    "postcss-loader": "x.x.x",
+    "webpack": "x.x.x",
+    "webpack-cli": "x.x.x",
+  },
+  "name": "webpack-project",
+  "scripts": {
+    "build": "webpack --mode=production --config-node-env=production",
+    "build:dev": "webpack --mode=development",
+    "watch": "webpack --watch",
+  },
+  "type": "module",
+  "version": "1.0.0",
+}
+`;
+
+exports[`create-webpack-app cli should scaffold PostCSS on top of the built-in CSS support when selected 2`] = `
+"// Generated using webpack-cli https://github.com/webpack/webpack-cli
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const isProduction = process.env.NODE_ENV === "production";
+
+/** @type {import("webpack").Configuration} */
+const config = {
+    // The page itself is the entry: webpack bundles the scripts and stylesheets
+    // it references and emits it as \`dist/index.html\`.
+    entry: { index: "./index.html" },
+    output: {
+        path: path.resolve(__dirname, "dist"),
+    },
+    // The PostCSS rule registers a loader for \`.css\`, which turns off the
+    // automatic detection of webpack's built-in CSS support — ask for it
+    experiments: {
+        css: true,
+    },
+    plugins: [
+        // Add your plugins here
+        // Learn more about plugins from https://webpack.js.org/configuration/plugins/
+    ],
+    module: {
+        rules: [
+            {
+                test: /\\.css$/i,
+                type: "css/auto",
+                use: ["postcss-loader"],
+            },
+            {
+                test: /\\.(eot|svg|ttf|woff|woff2|png|jpg|gif)$/i,
+                type: "asset",
+            },
+
+            // Add your rules for custom modules here
+            // Learn more about loaders from https://webpack.js.org/loaders/
+        ],
+    },
+};
+
+export default () => {
+    if (isProduction) {
+        config.mode = "production";
     } else {
         config.mode = "development";
     }

--- a/test/create-webpack-app/init/generators.test.js
+++ b/test/create-webpack-app/init/generators.test.js
@@ -131,6 +131,20 @@ describe("create-webpack-app generators", () => {
     expect(installed).not.toContain("ts-loader");
   });
 
+  it("keeps ts-loader reachable for what type stripping cannot do", async () => {
+    const actions = await actionsFor("default", {
+      langType: "Typescript",
+      cssTool: "none",
+      tsCompiler: "ts-loader",
+    });
+    const installed = packagesFrom(actions);
+
+    expect(installed).toContain("ts-loader");
+    // ts-loader 9 throws on TypeScript 7, so the compiler is pinned with it
+    expect(installed).toContain("typescript@5");
+    expect(installed).not.toContain("typescript");
+  });
+
   // Only the default template can lean on webpack: type stripping handles neither
   // `.tsx` nor the single-file components the framework loaders produce.
   for (const template of ["react", "vue", "svelte"]) {

--- a/test/create-webpack-app/init/generators.test.js
+++ b/test/create-webpack-app/init/generators.test.js
@@ -1,0 +1,130 @@
+const path = require("node:path");
+const { pathToFileURL } = require("node:url");
+
+const LIB = path.resolve(__dirname, "../../../packages/create-webpack-app/lib");
+
+const BASE_ANSWERS = {
+  projectPath: "/tmp/create-webpack-app-generators",
+  langType: "ES6",
+  devServer: true,
+  workboxWebpackPlugin: false,
+  useReactState: true,
+  useVueStore: true,
+  packageManager: "npm",
+};
+
+// Each template scaffolds its stylesheet in a different place
+const STYLESHEETS = {
+  default: (extension) => `styles.${extension}`,
+  react: (extension) => `global.${extension}`,
+  vue: (extension) => `global.${extension}`,
+  svelte: (extension) => `global.${extension}`,
+};
+
+const TEMPLATES = Object.keys(STYLESHEETS);
+
+// Every choice of the CSS tool question, and what it has to pull in
+const CSS_TOOLS = [
+  { answer: "none", extension: "css", packages: [] },
+  { answer: "PostCSS", extension: "css", packages: ["postcss-loader", "postcss", "autoprefixer"] },
+  { answer: "SASS", extension: "scss", packages: ["sass-loader", "sass"] },
+  {
+    answer: "SASS with PostCSS",
+    extension: "scss",
+    packages: ["sass-loader", "sass", "postcss-loader"],
+  },
+  { answer: "LESS", extension: "less", packages: ["less-loader", "less"] },
+  {
+    answer: "LESS with PostCSS",
+    extension: "less",
+    packages: ["less-loader", "less", "postcss-loader"],
+  },
+  { answer: "Stylus", extension: "styl", packages: ["stylus-loader", "stylus"] },
+  {
+    answer: "Stylus with PostCSS",
+    extension: "styl",
+    packages: ["stylus-loader", "stylus", "postcss-loader"],
+  },
+];
+
+/**
+ * Registers a generator against the few plop methods it calls, so its answer
+ * handling can be exercised without a plop instance.
+ * @param {string} template template name
+ * @returns {Promise<EXPECTED_ANY>} the generator config
+ */
+const generatorFor = async (template) => {
+  const module = await import(pathToFileURL(path.join(LIB, "generators/init", `${template}.js`)));
+
+  let config;
+
+  await module.default({
+    load: async () => {},
+    setDefaultInclude: () => {},
+    setPlopfilePath: () => {},
+    getPlopfilePath: () => path.join(LIB, "plopfile.js"),
+    setGenerator: (name, generatorConfig) => {
+      config = generatorConfig;
+    },
+  });
+
+  return config;
+};
+
+// The action list is built without running any action, so no project is written
+// and nothing is installed.
+const actionsFor = async (template, answers) => {
+  const generator = await generatorFor(template);
+
+  return generator.actions({ ...BASE_ANSWERS, ...answers });
+};
+
+const filesFrom = (actions) =>
+  actions
+    .filter((action) => action.type === "generate-files")
+    .map((action) => path.basename(action.path));
+
+const packagesFrom = (actions) =>
+  actions.find((action) => action.type === "install-dependencies").packages;
+
+describe("create-webpack-app generators", () => {
+  for (const template of TEMPLATES) {
+    for (const { answer, extension, packages } of CSS_TOOLS) {
+      it(`scaffolds the ${template} template with "${answer}"`, async () => {
+        const actions = await actionsFor(template, { cssTool: answer });
+        const files = filesFrom(actions);
+        const installed = packagesFrom(actions);
+
+        // the starter stylesheet is written in the language that was picked
+        expect(files).toContain(STYLESHEETS[template](extension));
+
+        for (const name of packages) {
+          expect(installed).toContain(name);
+        }
+
+        // PostCSS is the only tool that needs a config file
+        if (answer.includes("PostCSS")) {
+          expect(files).toContain("postcss.config.js");
+        } else {
+          expect(files).not.toContain("postcss.config.js");
+        }
+
+        // whatever is picked, webpack's own CSS and HTML support stays untouched
+        expect(installed).not.toContain("css-loader");
+        expect(installed).not.toContain("style-loader");
+        expect(installed).not.toContain("mini-css-extract-plugin");
+        expect(installed).not.toContain("html-webpack-plugin");
+        expect(files).toContain("index.html");
+      });
+    }
+  }
+
+  it("keeps the TypeScript entry point and its config", async () => {
+    const actions = await actionsFor("default", { langType: "Typescript", cssTool: "none" });
+    const files = filesFrom(actions);
+
+    expect(files).toContain("index.ts");
+    expect(files).toContain("tsconfig.json");
+    expect(packagesFrom(actions)).toContain("ts-loader");
+  });
+});

--- a/test/create-webpack-app/init/generators.test.js
+++ b/test/create-webpack-app/init/generators.test.js
@@ -140,8 +140,8 @@ describe("create-webpack-app generators", () => {
     const installed = packagesFrom(actions);
 
     expect(installed).toContain("ts-loader");
-    // ts-loader 9 throws on TypeScript 7, so the compiler is pinned with it
-    expect(installed).toContain("typescript@5");
+    // ts-loader 9 throws on TypeScript 7, so it pins the last 6.x with it
+    expect(installed).toContain("typescript@6");
     expect(installed).not.toContain("typescript");
   });
 

--- a/test/create-webpack-app/init/generators.test.js
+++ b/test/create-webpack-app/init/generators.test.js
@@ -119,12 +119,25 @@ describe("create-webpack-app generators", () => {
     }
   }
 
-  it("keeps the TypeScript entry point and its config", async () => {
+  it("scaffolds TypeScript on webpack's own support, with a tsconfig to check against", async () => {
     const actions = await actionsFor("default", { langType: "Typescript", cssTool: "none" });
     const files = filesFrom(actions);
+    const installed = packagesFrom(actions);
 
     expect(files).toContain("index.ts");
     expect(files).toContain("tsconfig.json");
-    expect(packagesFrom(actions)).toContain("ts-loader");
+    // `typescript` is for the editor and `check:types`, not for the build
+    expect(installed).toContain("typescript");
+    expect(installed).not.toContain("ts-loader");
   });
+
+  // Only the default template can lean on webpack: type stripping handles neither
+  // `.tsx` nor the single-file components the framework loaders produce.
+  for (const template of ["react", "vue", "svelte"]) {
+    it(`keeps a TypeScript loader for the ${template} template`, async () => {
+      const actions = await actionsFor(template, { langType: "Typescript", cssTool: "none" });
+
+      expect(packagesFrom(actions)).toContain("ts-loader");
+    });
+  }
 });

--- a/test/create-webpack-app/init/init.test.js
+++ b/test/create-webpack-app/init/init.test.js
@@ -9,7 +9,6 @@ jest.setTimeout(480000);
 const { run, runPromptWithAnswers } = createPathDependentUtils("create-webpack-app");
 
 const ENTER = "\u000D";
-const UP = "\u001B\u005B\u0041";
 const DOWN = "\u001B\u005B\u0042";
 
 const defaultTemplateFiles = [
@@ -167,8 +166,7 @@ describe("create-webpack-app cli", () => {
         `${DOWN}${ENTER}`,
         `n${ENTER}`,
         `n${ENTER}`,
-        `n${ENTER}`,
-        `${UP}${ENTER}`,
+        ENTER,
         ENTER,
         // test for conflicts
         `y${ENTER}`,
@@ -299,7 +297,7 @@ describe("create-webpack-app cli", () => {
     const { stdout } = await runPromptWithAnswers(
       dir,
       ["init", "."],
-      [`${DOWN}${DOWN}${ENTER}`, `n${ENTER}`, `n${ENTER}`, `n${ENTER}`, `${UP}${ENTER}`, ENTER],
+      [`${DOWN}${DOWN}${ENTER}`, `n${ENTER}`, `n${ENTER}`, ENTER, ENTER],
     );
 
     expect(stdout).toContain("Project has been initialised with webpack!");
@@ -331,7 +329,7 @@ describe("create-webpack-app cli", () => {
     const { stdout } = await runPromptWithAnswers(
       dir,
       ["init", "."],
-      [`${DOWN}${ENTER}`, `n${ENTER}`, `n${ENTER}`, `n${ENTER}`, `${UP}${ENTER}`, ENTER],
+      [`${DOWN}${ENTER}`, `n${ENTER}`, `n${ENTER}`, ENTER, ENTER],
     );
 
     expect(stdout).toContain("Project has been initialised with webpack!");
@@ -352,77 +350,11 @@ describe("create-webpack-app cli", () => {
     expect(readFromWebpackConfig(dir)).toMatchSnapshot();
   });
 
-  it("should use css preprocessor with postcss in project when selected", async () => {
-    const { stdout } = await runPromptWithAnswers(
-      dir,
-      ["init", "."],
-      [
-        ENTER,
-        `n${ENTER}`,
-        `n${ENTER}`,
-        `n${ENTER}`,
-        `${DOWN}${ENTER}`,
-        `n${ENTER}`,
-        `y${ENTER}`,
-        ENTER,
-        ENTER,
-      ],
-    );
-
-    expect(stdout).toContain("Project has been initialised with webpack!");
-    expect(stdout).toContain("webpack.config.js");
-
-    // Test files
-    for (const file of defaultTemplateFiles) {
-      expect(existsSync(resolve(dir, file))).toBeTruthy();
-    }
-
-    // Check if the generated package.json file content matches the snapshot
-    expect(readFromPkgJSON(dir)).toMatchSnapshot();
-
-    // Check if the generated webpack configuration matches the snapshot
-    expect(readFromWebpackConfig(dir)).toMatchSnapshot();
-  });
-
-  it("should use css preprocessor and css with postcss in project when selected", async () => {
-    const { stdout } = await runPromptWithAnswers(
-      dir,
-      ["init", "."],
-      [
-        `${ENTER}`,
-        `n${ENTER}`,
-        `n${ENTER}`,
-        `n${ENTER}`,
-        `${DOWN}${ENTER}`,
-        `y${ENTER}`,
-        `y${ENTER}`,
-        ENTER,
-        ENTER,
-      ],
-    );
-
-    expect(stdout).toContain("Project has been initialised with webpack!");
-    expect(stdout).toContain("webpack.config.js");
-
-    // Test files
-    const files = [...defaultTemplateFiles, "postcss.config.js"];
-
-    for (const file of files) {
-      expect(existsSync(resolve(dir, file))).toBeTruthy();
-    }
-
-    // Check if the generated package.json file content matches the snapshot
-    expect(readFromPkgJSON(dir)).toMatchSnapshot();
-
-    // Check if the generated webpack configuration matches the snapshot
-    expect(readFromWebpackConfig(dir)).toMatchSnapshot();
-  });
-
   it("should configure WDS as opted", async () => {
     const { stdout } = await runPromptWithAnswers(
       dir,
       ["init", "."],
-      [ENTER, ENTER, `n${ENTER}`, `n${ENTER}`, `${UP}${ENTER}`, ENTER],
+      [ENTER, ENTER, `n${ENTER}`, ENTER, ENTER],
     );
 
     expect(stdout).toContain("Would you like to use Webpack Dev server?");
@@ -441,21 +373,54 @@ describe("create-webpack-app cli", () => {
     expect(readFromWebpackConfig(dir)).toMatchSnapshot();
   });
 
-  it("should configure native HTML support as opted", async () => {
+  it("should not ask about HTML and CSS, which webpack supports out of the box", async () => {
     const { stdout } = await runPromptWithAnswers(
       dir,
       ["init", "."],
-      [ENTER, `n${ENTER}`, ENTER, `n${ENTER}`, `${UP}${ENTER}`, ENTER],
+      [ENTER, ENTER, ENTER, ENTER, ENTER],
     );
 
-    expect(stdout).toContain("Do you want to simplify the creation of HTML files for your bundle?");
     expect(stdout).toContain("Project has been initialised with webpack!");
-    expect(stdout).toContain("webpack.config.js");
+    expect(stdout).not.toContain(
+      "Do you want to simplify the creation of HTML files for your bundle?",
+    );
+    expect(stdout).not.toContain("Which of the following CSS solution do you want to use?");
+    expect(stdout).not.toContain("Do you want to use PostCSS in your project?");
+    expect(stdout).not.toContain("Do you want to extract CSS into separate files?");
 
-    // Test files
-    for (const file of defaultTemplateFiles) {
-      expect(existsSync(resolve(dir, file))).toBeTruthy();
-    }
+    // The page is the entry, and nothing loads HTML or CSS
+    const config = readFromWebpackConfig(dir);
+
+    expect(config).toContain('entry: { index: "./index.html" }');
+    expect(config).not.toContain("html-webpack-plugin");
+    expect(config).not.toContain("css-loader");
+    expect(config).not.toContain("mini-css-extract-plugin");
+
+    const { devDependencies } = readFromPkgJSON(dir);
+
+    expect(Object.keys(devDependencies)).not.toContain("html-webpack-plugin");
+    expect(Object.keys(devDependencies)).not.toContain("css-loader");
+    expect(existsSync(resolve(dir, "src/styles.css"))).toBeTruthy();
+    expect(existsSync(resolve(dir, "postcss.config.js"))).toBeFalsy();
+  });
+
+  it("should scaffold a preprocessor through the built-in CSS support when selected", async () => {
+    const { stdout } = await runPromptWithAnswers(
+      dir,
+      ["init", "."],
+      [ENTER, `n${ENTER}`, `n${ENTER}`, `${DOWN}${ENTER}`, ENTER],
+    );
+
+    expect(stdout).toContain("Which CSS preprocessor do you want to use?");
+    expect(stdout).toContain("Project has been initialised with webpack!");
+
+    // Sass is wired as a `css/auto` rule, so it needs no css-loader
+    const config = readFromWebpackConfig(dir);
+
+    expect(config).toContain('type: "css/auto"');
+    expect(config).toContain('use: ["sass-loader"]');
+    expect(config).not.toContain("css-loader");
+    expect(existsSync(resolve(dir, "src/styles.scss"))).toBeTruthy();
 
     // Check if the generated package.json file content matches the snapshot
     expect(readFromPkgJSON(dir)).toMatchSnapshot();
@@ -468,7 +433,7 @@ describe("create-webpack-app cli", () => {
     const { stdout } = await runPromptWithAnswers(
       dir,
       ["init", "."],
-      [ENTER, `n${ENTER}`, ENTER, ENTER, `${UP}${ENTER}`, ENTER],
+      [ENTER, `n${ENTER}`, ENTER, ENTER, ENTER],
     );
 
     expect(stdout).toContain("Do you want to add PWA support?");
@@ -491,7 +456,7 @@ describe("create-webpack-app cli", () => {
     const { stdout } = await runPromptWithAnswers(
       dir,
       ["init", "."],
-      [ENTER, `n${ENTER}`, `n${ENTER}`, `n${ENTER}`, `${UP}${ENTER}`, `${DOWN}${ENTER}`],
+      [ENTER, `n${ENTER}`, `n${ENTER}`, ENTER, `${DOWN}${ENTER}`],
     );
 
     expect(stdout).toContain("Project has been initialised with webpack!");
@@ -515,7 +480,7 @@ describe("create-webpack-app cli", () => {
     const { stdout } = await runPromptWithAnswers(
       dir,
       ["init", ".", "--template=react"],
-      [ENTER, `y${ENTER}`, `y${ENTER}`, ENTER, `y${ENTER}`, ENTER, ENTER, ENTER],
+      [ENTER, `y${ENTER}`, `y${ENTER}`, ENTER, ENTER],
     );
 
     expect(stdout).toContain("Project has been initialised with webpack!");
@@ -537,7 +502,7 @@ describe("create-webpack-app cli", () => {
     const { stdout } = await runPromptWithAnswers(
       dir,
       ["init", ".", "--template=react"],
-      [`${DOWN}${ENTER}`, `y${ENTER}`, `y${ENTER}`, ENTER, `y${ENTER}`, ENTER, ENTER, ENTER],
+      [`${DOWN}${ENTER}`, `y${ENTER}`, `y${ENTER}`, ENTER, ENTER],
     );
 
     expect(stdout).toContain("Project has been initialised with webpack!");
@@ -555,7 +520,7 @@ describe("create-webpack-app cli", () => {
     const { stdout } = await runPromptWithAnswers(
       dir,
       ["init", ".", "--template=vue"],
-      [ENTER, `y${ENTER}`, `y${ENTER}`, `${ENTER}`, `y${ENTER}`, ENTER, ENTER],
+      [ENTER, `y${ENTER}`, `y${ENTER}`, ENTER, ENTER],
     );
 
     expect(stdout).toContain("Project has been initialised with webpack!");
@@ -579,7 +544,7 @@ describe("create-webpack-app cli", () => {
     const { stdout } = await runPromptWithAnswers(
       dir,
       ["init", ".", "--template=vue"],
-      [`${DOWN}${ENTER}`, `y${ENTER}`, `y${ENTER}`, `${ENTER}`, `y${ENTER}`, ENTER, ENTER],
+      [`${DOWN}${ENTER}`, `y${ENTER}`, `y${ENTER}`, ENTER, ENTER],
     );
 
     expect(stdout).toContain("Project has been initialised with webpack!");
@@ -597,7 +562,7 @@ describe("create-webpack-app cli", () => {
     const { stdout } = await runPromptWithAnswers(
       dir,
       ["init", ".", "--template=svelte"],
-      [ENTER, `y${ENTER}`, ENTER, `y${ENTER}`, ENTER, ENTER],
+      [ENTER, `y${ENTER}`, ENTER, ENTER],
     );
 
     expect(stdout).toContain("Project has been initialised with webpack!");
@@ -619,7 +584,7 @@ describe("create-webpack-app cli", () => {
     const { stdout } = await runPromptWithAnswers(
       dir,
       ["init", ".", "--template=svelte"],
-      [`${DOWN}${ENTER}`, `y${ENTER}`, ENTER, `y${ENTER}`, ENTER, ENTER],
+      [`${DOWN}${ENTER}`, `y${ENTER}`, ENTER, ENTER],
     );
 
     expect(stdout).toContain("Project has been initialised with webpack!");

--- a/test/create-webpack-app/init/init.test.js
+++ b/test/create-webpack-app/init/init.test.js
@@ -318,6 +318,13 @@ describe("create-webpack-app cli", () => {
       expect(existsSync(resolve(dir, file))).toBeTruthy();
     }
 
+    // webpack strips the types itself, so the project carries no TypeScript loader
+    const { devDependencies } = readFromPkgJSON(dir);
+
+    expect(readFromWebpackConfig(dir, "webpack.config.ts")).not.toContain("ts-loader");
+    expect(Object.keys(devDependencies)).not.toContain("ts-loader");
+    expect(Object.keys(devDependencies)).toContain("typescript");
+
     // Check if the generated package.json file content matches the snapshot
     expect(readFromPkgJSON(dir)).toMatchSnapshot();
 

--- a/test/create-webpack-app/init/init.test.js
+++ b/test/create-webpack-app/init/init.test.js
@@ -297,9 +297,10 @@ describe("create-webpack-app cli", () => {
     const { stdout } = await runPromptWithAnswers(
       dir,
       ["init", "."],
-      [`${DOWN}${DOWN}${ENTER}`, `n${ENTER}`, `n${ENTER}`, ENTER, ENTER],
+      [`${DOWN}${DOWN}${ENTER}`, ENTER, `n${ENTER}`, `n${ENTER}`, ENTER, ENTER],
     );
 
+    expect(stdout).toContain("How should TypeScript be compiled?");
     expect(stdout).toContain("Project has been initialised with webpack!");
     expect(stdout).toContain("webpack.config.ts");
     expect(stdout).toContain("tsconfig.json");

--- a/test/create-webpack-app/init/init.test.js
+++ b/test/create-webpack-app/init/init.test.js
@@ -385,6 +385,7 @@ describe("create-webpack-app cli", () => {
       "Do you want to simplify the creation of HTML files for your bundle?",
     );
     expect(stdout).not.toContain("Which of the following CSS solution do you want to use?");
+    expect(stdout).not.toContain("Will you be using CSS styles along with");
     expect(stdout).not.toContain("Do you want to use PostCSS in your project?");
     expect(stdout).not.toContain("Do you want to extract CSS into separate files?");
 
@@ -393,7 +394,7 @@ describe("create-webpack-app cli", () => {
 
     expect(config).toContain('entry: { index: "./index.html" }');
     expect(config).not.toContain("html-webpack-plugin");
-    expect(config).not.toContain("css-loader");
+    expect(config).not.toContain('"css-loader"');
     expect(config).not.toContain("mini-css-extract-plugin");
 
     const { devDependencies } = readFromPkgJSON(dir);
@@ -408,10 +409,10 @@ describe("create-webpack-app cli", () => {
     const { stdout } = await runPromptWithAnswers(
       dir,
       ["init", "."],
-      [ENTER, `n${ENTER}`, `n${ENTER}`, `${DOWN}${ENTER}`, ENTER],
+      [ENTER, `n${ENTER}`, `n${ENTER}`, `${DOWN}${DOWN}${ENTER}`, ENTER],
     );
 
-    expect(stdout).toContain("Which CSS preprocessor do you want to use?");
+    expect(stdout).toContain("Which CSS tool do you want to use?");
     expect(stdout).toContain("Project has been initialised with webpack!");
 
     // Sass is wired as a `css/auto` rule, so it needs no css-loader
@@ -419,8 +420,69 @@ describe("create-webpack-app cli", () => {
 
     expect(config).toContain('type: "css/auto"');
     expect(config).toContain('use: ["sass-loader"]');
-    expect(config).not.toContain("css-loader");
+    expect(config).not.toContain('"css-loader"');
     expect(existsSync(resolve(dir, "src/styles.scss"))).toBeTruthy();
+
+    // Check if the generated package.json file content matches the snapshot
+    expect(readFromPkgJSON(dir)).toMatchSnapshot();
+
+    // Check if the generated webpack configuration matches the snapshot
+    expect(readFromWebpackConfig(dir)).toMatchSnapshot();
+  });
+
+  it("should scaffold PostCSS on top of the built-in CSS support when selected", async () => {
+    const { stdout } = await runPromptWithAnswers(
+      dir,
+      ["init", "."],
+      [ENTER, `n${ENTER}`, `n${ENTER}`, `${DOWN}${ENTER}`, ENTER],
+    );
+
+    expect(stdout).toContain("Project has been initialised with webpack!");
+
+    // A loader for `.css` turns the auto detection off, so the config asks for
+    // the built-in CSS support explicitly
+    const config = readFromWebpackConfig(dir);
+
+    expect(config).toContain("experiments: {");
+    expect(config).toContain("css: true");
+    expect(config).toContain('use: ["postcss-loader"]');
+    expect(config).not.toContain('"css-loader"');
+    expect(existsSync(resolve(dir, "postcss.config.js"))).toBeTruthy();
+
+    const { devDependencies } = readFromPkgJSON(dir);
+
+    expect(Object.keys(devDependencies)).toContain("postcss-loader");
+    expect(Object.keys(devDependencies)).toContain("autoprefixer");
+
+    // Check if the generated package.json file content matches the snapshot
+    expect(readFromPkgJSON(dir)).toMatchSnapshot();
+
+    // Check if the generated webpack configuration matches the snapshot
+    expect(readFromWebpackConfig(dir)).toMatchSnapshot();
+  });
+
+  it("should chain PostCSS after a preprocessor when both are selected", async () => {
+    const { stdout } = await runPromptWithAnswers(
+      dir,
+      ["init", "."],
+      [ENTER, `n${ENTER}`, `n${ENTER}`, `${DOWN}${DOWN}${DOWN}${ENTER}`, ENTER],
+    );
+
+    expect(stdout).toContain("Project has been initialised with webpack!");
+
+    // `use` is applied right to left, so Sass compiles first and PostCSS runs over it
+    const config = readFromWebpackConfig(dir);
+
+    expect(config).toContain('use: ["postcss-loader", "sass-loader"]');
+    expect(config).toContain('use: ["postcss-loader"]');
+    expect(config).toContain("css: true");
+    expect(existsSync(resolve(dir, "src/styles.scss"))).toBeTruthy();
+    expect(existsSync(resolve(dir, "postcss.config.js"))).toBeTruthy();
+
+    const { devDependencies } = readFromPkgJSON(dir);
+
+    expect(Object.keys(devDependencies)).toContain("sass-loader");
+    expect(Object.keys(devDependencies)).toContain("postcss-loader");
 
     // Check if the generated package.json file content matches the snapshot
     expect(readFromPkgJSON(dir)).toMatchSnapshot();


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

#4833 moved the `init` templates onto webpack's built-in HTML and CSS support, but the questions about them stayed. Since webpack handles both out of the box, `init` no longer asks whether to simplify HTML creation, which CSS solution to use, whether PostCSS is wanted, or whether CSS should be extracted: `index.html` is always the entry point and a stylesheet is always scaffolded. One question remains for the preprocessors webpack does not cover (SASS/LESS/Stylus), wired through a `type: "css/auto"` rule that adds only the preprocessor loader. The default template goes from 9 questions to 5. Refs #4833.

Generating and building each template also surfaced three defects that predate both PRs and are fixed here: `baseUrl` for the Vue TypeScript `paths` (`TS5090`), a fully specified `./router/index.js` import under `"type": "module"`, and Svelte 5's `mount()` instead of `new App()`, which rendered a blank page.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

feat

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — `test/create-webpack-app/init/init.test.js` gains a case asserting the HTML/CSS questions are gone and that the generated config and dependencies carry no `html-webpack-plugin`/`css-loader`/`mini-css-extract-plugin`, plus a case covering the preprocessor path (`type: "css/auto"` with only `sass-loader`); the prompt sequences and snapshots are updated. Beyond the suite, each template was generated and production-built, and the emitted `dist/index.html` loaded in Chromium: every one renders with its stylesheet applied and no page errors, SASS/LESS variants included.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No for generated projects. The prompts change, so the `cssType`, `isCSS`, `isPostCSS` and `html` answers are replaced by a single `cssPreprocessor` answer — this only affects anything driving the generator with pre-supplied answers.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

Documented in this PR: `packages/create-webpack-app/README.md` notes that every template relies on webpack's built-in HTML and CSS support, and each template's generated `README.md` explains that the page is the entry point and how to add a preprocessor.

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Yes. Claude Code made the template and generator edits and ran the verification described above — generating every template, building it, and loading the result in a browser. I reviewed the diff and the verification output before submitting.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HY5y12g53KYEfE6S1iDeRe)_