### PR TITLE
ci: use the input names changesets/action v2 expects

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,10 +34,10 @@ jobs:
         id: changesets
         uses: changesets/action@198f833dd7d863100ea6e28967bc9a9fdefadb0a # v2.1.0
         with:
-          version: npm run version
-          publish: npm run release
-          commit: "chore(release): new release"
-          title: "chore(release): new release"
+          version-script: npm run version
+          publish-script: npm run release
+          commit-message: "chore(release): new release"
+          pr-title: "chore(release): new release"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: "" # https://github.com/changesets/changesets/issues/1152#issuecomment-3190884868


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

The Release workflow has failed on every push to `main` since #4831 bumped `changesets/action` to v2, which renamed every input the workflow passes and errors out rather than ignoring the old ones: `version` → `version-script`, `publish` → `publish-script`, `commit` → `commit-message`, `title` → `pr-title`. Run 121 (11 Aug) was the last success.

Worth noting for review: the action's own error message misspells one of them as `commit-mesage`. `action.yml` at the pinned commit spells it `commit-message`, and taking the error at its word would silently fall back to the default `Version Packages` commit message. The one output this workflow consumes, `steps.changesets.outputs.published`, is unchanged in v2.

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

ci

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

No — a workflow input rename that no test can exercise. Each name was checked against `action.yml` at the pinned commit `198f833`, and the file was verified to parse with the four inputs set as intended. It proves itself on the next push to `main`, since the workflow has no manual trigger.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

n/a — though note that seven releases have been skipped while this was broken, so the first successful run will open a version PR covering everything accumulated since 11 Aug.

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Claude Code was used to read the failing job log, trace the breakage back to the run that introduced it, check the input names against the pinned action's `action.yml` (catching the typo in the error message), and apply the rename. The change was reviewed before committing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HY5y12g53KYEfE6S1iDeRe)_